### PR TITLE
fix(metadata): change method replace to replaceAll

### DIFF
--- a/components/modals/meta/component.jsx
+++ b/components/modals/meta/component.jsx
@@ -65,8 +65,8 @@ class ModalMeta extends PureComponent {
     const parsedCitation =
       citation &&
       citation
-        .replace('[selected area name]', locationName)
-        .replace('[date]', moment().format('DD/MM/YYYY'));
+        .replaceAll('[selected area name]', locationName)
+        .replaceAll('[date]', moment().format('DD/MM/YYYY'));
 
     return (
       <div className="modal-meta-content">


### PR DESCRIPTION
## Overview

Using replaceAll to avoid errors when we have more than one occurrence of the same variable in metadata modal. Ex: [date]

## Demo

### Before
![Screenshot 2023-06-12 at 17 32 21](https://github.com/wri/gfw/assets/23243868/5c5cce39-bedb-4c29-bba2-bc4879475faa)


### After
![Screenshot 2023-06-12 at 17 32 33](https://github.com/wri/gfw/assets/23243868/7076fc01-5a56-4a2c-b4cf-ad2d49a86b81)



## Testing

- Open the map
- Select Tropical Tree Cover layer
- Open metadata info
- check the text

