### PR TITLE
[FLAG-784] Update VIIRS metadata request URL

### DIFF
--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -1,4 +1,4 @@
-import { tilesRequest, cartoRequest, dataRequest } from 'utils/request';
+import { cartoRequest, dataRequest } from 'utils/request';
 import { PROXIES } from 'utils/proxies';
 import forestTypes from 'data/forest-types';
 import landCategories from 'data/land-categories';
@@ -2181,13 +2181,17 @@ export const fetchFiresWithin = (params) => {
 };
 
 export const fetchVIIRSLatest = () =>
-  tilesRequest
-    .get('/nasa_viirs_fire_alerts/v20220726/max_alert__date')
+  dataRequest
+    .get('dataset/nasa_viirs_fire_alerts/latest/')
     .then(({ data }) => {
-      const date = data && data.data && data.data.max_date;
+      const {
+        metadata: {
+          content_date_range: { end_date },
+        },
+      } = data;
 
       return {
-        date,
+        date: end_date,
       };
     })
     .catch(() => ({

--- a/utils/apis.js
+++ b/utils/apis.js
@@ -17,9 +17,6 @@ export const RESOURCE_WATCH_API = 'https://api.resourcewatch.org/v1';
 export const RESOURCE_WATCH_STAGING_API =
   'https://staging-api.resourcewatch.org/v1';
 
-// GFW TILES API
-export const GFW_TILES_API = 'https://tiles.globalforestwatch.org';
-
 // CARTO API
 export const CARTO_API = 'https://wri-01.carto.com/api/v2';
 

--- a/utils/gfw-meta.js
+++ b/utils/gfw-meta.js
@@ -31,12 +31,10 @@ export default async function getGfwMeta() {
       },
       VIIRS: {
         ...viirsLatest,
-        ...(viirsLatest?.date && {
-          defaultStartDate: moment(viirsLatest?.date)
-            .add(-7, 'days')
-            .format('YYYY-MM-DD'),
-          defaultEndDate: viirsLatest?.date,
-        }),
+        defaultStartDate: moment(viirsLatest?.date)
+          .add(-7, 'days')
+          .format('YYYY-MM-DD'),
+        defaultEndDate: viirsLatest?.date,
       },
     },
   };

--- a/utils/request.js
+++ b/utils/request.js
@@ -2,7 +2,6 @@ import { CancelToken, create } from 'axios';
 import wriAPISerializer from 'wri-json-api-serializer';
 
 import {
-  GFW_TILES_API,
   CARTO_API,
   MAPBOX_API,
   RESOURCE_WATCH_API,
@@ -76,11 +75,6 @@ export const metadataRequest = create({
   ...(!isServer && {
     baseURL: PROXIES.METADATA_API,
   }),
-});
-
-export const tilesRequest = create({
-  ...defaultRequestConfig,
-  baseURL: GFW_TILES_API,
 });
 
 export const rwRequest = create({


### PR DESCRIPTION
## Overview

`fetchVIIRSLatest` is a method to fetch the `updateAt` date before request anything to Data API, however, the endpoint used is deprecated and needs to be updated.

Old endpoint: https://tiles.globalforestwatch.org/nasa_viirs_fire_alerts/v20220726/max_alert__date

New endpoint:  https://data-api.globalforestwatch.org/dataset/nasa_viirs_fire_alerts/latest/

We need to update this endpoint to solve issues with date in Fire Alerts Widget.

This ticket needs Data API team implementation.


## Notes

Waiting implementation from Data API to test
