### PR TITLE
[FLAG-536] Add space between numbers and units for widgets

### DIFF
--- a/components/charts/components/pie-chart-legend/component.jsx
+++ b/components/charts/components/pie-chart-legend/component.jsx
@@ -20,7 +20,7 @@ class PieChartLegend extends PureComponent {
         `${formatNumber({
           num: item[config.key],
           unit: item.unit ? item.unit : config.unit,
-          spaceUnit: item.unit !== '%',
+          spaceUnit: item.unit !== '%' && config.unit !== 'countsK',
         })}`?.length > 9
     );
 
@@ -34,7 +34,7 @@ class PieChartLegend extends PureComponent {
             const value = `${formatNumber({
               num: item[config.key],
               unit: item.unit ? item.unit : config.unit,
-              spaceUnit: item.unit !== '%',
+              spaceUnit: item.unit !== '%' && config.unit !== 'countsK',
             })}`;
             return (
               <li className="legend-item" key={index.toString()}>

--- a/components/charts/components/pie-chart-legend/component.jsx
+++ b/components/charts/components/pie-chart-legend/component.jsx
@@ -20,6 +20,7 @@ class PieChartLegend extends PureComponent {
         `${formatNumber({
           num: item[config.key],
           unit: item.unit ? item.unit : config.unit,
+          spaceUnit: item.unit !== '%',
         })}`?.length > 9
     );
 
@@ -33,6 +34,7 @@ class PieChartLegend extends PureComponent {
             const value = `${formatNumber({
               num: item[config.key],
               unit: item.unit ? item.unit : config.unit,
+              spaceUnit: item.unit !== '%',
             })}`;
             return (
               <li className="legend-item" key={index.toString()}>

--- a/components/numbered-list/component.jsx
+++ b/components/numbered-list/component.jsx
@@ -73,6 +73,7 @@ class NumberedList extends PureComponent {
                         {formatNumber({
                           num: item.value,
                           unit: item.unit || formatUnit,
+                          spaceUnit: true,
                         })}
                       </div>
                     </div>
@@ -81,6 +82,7 @@ class NumberedList extends PureComponent {
                       {formatNumber({
                         num: item.value,
                         unit: item.unit || formatUnit,
+                        spaceUnit: true,
                       })}
                     </div>
                   )}

--- a/components/widget/components/widget-pie-chart-legend/component.jsx
+++ b/components/widget/components/widget-pie-chart-legend/component.jsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { format } from 'd3-format';
+import { formatNumber } from 'utils/format';
 
 import PieChart from 'components/charts/pie-chart';
 import PieChartLegend from 'components/charts/components/pie-chart-legend';
@@ -69,9 +69,13 @@ class WidgetPieChart extends PureComponent {
                 ? [
                     {
                       key: 'value',
-                      unit: 'ha',
                       labelKey: 'label',
-                      unitFormat: (value) => format('.3s')(value),
+                      unitFormat: (value) =>
+                        formatNumber({
+                          num: value,
+                          unit: 'ha',
+                          spaceUnit: true,
+                        }),
                     },
                   ]
                 : [
@@ -79,7 +83,8 @@ class WidgetPieChart extends PureComponent {
                       key: 'percentage',
                       unit: '%',
                       labelKey: 'label',
-                      unitFormat: (value) => format('.1f')(value),
+                      unitFormat: (value) =>
+                        formatNumber({ num: value, specialSpecifier: '.1f' }),
                     },
                   ]
             }

--- a/components/widgets/climate/carbon-flux/index.js
+++ b/components/widgets/climate/carbon-flux/index.js
@@ -1,8 +1,5 @@
 import { getCarbonFlux, getCarbonFluxOTF } from 'services/analysis-cached';
 
-// import OTFAnalysis from 'services/otf-analysis';
-
-// TODO: carbon flux layer&dataset
 import {
   POLITICAL_BOUNDARIES_DATASET,
   CARBON_FLUX_DATASET,

--- a/components/widgets/climate/carbon-flux/selectors.js
+++ b/components/widgets/climate/carbon-flux/selectors.js
@@ -1,5 +1,4 @@
 import { createSelector, createStructuredSelector } from 'reselect';
-import { format } from 'd3-format';
 import { formatNumber } from 'utils/format';
 import isEmpty from 'lodash/isEmpty';
 
@@ -53,7 +52,10 @@ export const parseConfig = createSelector(
 
     // format numbers to operate with array (it's just to make operations more simple, it'll get changed back after operations)
     const tickFormatter = (value) =>
-      format('.2r')(value * `1e-${maxValueDigits}`);
+      formatNumber({
+        num: value * `1e-${maxValueDigits}`,
+        specialSpecifier: '.2r',
+      });
 
     // make ticks multiple of 0.5 (client request a step of 0.5 within ticks)
     const tick = Math.ceil(tickFormatter(maxValue) / 0.5) * 0.5;
@@ -101,7 +103,8 @@ export const parseConfig = createSelector(
         domain: [ticks[0], ticks[ticks.length - 1]],
         allowDecimals: false,
         ticks,
-        tickFormatter: (value) => format('.2r')(value * 1e-9),
+        tickFormatter: (value) =>
+          formatNumber({ num: value * 1e-9, specialSpecifier: '.2r' }),
         label: {
           value: 'GtCO\u2082e/year',
           fontSize: 14,
@@ -212,19 +215,19 @@ export const parseConfig = createSelector(
         {
           key: 'removals',
           label: 'Removals',
-          unitFormat: (value) => `${format('.3s')(value)}tCO\u2082e`,
+          unitFormat: (value) => formatNumber({ num: value, unit: 'tCO2' }),
           color: removals,
         },
         {
           key: 'emissions',
           label: 'Emissions',
-          unitFormat: (value) => `${format('.3s')(value)}tCO\u2082e`,
+          unitFormat: (value) => formatNumber({ num: value, unit: 'tCO2' }),
           color: emissions,
         },
         {
           key: 'flux',
           label: netFluxData > 0 ? 'Net emissions' : 'Net removals',
-          unitFormat: (value) => `${format('.3s')(value)}tCO\u2082e`,
+          unitFormat: (value) => formatNumber({ num: value, unit: 'tCO2' }),
           color: netFluxData > 0 ? netEmissions : netRemovals,
         },
       ],
@@ -270,14 +273,17 @@ export const parseSentence = createSelector(
       totalEmissions: formatNumber({
         num: emissions / yearTotal,
         unit: 'tCO2',
+        spaceUnit: true,
       }),
       totalRemovals: formatNumber({
         num: removals / yearTotal,
         unit: 'tCO2',
+        spaceUnit: true,
       }),
       totalFlux: formatNumber({
         num: flux / yearTotal,
         unit: 'tCO2',
+        spaceUnit: true,
       }),
     };
 

--- a/components/widgets/climate/carbon-flux/selectors.js
+++ b/components/widgets/climate/carbon-flux/selectors.js
@@ -215,19 +215,22 @@ export const parseConfig = createSelector(
         {
           key: 'removals',
           label: 'Removals',
-          unitFormat: (value) => formatNumber({ num: value, unit: 'tCO2' }),
+          unitFormat: (value) =>
+            formatNumber({ num: value, unit: 'tCO2', spaceUnit: true }),
           color: removals,
         },
         {
           key: 'emissions',
           label: 'Emissions',
-          unitFormat: (value) => formatNumber({ num: value, unit: 'tCO2' }),
+          unitFormat: (value) =>
+            formatNumber({ num: value, unit: 'tCO2', spaceUnit: true }),
           color: emissions,
         },
         {
           key: 'flux',
           label: netFluxData > 0 ? 'Net emissions' : 'Net removals',
-          unitFormat: (value) => formatNumber({ num: value, unit: 'tCO2' }),
+          unitFormat: (value) =>
+            formatNumber({ num: value, unit: 'tCO2', spaceUnit: true }),
           color: netFluxData > 0 ? netEmissions : netRemovals,
         },
       ],
@@ -247,12 +250,8 @@ export const parseSentence = createSelector(
   (data, sentences, indicator, locationName, settings, adminLevel) => {
     if (!data || isEmpty(data)) return null;
 
-    const {
-      globalInitial,
-      globalWithIndicator,
-      initial,
-      withIndicator,
-    } = sentences;
+    const { globalInitial, globalWithIndicator, initial, withIndicator } =
+      sentences;
     const { startYear, endYear, sentence: sentenceSettings } = settings;
     const { netCarbonFlux: netCarbonFluxWording } = sentenceSettings;
 

--- a/components/widgets/climate/carbon-stock/selectors.js
+++ b/components/widgets/climate/carbon-stock/selectors.js
@@ -128,7 +128,7 @@ export const parseSentence = createSelector(
     const params = {
       location: locationName,
       carbonStored: allGround > soil ? 'biomass' : 'soil',
-      carbonValue: formatNumber({ num: total, unit: 't' }),
+      carbonValue: formatNumber({ num: total, unit: 't', spaceUnit: true }),
     };
 
     return {

--- a/components/widgets/climate/emissions-deforestation-drivers/selectors.js
+++ b/components/widgets/climate/emissions-deforestation-drivers/selectors.js
@@ -5,7 +5,7 @@ import sumBy from 'lodash/sumBy';
 import entries from 'lodash/entries';
 import groupBy from 'lodash/groupBy';
 import findIndex from 'lodash/findIndex';
-import { format } from 'd3-format';
+import { formatNumber } from 'utils/format';
 import sortBy from 'lodash/sortBy';
 import { yearTicksFormatter } from 'components/widgets/utils/data';
 
@@ -140,9 +140,8 @@ export const parseConfig = createSelector(
       {
         key: 'total',
         label: 'Total',
-        unit: 't CO2e',
         unitFormat: (value) =>
-          value < 1000 ? Math.round(value) : format('.3s')(value),
+          formatNumber({ num: value, unit: 'tCO2', spaceUnit: true }),
       },
     ];
     tooltip = tooltip.concat(
@@ -153,10 +152,9 @@ export const parseConfig = createSelector(
           return {
             key: `class_${d.driver}`,
             label,
-            unit: 't CO2e',
             color: categoryColors[d.driver],
             unitFormat: (value) =>
-              value < 1000 ? Math.round(value) : format('.3s')(value),
+              formatNumber({ num: value, unit: 'tCO2', spaceUnit: true }),
           };
         })
         .reverse()
@@ -211,7 +209,11 @@ export const parseSentence = createSelector(
       location: locationName === 'global' ? 'Globally' : locationName,
       startYear,
       endYear,
-      totalEmissions: `${format('.3s')(totalEmissions)}t of CO\u2082e`,
+      totalEmissions: formatNumber({
+        num: totalEmissions,
+        unit: 'tCO2',
+        spaceUnit: true,
+      }),
       component: {
         key: 'deforestation',
         tooltip:

--- a/components/widgets/climate/emissions-deforestation-drivers/selectors.js
+++ b/components/widgets/climate/emissions-deforestation-drivers/selectors.js
@@ -175,7 +175,9 @@ export const parseConfig = createSelector(
       xAxis: {
         tickFormatter: yearTicksFormatter,
       },
-      unit: 't CO2e',
+      unitFormat: (value) =>
+        formatNumber({ num: value, specialSpecifier: '.2s', spaceUnit: true }),
+      unit: 'tCO2e',
       tooltip,
     };
   }

--- a/components/widgets/climate/emissions-deforestation/selectors.js
+++ b/components/widgets/climate/emissions-deforestation/selectors.js
@@ -1,5 +1,4 @@
 import { createSelector, createStructuredSelector } from 'reselect';
-import { format } from 'd3-format';
 import isEmpty from 'lodash/isEmpty';
 
 import { formatNumber } from 'utils/format';
@@ -79,13 +78,13 @@ export const parseConfig = createSelector(
         {
           key: 'emissions',
           label: emissionLabel,
-          unit: 't CO2e',
-          unitFormat: (value) => format('.3s')(value),
+          unitFormat: (value) =>
+            formatNumber({ num: value, unit: 'tCO2', spaceUnit: true }),
           color: loss.main,
         },
       ],
-      unit: 't CO2e',
-      unitFormat: (value) => format('.2s')(value),
+      unitFormat: (value) =>
+        formatNumber({ num: value, unit: 'tCO2', spaceUnit: true }),
     };
   }
 );
@@ -114,9 +113,17 @@ export const parseSentence = createSelector(
     const sentence = initial + emissionString;
 
     const params = {
-      value: `${formatNumber({ num: totalBiomass, unit: 't' })} of CO\u2082e`,
+      value: `${formatNumber({
+        num: totalBiomass,
+        unit: 't',
+        spaceUnit: true,
+      })} of CO\u2082e`,
       location: locationName,
-      annualAvg: formatNumber({ num: totalBiomass / data.length, unit: 't' }),
+      annualAvg: formatNumber({
+        num: totalBiomass / data.length,
+        unit: 't',
+        spaceUnit: true,
+      }),
       startYear,
       endYear,
       indicatorText,

--- a/components/widgets/climate/emissions-deforestation/selectors.js
+++ b/components/widgets/climate/emissions-deforestation/selectors.js
@@ -84,7 +84,8 @@ export const parseConfig = createSelector(
         },
       ],
       unitFormat: (value) =>
-        formatNumber({ num: value, unit: 'tCO2', spaceUnit: true }),
+        formatNumber({ num: value, specialSpecifier: '.2s', spaceUnit: true }),
+      unit: 'tCO2e',
     };
   }
 );

--- a/components/widgets/climate/soil-organic/selectors.js
+++ b/components/widgets/climate/soil-organic/selectors.js
@@ -101,7 +101,11 @@ export const parseSentence = createSelector(
       const value =
         settings.variable === 'totalbiomass'
           ? formatNumber({ num: percent, unit: '%' })
-          : formatNumber({ num: avgBiomDensity, unit: 'tC/ha' });
+          : formatNumber({
+              num: avgBiomDensity,
+              unit: 'tC/ha',
+              spaceUnit: true,
+            });
 
       const labels = {
         biomassdensity: 'soil organic carbon density',
@@ -131,8 +135,16 @@ export const parseSentence = createSelector(
       sentence: sentences.initial,
       params: {
         location,
-        biomassDensity: formatNumber({ num: biomassdensity, unit: 'tC/ha' }),
-        totalBiomass: formatNumber({ num: totalbiomass, unit: 'tC' }),
+        biomassDensity: formatNumber({
+          num: biomassdensity,
+          unit: 'tC/ha',
+          spaceUnit: true,
+        }),
+        totalBiomass: formatNumber({
+          num: totalbiomass,
+          unit: 'tC',
+          spaceUnit: true,
+        }),
       },
     };
   }

--- a/components/widgets/climate/whrc-biomass/selectors.js
+++ b/components/widgets/climate/whrc-biomass/selectors.js
@@ -119,7 +119,11 @@ export const parseSentence = createSelector(
       const value =
         settings.unit === 'totalBiomass'
           ? formatNumber({ num: percent, unit: '%' })
-          : formatNumber({ num: avgBiomDensity, unit: 't/ha' });
+          : formatNumber({
+              num: avgBiomDensity,
+              unit: 't/ha',
+              spaceUnit: true,
+            });
 
       const labels = {
         biomassDensity: 'biomass density',
@@ -143,8 +147,16 @@ export const parseSentence = createSelector(
       sentence: sentences.initial,
       params: {
         location: location && location.label,
-        biomassDensity: formatNumber({ num: biomassDensity, unit: 't/ha' }),
-        totalBiomass: formatNumber({ num: biomass, unit: 't' }),
+        biomassDensity: formatNumber({
+          num: biomassDensity,
+          unit: 't/ha',
+          spaceUnit: true,
+        }),
+        totalBiomass: formatNumber({
+          num: biomass,
+          unit: 't',
+          spaceUnit: true,
+        }),
       },
     };
   }

--- a/components/widgets/fires/burned-area-cumulative/selectors.js
+++ b/components/widgets/fires/burned-area-cumulative/selectors.js
@@ -1,7 +1,7 @@
 /* eslint-disable prefer-destructuring */
 import { createSelector, createStructuredSelector } from 'reselect';
 import moment from 'moment';
-import { format } from 'd3-format';
+import { formatNumber } from 'utils/format';
 import isEmpty from 'lodash/isEmpty';
 import sortBy from 'lodash/sortBy';
 import groupBy from 'lodash/groupBy';
@@ -255,7 +255,8 @@ export const parseConfig = createSelector(
         unit: ` MODIS burned area`,
         color: colors.main,
         nullValue: 'No data available',
-        unitFormat: (value) => `${format('.3s')(value)}ha`,
+        unitFormat: (value) =>
+          formatNumber({ num: value, unit: 'ha', spaceUnit: true }),
       },
     ];
     const compareYearsLines = {};
@@ -282,7 +283,8 @@ export const parseConfig = createSelector(
           unit: ` MODIS burned area`,
           color: compareYears.length === 1 ? colors.compareYear : colorRange[i],
           nullValue: 'No data available',
-          unitFormat: (value) => `${format('.3s')(value)}ha`,
+          unitFormat: (value) =>
+            formatNumber({ num: value, unit: 'ha', spaceUnit: true }),
         });
         compareYearsLines[year] = {
           stroke:
@@ -494,12 +496,12 @@ export const parseSentence = createSelector(
       dataset_start_year: 2001,
       maxYear,
       maxTotal: {
-        value: maxTotal ? format(',')(maxTotal) : 0,
+        value: maxTotal ? formatNumber({ num: maxTotal, unit: ',' }) : 0,
         color: colors.main,
       },
       area: {
         value: totalCurrentYear
-          ? `${format('.2s')(totalCurrentYear)}ha`
+          ? formatNumber({ num: totalCurrentYear, unit: 'ha', spaceUnit: true })
           : '0ha',
         color: colors.main,
       },
@@ -508,7 +510,9 @@ export const parseSentence = createSelector(
         color: statusColor,
       },
       maxArea: {
-        value: maxTotal ? `${format('.2s')(maxTotal)}ha` : '0ha',
+        value: maxTotal
+          ? formatNumber({ num: maxTotal, unit: 'ha', spaceUnit: true })
+          : '0ha',
         color: colors.main,
       },
     };

--- a/components/widgets/fires/burned-area-cumulative/selectors.js
+++ b/components/widgets/fires/burned-area-cumulative/selectors.js
@@ -502,7 +502,7 @@ export const parseSentence = createSelector(
       area: {
         value: totalCurrentYear
           ? formatNumber({ num: totalCurrentYear, unit: 'ha', spaceUnit: true })
-          : '0ha',
+          : '0 ha',
         color: colors.main,
       },
       status: {
@@ -512,7 +512,7 @@ export const parseSentence = createSelector(
       maxArea: {
         value: maxTotal
           ? formatNumber({ num: maxTotal, unit: 'ha', spaceUnit: true })
-          : '0ha',
+          : '0 ha',
         color: colors.main,
       },
     };

--- a/components/widgets/fires/burned-area-ranked/selectors.js
+++ b/components/widgets/fires/burned-area-ranked/selectors.js
@@ -240,7 +240,11 @@ export const parseSentence = createSelector(
       },
       thresh: `${thresh}%`,
       topRegion,
-      topRegionCount: formatNumber({ num: topRegionCount, unit: 'ha' }),
+      topRegionCount: formatNumber({
+        num: topRegionCount,
+        unit: 'ha',
+        spaceUnit: true,
+      }),
       topRegionPerc: formatNumber({ num: topRegionPerc, unit: '%' }),
       topRegionDensity: formatNumber({ num: topRegionDensity, unit: '%' }),
       location: locationName === 'global' ? 'globally' : locationName,

--- a/components/widgets/fires/burned-area/selectors.js
+++ b/components/widgets/fires/burned-area/selectors.js
@@ -471,7 +471,7 @@ export const parseSentence = createSelector(
       dataset_start_year: 2001,
       dataset: 'MODIS',
       area: {
-        value: total ? `${format('.2s')(total)}ha` : '0ha',
+        value: total ? `${format('.2s')(total)}ha` : '0 ha',
         color: colors.main,
       },
       status: {

--- a/components/widgets/fires/fires-alerts-historical-daily/selectors.js
+++ b/components/widgets/fires/fires-alerts-historical-daily/selectors.js
@@ -1,20 +1,20 @@
 import { createSelector, createStructuredSelector } from 'reselect';
 import moment from 'moment';
-import { format } from 'd3-format';
+import { formatNumber } from 'utils/format';
 import isEmpty from 'lodash/isEmpty';
 import sumBy from 'lodash/sumBy';
 import sortBy from 'lodash/sortBy';
 
 import { getChartConfig } from 'components/widgets/utils/data';
 
-const getAlerts = state => state.data;
-const getColors = state => state.colors || null;
-const getStartDate = state => state.settings.startDate;
-const getEndDate = state => state.settings.endDate;
-const getSentences = state => state.sentences || null;
-const getLocationObject = state => state.location;
-const getOptionsSelected = state => state.optionsSelected;
-const getIndicator = state => state.indicator;
+const getAlerts = (state) => state.data;
+const getColors = (state) => state.colors || null;
+const getStartDate = (state) => state.settings.startDate;
+const getEndDate = (state) => state.settings.endDate;
+const getSentences = (state) => state.sentences || null;
+const getLocationObject = (state) => state.location;
+const getOptionsSelected = (state) => state.optionsSelected;
+const getIndicator = (state) => state.indicator;
 
 const zeroFillDays = (startDate, endDate) => {
   const start = moment(startDate);
@@ -23,7 +23,7 @@ const zeroFillDays = (startDate, endDate) => {
 
   return [
     startDate,
-    ...dates.map(() => start.add(1, 'days').format('YYYY-MM-DD'))
+    ...dates.map(() => start.add(1, 'days').format('YYYY-MM-DD')),
   ];
 };
 
@@ -32,11 +32,11 @@ export const getData = createSelector(
   (data, startDate, endDate) => {
     if (!data || isEmpty(data)) return null;
 
-    const zeroFilledData = zeroFillDays(startDate, endDate).map(date => ({
+    const zeroFilledData = zeroFillDays(startDate, endDate).map((date) => ({
       date,
       alert__count: 0,
       count: 0,
-      ...data.find(d => d.alert__date === date)
+      ...data.find((d) => d.alert__date === date),
     }));
 
     return sortBy(zeroFilledData, 'date');
@@ -48,17 +48,19 @@ export const parseConfig = createSelector(
   (colors, startDate, endDate) => {
     const tooltip = [
       {
-        label: 'Fire alerts'
+        label: 'Fire alerts',
       },
       {
         key: 'count',
         labelKey: 'alert__date',
-        labelFormat: value => moment(value).format('MMM DD YYYY'),
+        labelFormat: (value) => moment(value).format('MMM DD YYYY'),
         unit: ' VIIRS alerts',
         color: colors.main,
-        unitFormat: value =>
-          (Number.isInteger(value) ? format(',')(value) : value)
-      }
+        unitFormat: (value) =>
+          Number.isInteger(value)
+            ? formatNumber({ num: value, unit: ',' })
+            : value,
+      },
     ];
 
     return {
@@ -69,8 +71,8 @@ export const parseConfig = createSelector(
         ticks: [startDate, endDate],
         interval: 0,
         padding: { left: 20, right: 20 },
-        tickFormatter: t => moment(t).format('MMM YYYY')
-      }
+        tickFormatter: (t) => moment(t).format('MMM YYYY'),
+      },
     };
   }
 );
@@ -84,7 +86,7 @@ export const parseSentence = createSelector(
     getStartDate,
     getEndDate,
     getOptionsSelected,
-    getIndicator
+    getIndicator,
   ],
   (
     data,
@@ -115,9 +117,9 @@ export const parseSentence = createSelector(
       end_date: moment(endDate).format('Do of MMMM YYYY'),
       dataset: dataset && dataset.label,
       total_alerts: {
-        value: total ? format(',')(total) : 0,
-        color: colors.main
-      }
+        value: total ? formatNumber({ num: total, unit: ',' }) : 0,
+        color: colors.main,
+      },
     };
     return { sentence, params };
   }
@@ -126,5 +128,5 @@ export const parseSentence = createSelector(
 export default createStructuredSelector({
   data: getData,
   config: parseConfig,
-  sentence: parseSentence
+  sentence: parseSentence,
 });

--- a/components/widgets/fires/fires-alerts-historical-weekly/selectors.js
+++ b/components/widgets/fires/fires-alerts-historical-weekly/selectors.js
@@ -1,6 +1,6 @@
 import { createSelector, createStructuredSelector } from 'reselect';
 import moment from 'moment';
-import { format } from 'd3-format';
+import { formatNumber } from 'utils/format';
 import groupBy from 'lodash/groupBy';
 import isEmpty from 'lodash/isEmpty';
 import sumBy from 'lodash/sumBy';
@@ -151,7 +151,9 @@ export const parseConfig = createSelector(
         unit: ' VIIRS alerts',
         color: colors.main,
         unitFormat: (value) =>
-          Number.isInteger(value) ? format(',')(value) : value,
+          Number.isInteger(value)
+            ? formatNumber({ num: value, unit: ',' })
+            : value,
       },
     ];
 
@@ -246,7 +248,7 @@ export const parseSentence = createSelector(
       end_date: moment(endDate).format('Do of MMMM YYYY'),
       dataset: dataset && dataset.label,
       total_alerts: {
-        value: total ? format(',')(total) : 0,
+        value: total ? formatNumber({ num: total, unit: ',' }) : 0,
         color: colors.main,
       },
     };

--- a/components/widgets/fires/fires-alerts/selectors.js
+++ b/components/widgets/fires/fires-alerts/selectors.js
@@ -1,7 +1,7 @@
 /* eslint-disable prefer-destructuring */
 import { createSelector, createStructuredSelector } from 'reselect';
 import moment from 'moment';
-import { format } from 'd3-format';
+import { formatNumber } from 'utils/format';
 import isEmpty from 'lodash/isEmpty';
 import sortBy from 'lodash/sortBy';
 import orderBy from 'lodash/orderBy';
@@ -263,7 +263,8 @@ export const parseConfig = createSelector(
         labelFormat: (value) => moment(value).format('MMM DD YYYY'),
         unit: ` ${dataset.toUpperCase()} alerts`,
         color: colors.main,
-        unitFormat: (value) => Number.isInteger(value) && format(',')(value),
+        unitFormat: (value) =>
+          Number.isInteger(value) && formatNumber({ num: value, unit: ',' }),
       },
     ];
 
@@ -281,7 +282,8 @@ export const parseConfig = createSelector(
         unit: ` ${dataset.toUpperCase()} alerts`,
         color: '#49b5e3',
         nullValue: 'No data available',
-        unitFormat: (value) => Number.isInteger(value) && format(',')(value),
+        unitFormat: (value) =>
+          Number.isInteger(value) && formatNumber({ num: value, unit: ',' }),
       });
     }
 
@@ -479,7 +481,7 @@ export const parseSentence = createSelector(
       dataset_start_year: dataset === 'viirs' ? 2012 : 2001,
       dataset: dataset.toUpperCase(),
       count: {
-        value: total ? format(',')(total) : 0,
+        value: total ? formatNumber({ num: total, unit: ',' }) : 0,
         color: colors.main,
       },
       status: {

--- a/components/widgets/fires/tree-loss-fires-annual/selectors.js
+++ b/components/widgets/fires/tree-loss-fires-annual/selectors.js
@@ -3,7 +3,6 @@ import isEmpty from 'lodash/isEmpty';
 import sumBy from 'lodash/sumBy';
 import groupBy from 'lodash/groupBy';
 import maxBy from 'lodash/maxBy';
-import { format } from 'd3-format';
 import { formatNumber } from 'utils/format';
 import {
   yearTicksFormatter,
@@ -113,14 +112,20 @@ const parseConfig = createSelector([getColors], (colors) => ({
     },
     {
       key: 'umd_tree_cover_loss__ha',
-      unitFormat: (value) => formatNumber({ num: value, unit: 'ha' }),
+      unitFormat: (value) =>
+        formatNumber({ num: value, unit: 'ha', spaceUnit: true }),
       label: 'Tree cover loss',
       color: colors.treeCoverLoss,
     },
     {
       key: 'umd_tree_cover_loss_from_fires__ha',
       label: 'Tree cover loss from fires',
-      unitFormat: (value) => formatNumber({ num: value, unit: 'ha' }),
+      unitFormat: (value) =>
+        formatNumber({
+          num: value,
+          unit: 'ha',
+          spaceUnit: true,
+        }),
       color: colors.main,
     },
   ],
@@ -170,19 +175,26 @@ const parseSentence = createSelector(
       location: locationLabel,
       startYear,
       endYear,
-      treeCoverLossFires: formatNumber({ num: treeCoverLossFires, unit: 'ha' }),
+      treeCoverLossFires: formatNumber({
+        num: treeCoverLossFires,
+        unit: 'ha',
+        spaceUnit: true,
+      }),
       treeCoverLossNotFires: formatNumber({
         num: treeCoverLossNotFires,
         unit: 'ha',
+        spaceUnit: true,
       }),
       highestYearFires: highestYearFires.year,
       highestYearFiresLossFires: formatNumber({
         num: highestYearFires.treeCoverLossFires,
         unit: 'ha',
+        spaceUnit: true,
       }),
-      highestYearFiresPercentageLossFires: `${format('.2r')(
-        highestYearFiresPercentageLossFires
-      )}%`,
+      highestYearFiresPercentageLossFires: formatNumber({
+        num: highestYearFiresPercentageLossFires,
+        unit: '%',
+      }),
     };
 
     return {

--- a/components/widgets/fires/tree-loss-fires-proportion/selectors.js
+++ b/components/widgets/fires/tree-loss-fires-proportion/selectors.js
@@ -1,7 +1,7 @@
 import { createSelector, createStructuredSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
 import sumBy from 'lodash/sumBy';
-import { format } from 'd3-format';
+import { formatNumber } from 'utils/format';
 
 // get list data
 const getLoss = (state) => state.data && state.data.loss;
@@ -95,7 +95,10 @@ const parseSentence = createSelector(
       location: locationLabel,
       startYear,
       endYear,
-      lossFiresPercentage: `${format('.2r')(lossFiresPercentage)}%`,
+      lossFiresPercentage: formatNumber({
+        num: lossFiresPercentage,
+        unit: '%',
+      }),
     };
 
     return {

--- a/components/widgets/fires/tree-loss-fires/selectors.js
+++ b/components/widgets/fires/tree-loss-fires/selectors.js
@@ -96,7 +96,8 @@ export const parseSentence = createSelector(
         topRegionData &&
         formatNumber({ num: topRegionData.percentage, unit: '%' }),
       topLocationLoss:
-        topRegionData && formatNumber({ num: topRegionData.loss, unit: 'ha' }),
+        topRegionData &&
+        formatNumber({ num: topRegionData.loss, unit: 'ha', spaceUnit: true }),
       topLocationLossAverage:
         topRegionData &&
         formatNumber({
@@ -105,6 +106,7 @@ export const parseSentence = createSelector(
               ? topRegionData.loss / topRegionData.numberOfYears
               : 0,
           unit: 'ha',
+          spaceUnit: true,
         }),
       location:
         location.label === 'global' ? 'globally' : location && location.label,

--- a/components/widgets/forest-change/fao-deforest/selectors.js
+++ b/components/widgets/forest-change/fao-deforest/selectors.js
@@ -1,16 +1,16 @@
 import { createSelector, createStructuredSelector } from 'reselect';
 import findIndex from 'lodash/findIndex';
 import sumBy from 'lodash/sumBy';
-import { format } from 'd3-format';
+import { formatNumber } from 'utils/format';
 
-const getData = state => state.data;
-const getAdm0 = state => state.adm0;
-const getLocationName = state => state.locationLabel;
-const getColors = state => state.colors;
-const getSettings = state => state.settings;
-const getPeriod = state => state.settings.period;
-const getSentences = state => state.sentences;
-const getTitle = state => state.title;
+const getData = (state) => state.data;
+const getAdm0 = (state) => state.adm0;
+const getLocationName = (state) => state.locationLabel;
+const getColors = (state) => state.colors;
+const getSettings = (state) => state.settings;
+const getPeriod = (state) => state.settings.period;
+const getSentences = (state) => state.sentences;
+const getTitle = (state) => state.title;
 
 export const parseData = createSelector(
   [getData, getAdm0, getColors],
@@ -19,7 +19,7 @@ export const parseData = createSelector(
     const { rank } = data;
     let dataTrimmed = rank;
     if (adm0) {
-      const locationIndex = findIndex(rank, d => d.iso === adm0);
+      const locationIndex = findIndex(rank, (d) => d.iso === adm0);
       let trimStart = locationIndex - 2;
       let trimEnd = locationIndex + 3;
       if (locationIndex < 2) {
@@ -33,11 +33,11 @@ export const parseData = createSelector(
       dataTrimmed = rank.slice(trimStart, trimEnd);
     }
 
-    return dataTrimmed.map(d => ({
+    return dataTrimmed.map((d) => ({
       ...d,
       label: d.name,
       color: colors.main,
-      value: d.deforest
+      value: d.deforest,
     }));
   }
 );
@@ -51,9 +51,9 @@ export const parseSentence = createSelector(
       noDeforest,
       humanDeforest,
       globalInitial,
-      globalHuman
+      globalHuman,
     } = sentences;
-    const topFao = data.fao.filter(d => d.year === settings.period);
+    const topFao = data.fao.filter((d) => d.year === settings.period);
     const { deforest, humdef } = topFao[0] || {};
     const totalDeforest = sumBy(data.rank, 'deforest') || 0;
     const rate = currentLabel === 'global' ? totalDeforest : deforest;
@@ -63,19 +63,16 @@ export const parseSentence = createSelector(
       sentence = humdef ? globalHuman : globalInitial;
     } else if (!deforest) sentence = noDeforest;
 
-    const rateFormat = rate < 1 ? '.3r' : '.3s';
-    const humanFormat = humdef < 1 ? '.3r' : '.3s';
-
     const params = {
       location: currentLabel,
       year: period,
-      rate: `${format(rateFormat)(rate)}ha`,
-      human: `${format(humanFormat)(humdef)}ha`
+      rate: formatNumber({ num: rate, unit: 'ha', spaceUnit: true }),
+      human: formatNumber({ num: humdef, unit: 'ha', spaceUnit: true }),
     };
 
     return {
       sentence,
-      params
+      params,
     };
   }
 );
@@ -94,5 +91,5 @@ export const parseTitle = createSelector(
 export default createStructuredSelector({
   data: parseData,
   sentence: parseSentence,
-  title: parseTitle
+  title: parseTitle,
 });

--- a/components/widgets/forest-change/fao-deforest/selectors.js
+++ b/components/widgets/forest-change/fao-deforest/selectors.js
@@ -63,11 +63,24 @@ export const parseSentence = createSelector(
       sentence = humdef ? globalHuman : globalInitial;
     } else if (!deforest) sentence = noDeforest;
 
+    const rateFormat = rate < 1 ? '.3r' : '.3s';
+    const humanFormat = humdef < 1 ? '.3r' : '.3s';
+
     const params = {
       location: currentLabel,
       year: period,
-      rate: formatNumber({ num: rate, unit: 'ha', spaceUnit: true }),
-      human: formatNumber({ num: humdef, unit: 'ha', spaceUnit: true }),
+      rate: formatNumber({
+        num: rate,
+        unit: 'ha',
+        spaceUnit: true,
+        specialSpecifier: rateFormat,
+      }),
+      human: formatNumber({
+        num: humdef,
+        unit: 'ha',
+        spaceUnit: true,
+        specialSpecifier: humanFormat,
+      }),
     };
 
     return {

--- a/components/widgets/forest-change/fao-reforest/selectors.js
+++ b/components/widgets/forest-change/fao-reforest/selectors.js
@@ -2,7 +2,7 @@ import { createSelector, createStructuredSelector } from 'reselect';
 import uniqBy from 'lodash/uniqBy';
 import findIndex from 'lodash/findIndex';
 import sortBy from 'lodash/sortBy';
-import { format } from 'd3-format';
+import { formatNumber } from 'utils/format';
 
 const getData = (state) => state.data || null;
 const getAdm0 = (state) => state.adm0 || null;
@@ -74,7 +74,12 @@ export const parseSentence = createSelector(
     const params = {
       location: locationName,
       year: period,
-      rate: `${format(formatType)(rate)}ha`,
+      rate: formatNumber({
+        num: rate,
+        unit: 'ha',
+        spaceUnit: true,
+        specialSpecifier: formatType,
+      }),
     };
 
     return {

--- a/components/widgets/forest-change/glads/selectors.js
+++ b/components/widgets/forest-change/glads/selectors.js
@@ -1,6 +1,6 @@
 import { createSelector, createStructuredSelector } from 'reselect';
 import moment from 'moment';
-import { format } from 'd3-format';
+import { formatNumber } from 'utils/format';
 import isEmpty from 'lodash/isEmpty';
 import sumBy from 'lodash/sumBy';
 import { buildDateArray } from 'components/widgets/utils/dates';
@@ -97,7 +97,9 @@ export const parseConfig = createSelector(
           key: 'count',
           unit: '',
           unitFormat: (value) =>
-            Number.isInteger(value) ? format(',')(value) : value,
+            Number.isInteger(value)
+              ? formatNumber({ num: value, unit: ',' })
+              : value,
         },
       ],
     };
@@ -115,9 +117,9 @@ export const parseSentence = createSelector(
       location: currentLabel,
       count:
         typeof weekGladCount === 'number'
-          ? format(',')(weekGladCount)
+          ? formatNumber({ num: weekGladCount, unit: ',' })
           : weekGladCount,
-      weeklyMean: format(',')(averageGladCount),
+      weeklyMean: formatNumber({ num: averageGladCount, unit: ',' }),
     };
     return { sentence, params };
   }

--- a/components/widgets/forest-change/integrated-alerts-ranked/selectors.js
+++ b/components/widgets/forest-change/integrated-alerts-ranked/selectors.js
@@ -1,7 +1,7 @@
 import { createSelector, createStructuredSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
 import sortBy from 'lodash/sortBy';
-import { format } from 'd3-format';
+import { formatNumber } from 'utils/format';
 import groupBy from 'lodash/groupBy';
 import sumBy from 'lodash/sumBy';
 
@@ -70,7 +70,7 @@ export const parseList = createSelector(
         return {
           id: k,
           color: colors.main,
-          percentage: `${format('.2r')(countsAreaPerc)}%`,
+          percentage: formatNumber({ num: countsAreaPerc, unit: '%' }),
           countsPerHa,
           count: counts,
           area: countsArea,
@@ -117,9 +117,14 @@ export const parseSentence = createSelector(
 
     const params = {
       timeframe: timeFrame && timeFrame.label,
-      count: format(',')(totalCount),
-      area: `${format(formatType)(countArea)}ha`,
-      topPercent: `${format('.2r')(topCount)}%`,
+      count: formatNumber({ num: totalCount, unit: ',' }),
+      area: formatNumber({
+        num: countArea,
+        unit: 'ha',
+        specialSpecifier: formatType,
+        spaceUnit: true,
+      }),
+      topPercent: formatNumber({ num: topCount, unit: '%' }),
       topRegions:
         percentileLength === 1
           ? `${percentileLength} region`

--- a/components/widgets/forest-change/integrated-deforestation-alerts/selectors.js
+++ b/components/widgets/forest-change/integrated-deforestation-alerts/selectors.js
@@ -197,7 +197,11 @@ export const parseSentence = createSelector(
       system,
       totalArea: !totalArea
         ? ' '
-        : `covering a total of ${formatNumber({ num: totalArea, unit: 'ha' })}`,
+        : `covering a total of ${formatNumber({
+            num: totalArea,
+            unit: 'ha',
+            spaceUnit: true,
+          })}`,
       total: formatNumber({ num: totalAlertCount, unit: ',' }),
       highConfPerc:
         highAlertPercentage === 0

--- a/components/widgets/forest-change/net-change/selectors.js
+++ b/components/widgets/forest-change/net-change/selectors.js
@@ -93,12 +93,8 @@ const parseSentence = createSelector(
   [parseData, getSettings, getLocationLabel, getIndicator, getSentence],
   (data, settings, locationLabel, indicator, sentences) => {
     if (!data) return null;
-    const {
-      globalInitial,
-      globalWithIndicator,
-      initial,
-      withIndicator,
-    } = sentences;
+    const { globalInitial, globalWithIndicator, initial, withIndicator } =
+      sentences;
     const { startYear, endYear } = settings;
     const { change, net } = data;
 

--- a/components/widgets/forest-change/net-change/selectors.js
+++ b/components/widgets/forest-change/net-change/selectors.js
@@ -2,7 +2,6 @@ import { createSelector, createStructuredSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
 import sumBy from 'lodash/sumBy';
 import meanBy from 'lodash/meanBy';
-import { format } from 'd3-format';
 import { formatNumber } from 'utils/format';
 
 // get list data
@@ -113,8 +112,8 @@ const parseSentence = createSelector(
       location: locationLabel,
       startYear,
       endYear,
-      netChange: formatNumber({ num: net, unit: 'ha' }),
-      netChangePerc: `${format('.2r')(change)}%`,
+      netChange: formatNumber({ num: net, unit: 'ha', spaceUnit: true }),
+      netChangePerc: formatNumber({ num: change, unit: '%' }),
     };
 
     return {

--- a/components/widgets/forest-change/tree-cover-gain-simple/selectors.js
+++ b/components/widgets/forest-change/tree-cover-gain-simple/selectors.js
@@ -2,27 +2,27 @@ import { createSelector, createStructuredSelector } from 'reselect';
 import { formatNumber } from 'utils/format';
 
 // get list data
-const getGain = state => state.data && state.data.gain;
-const getExtent = state => state.data && state.data.extent;
-const getSentence = state => state.sentence;
-const getLocationName = state => state.locationLabel;
-const getColors = state => state.colors;
+const getGain = (state) => state.data && state.data.gain;
+const getExtent = (state) => state.data && state.data.extent;
+const getSentence = (state) => state.sentence;
+const getLocationName = (state) => state.locationLabel;
+const getColors = (state) => state.colors;
 
 export const parseSentence = createSelector(
   [getGain, getExtent, getSentence, getLocationName],
   (gain, extent, sentence, location) => {
     if (!gain && !extent) return null;
-    const gainPerc = (gain && extent && gain / extent * 100) || 0;
+    const gainPerc = (gain && extent && (gain / extent) * 100) || 0;
 
     const params = {
-      gain: formatNumber({ num: gain, unit: 'ha' }),
+      gain: formatNumber({ num: gain, unit: 'ha', spaceUnit: true }),
       gainPercent: formatNumber({ num: gainPerc, unit: '%' }),
-      location
+      location,
     };
 
     return {
       sentence,
-      params
+      params,
     };
   }
 );
@@ -31,20 +31,20 @@ export const parseData = createSelector(
   [getGain, getExtent, getColors],
   (gain, extent, colors) => {
     if (!gain || !extent) return null;
-    const gainPerc = (gain && extent && gain / extent * 100) || 0;
+    const gainPerc = (gain && extent && (gain / extent) * 100) || 0;
 
     return [
       {
         label: 'Tree cover gain',
         value: gain,
         color: colors.main,
-        percentage: gainPerc
-      }
+        percentage: gainPerc,
+      },
     ];
   }
 );
 
 export default createStructuredSelector({
   sentence: parseSentence,
-  data: parseData
+  data: parseData,
 });

--- a/components/widgets/forest-change/tree-cover-gain/selectors.js
+++ b/components/widgets/forest-change/tree-cover-gain/selectors.js
@@ -145,7 +145,7 @@ export const parseSentence = createSelector(
 
     const params = {
       location: currentLabel === 'global' ? 'globally' : currentLabel,
-      gain: formatNumber({ num: gain, unit: 'ha' }),
+      gain: formatNumber({ num: gain, unit: 'ha', spaceUnit: 'true' }),
       indicator: (indicator && indicator.label) || 'region-wide',
       percent: formatNumber({ num: areaPercent, unit: '%' }),
       gainPercent: formatNumber({ num: gainPercent, unit: '%' }),

--- a/components/widgets/forest-change/tree-gain-located/selectors.js
+++ b/components/widgets/forest-change/tree-gain-located/selectors.js
@@ -3,7 +3,7 @@ import isEmpty from 'lodash/isEmpty';
 import uniqBy from 'lodash/uniqBy';
 import sumBy from 'lodash/sumBy';
 import sortBy from 'lodash/sortBy';
-import { format } from 'd3-format';
+import { formatNumber } from 'utils/format';
 
 // get list data
 const getGain = (state) => state.data && state.data.gain;
@@ -92,17 +92,36 @@ export const parseSentence = createSelector(
     const params = {
       indicator: indicator && indicator.label,
       location: locationName,
-      topGain: `${format('.2r')(topGain)}%`,
+      topGain: formatNumber({
+        num: topGain,
+        unit: '%',
+      }),
       percentileLength: percentileLength || '0',
       region: percentileLength > 1 ? topRegion.label : 'This region',
       value:
         topRegion.percentage > 0 && settings.unit === '%'
-          ? `${format('.2r')(topRegion.percentage)}%`
-          : `${format(valueFormat)(topRegion.gain)}ha`,
+          ? formatNumber({
+              num: topRegion.percentage,
+              unit: '%',
+            })
+          : formatNumber({
+              num: topRegion.gain,
+              unit: 'ha',
+              spaceUnit: true,
+              specialSpecifier: valueFormat,
+            }),
       average:
         topRegion.percentage > 0 && settings.unit === '%'
-          ? `${format('.2r')(avgGainPercentage)}%`
-          : `${format(aveFormat)(avgGain)}ha`,
+          ? formatNumber({
+              num: avgGainPercentage,
+              unit: '%',
+            })
+          : formatNumber({
+              num: avgGain,
+              unit: 'ha',
+              spaceUnit: true,
+              specialSpecifier: aveFormat,
+            }),
     };
 
     return {

--- a/components/widgets/forest-change/tree-loss-drivers/selectors.js
+++ b/components/widgets/forest-change/tree-loss-drivers/selectors.js
@@ -5,7 +5,7 @@ import sumBy from 'lodash/sumBy';
 import entries from 'lodash/entries';
 import groupBy from 'lodash/groupBy';
 import findIndex from 'lodash/findIndex';
-import { format } from 'd3-format';
+import { formatNumber } from 'utils/format';
 import sortBy from 'lodash/sortBy';
 import { yearTicksFormatter } from 'components/widgets/utils/data';
 
@@ -144,9 +144,8 @@ export const parseConfig = createSelector(
       {
         key: 'total',
         label: 'Total',
-        unit: 'ha',
         unitFormat: (value) =>
-          value < 1000 ? Math.round(value) : format('.3s')(value),
+          formatNumber({ num: value, unit: 'ha', spaceUnit: true }),
       },
     ];
     tooltip = tooltip.concat(
@@ -157,10 +156,9 @@ export const parseConfig = createSelector(
           return {
             key: `class_${d.driver}`,
             label,
-            unit: 'ha',
             color: categoryColors[d.driver],
             unitFormat: (value) =>
-              value < 1000 ? Math.round(value) : format('.3s')(value),
+              formatNumber({ num: value, unit: 'ha', spaceUnit: true }),
           };
         })
         .reverse()
@@ -234,10 +232,7 @@ export const parseSentence = createSelector(
       location: locationName === 'global' ? 'Globally' : locationName,
       startYear,
       endYear,
-      permPercent:
-        permPercent && permPercent < 0.1
-          ? '< 0.1%'
-          : `${format('.2r')(permPercent)}%`,
+      permPercent: formatNumber({ num: permPercent, unit: '%' }),
       component: {
         key: 'deforestation',
         tooltip:

--- a/components/widgets/forest-change/tree-loss-global/selectors.js
+++ b/components/widgets/forest-change/tree-loss-global/selectors.js
@@ -3,7 +3,7 @@ import isEmpty from 'lodash/isEmpty';
 import sumBy from 'lodash/sumBy';
 import sum from 'lodash/sum';
 import groupBy from 'lodash/groupBy';
-import { format } from 'd3-format';
+import { formatNumber } from 'utils/format';
 import moment from 'moment';
 import { getColorPalette } from 'components/widgets/utils/colors';
 import sortBy from 'lodash/sortBy';
@@ -119,8 +119,8 @@ export const parseConfig = createSelector(
       {
         key: 'total',
         label: 'Total',
-        unit: 'ha',
-        unitFormat: (value) => format('.3s')(value),
+        unitFormat: (value) =>
+          formatNumber({ num: value, unit: 'ha', spaceUnit: true }),
       },
     ];
     tooltip = tooltip.concat(
@@ -131,9 +131,9 @@ export const parseConfig = createSelector(
           return {
             key,
             label: (country && country.label) || 'Other',
-            unit: 'ha',
             color: colorRange[i],
-            unitFormat: (value) => format('.3s')(value),
+            unitFormat: (value) =>
+              formatNumber({ num: value, unit: 'ha', spaceUnit: true }),
           };
         })
         .reverse()
@@ -182,12 +182,13 @@ export const parseSentence = createSelector(
       location: locationLabel === 'global' ? 'globally' : locationLabel,
       startYear,
       endYear,
-      loss:
-        totalLoss < 1
-          ? `${format('.3s')(totalLoss)}ha`
-          : `${format('.3s')(totalLoss)}ha`,
-      percent: `${format('.2r')(percentageLoss)}%`,
-      emissions: `${format('.3s')(totalEmissions)}t`,
+      loss: formatNumber({ num: totalLoss, unit: 'ha', spaceUnit: true }),
+      percent: formatNumber({ num: percentageLoss, unit: '%' }),
+      emissions: formatNumber({
+        num: totalEmissions,
+        unit: 't',
+        spaceUnit: true,
+      }),
       extentYear,
     };
 

--- a/components/widgets/forest-change/tree-loss-located/selectors.js
+++ b/components/widgets/forest-change/tree-loss-located/selectors.js
@@ -4,7 +4,6 @@ import uniqBy from 'lodash/uniqBy';
 import sumBy from 'lodash/sumBy';
 import sortBy from 'lodash/sortBy';
 import { formatNumber } from 'utils/format';
-import { format } from 'd3-format';
 
 // get list data
 const getLoss = (state) => state.data && state.data.lossByRegion;
@@ -119,17 +118,17 @@ export const parseSentence = createSelector(
       location: locationName,
       startYear,
       endYear,
-      topLoss: `${format('.2r')(topLoss)}%`,
+      topLoss: formatNumber({ num: topLoss, unit: '%' }),
       percentileLength,
       region: percentileLength > 1 ? topRegion.label : 'This region',
       value:
         topRegion.percentage > 0 && settings.unit === '%'
           ? formatNumber({ num: topRegion.percentage, unit: '%' })
-          : formatNumber({ num: topRegion.loss, unit: 'ha' }),
+          : formatNumber({ num: topRegion.loss, unit: 'ha', spaceUnit: true }),
       average:
         topRegion.percentage > 0 && settings.unit === '%'
           ? formatNumber({ num: avgLossPercentage, unit: '%' })
-          : formatNumber({ num: avgLoss, unit: 'ha' }),
+          : formatNumber({ num: avgLoss, unit: 'ha', spaceUnit: true }),
     };
 
     return {

--- a/components/widgets/forest-change/tree-loss-plantations/selectors.js
+++ b/components/widgets/forest-change/tree-loss-plantations/selectors.js
@@ -2,7 +2,6 @@ import { createSelector, createStructuredSelector } from 'reselect';
 import sumBy from 'lodash/sumBy';
 import groupBy from 'lodash/groupBy';
 import uniqBy from 'lodash/uniqBy';
-import { format } from 'd3-format';
 import { formatNumber } from 'utils/format';
 import { getColorPalette } from 'components/widgets/utils/colors';
 import { zeroFillYears } from 'components/widgets/utils/data';
@@ -91,22 +90,22 @@ export const parseConfig = createSelector([getColors], (colors) => {
       {
         key: 'totalLoss',
         label: 'Total',
-        unit: 'ha',
-        unitFormat: (value) => format('.3s')(value),
+        unitFormat: (value) =>
+          formatNumber({ num: value, unit: 'ha', spaceUnit: true }),
       },
       {
         key: 'outsideAreaLoss',
         label: 'Natural forest',
         color: colorRange[1],
-        unit: 'ha',
-        unitFormat: (value) => format('.3s')(value),
+        unitFormat: (value) =>
+          formatNumber({ num: value, unit: 'ha', spaceUnit: true }),
       },
       {
         key: 'areaLoss',
         label: 'Plantations',
         color: colorRange[0],
-        unit: 'ha',
-        unitFormat: (value) => format('.3s')(value),
+        unitFormat: (value) =>
+          formatNumber({ num: value, unit: 'ha', spaceUnit: true }),
       },
     ],
   };
@@ -133,7 +132,11 @@ export const parseSentence = createSelector(
       startYear,
       endYear,
       lossPhrase,
-      value: `${format('.3s')(outsideEmissions)}t`,
+      value: formatNumber({
+        num: outsideEmissions,
+        unit: 't',
+        spaceUnit: true,
+      }),
       percentage: formatNumber({ num: percentage, unit: '%' }),
     };
 

--- a/components/widgets/forest-change/tree-loss-primary/selectors.js
+++ b/components/widgets/forest-change/tree-loss-primary/selectors.js
@@ -143,7 +143,8 @@ const parseConfig = createSelector([getColors], (colors) => ({
     },
     {
       key: 'area',
-      unitFormat: (value) => formatNumber({ num: value, unit: 'ha' }),
+      unitFormat: (value) =>
+        formatNumber({ num: value, unit: 'ha', spaceUnit: true }),
       label: 'Primary forest loss',
       color: colors.primaryForestLoss,
     },
@@ -222,7 +223,11 @@ const parseSentence = createSelector(
         num: Math.abs(initialExtent - finalExtent),
         unit: '%',
       }),
-      loss: formatNumber({ num: totalLossPrimary, unit: 'ha' }),
+      loss: formatNumber({
+        num: totalLossPrimary,
+        unit: 'ha',
+        spaceUnit: true,
+      }),
       percent: formatNumber({ num: percentageLoss, unit: '%' }),
       component: {
         key: 'total tree cover loss',

--- a/components/widgets/forest-change/tree-loss-ranked/selectors.js
+++ b/components/widgets/forest-change/tree-loss-ranked/selectors.js
@@ -163,13 +163,14 @@ export const parseSentence = createSelector(
         topRegionData &&
         formatNumber({ num: topRegionData.percentage, unit: '%' }),
       topLocationLoss:
-        topRegionData && formatNumber({ num: topRegionData.loss, unit: 'ha' }),
+        topRegionData &&
+        formatNumber({ num: topRegionData.loss, unit: 'ha', spaceUnit: true }),
       location:
         location.label === 'global' ? 'globally' : location && location.label,
       indicator_alt: indicatorName,
       startYear,
       endYear,
-      loss: formatNumber({ num: lossArea, unit: 'ha' }),
+      loss: formatNumber({ num: lossArea, unit: 'ha', spaceUnit: true }),
       localPercent: formatNumber({ num: areaPercent, unit: '%' }),
       globalPercent: formatNumber({ num: lossPercent, unit: '%' }),
       extentYear: settings.extentYear,

--- a/components/widgets/forest-change/tree-loss/selectors.js
+++ b/components/widgets/forest-change/tree-loss/selectors.js
@@ -1,7 +1,6 @@
 import { createSelector, createStructuredSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
 import sumBy from 'lodash/sumBy';
-import { format } from 'd3-format';
 import { formatNumber } from 'utils/format';
 import {
   yearTicksFormatter,
@@ -82,7 +81,8 @@ const parseConfig = createSelector([getColors], (colors) => ({
     {
       key: 'area',
       label: 'Tree cover loss',
-      unitFormat: (value) => formatNumber({ num: value, unit: 'ha' }),
+      unitFormat: (value) =>
+        formatNumber({ num: value, unit: 'ha', spaceUnit: true }),
       color: colors.main,
     },
     {
@@ -144,9 +144,13 @@ const parseSentence = createSelector(
       location: locationLabel,
       startYear,
       endYear,
-      loss: formatNumber({ num: totalLoss, unit: 'ha' }),
-      percent: `${format('.2r')(percentageLoss)}%`,
-      emissions: `${format('.3s')(totalEmissions)}t`,
+      loss: formatNumber({ num: totalLoss, unit: 'ha', spaceUnit: true }),
+      percent: formatNumber({ num: percentageLoss, unit: '%' }),
+      emissions: formatNumber({
+        num: totalEmissions,
+        unit: 't',
+        spaceUnit: true,
+      }),
       extentYear,
     };
 

--- a/components/widgets/land-cover/fao-cover/selectors.js
+++ b/components/widgets/land-cover/fao-cover/selectors.js
@@ -71,7 +71,7 @@ export const parseSentence = createSelector(
         : (extent / area_ha) * 100;
     const params = {
       location: locationName === 'global' ? 'globally' : locationName,
-      extent: formatNumber({ num: extent, unit: 'ha' }),
+      extent: formatNumber({ num: extent, unit: 'ha', spaceUnit: true }),
       primaryPercent: formatNumber({ num: primaryPercent, unit: '%' }),
     };
     let sentence = forest_primary > 0 ? initial : noPrimary;

--- a/components/widgets/land-cover/intact-tree-cover/selectors.js
+++ b/components/widgets/land-cover/intact-tree-cover/selectors.js
@@ -1,14 +1,14 @@
 import { createSelector, createStructuredSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
-import { format } from 'd3-format';
+import { formatNumber } from 'utils/format';
 
 // get list data
-const getData = state => state.data;
-const getLocationName = state => state.locationLabel;
-const getIndicator = state => state.indicator;
-const getColors = state => state.colors;
-const getSentences = state => state.sentences;
-const getTitle = state => state.title;
+const getData = (state) => state.data;
+const getLocationName = (state) => state.locationLabel;
+const getIndicator = (state) => state.indicator;
+const getColors = (state) => state.colors;
+const getSentences = (state) => state.sentences;
+const getTitle = (state) => state.title;
 
 // get lists selected
 export const parseData = createSelector(
@@ -21,20 +21,20 @@ export const parseData = createSelector(
         label: 'Intact Forest',
         value: extent,
         color: colors.intactForest,
-        percentage: extent / totalArea * 100
+        percentage: (extent / totalArea) * 100,
       },
       {
         label: 'Other Tree Cover',
         value: totalExtent - extent,
         color: colors.otherCover,
-        percentage: (totalExtent - extent) / totalArea * 100
+        percentage: ((totalExtent - extent) / totalArea) * 100,
       },
       {
         label: 'Non-Forest',
         value: totalArea - totalExtent,
         color: colors.nonForest,
-        percentage: (totalArea - totalExtent) / totalArea * 100
-      }
+        percentage: ((totalArea - totalExtent) / totalArea) * 100,
+      },
     ];
     return parsedData;
   }
@@ -48,24 +48,22 @@ export const parseSentence = createSelector(
       initial,
       withIndicator,
       noIntact,
-      noIntactWithIndicator
+      noIntactWithIndicator,
     } = sentences;
     const totalExtent = parsedData
-      .filter(d => d.label !== 'Non-Forest')
-      .map(d => d.value)
+      .filter((d) => d.label !== 'Non-Forest')
+      .map((d) => d.value)
       .reduce((sum, d) => sum + d);
-    const intactData = parsedData.find(d => d.label === 'Intact Forest').value;
-    const intactPercentage = intactData && intactData / totalExtent * 100;
+    const intactData = parsedData.find((d) => d.label === 'Intact Forest')
+      .value;
+    const intactPercentage = intactData && (intactData / totalExtent) * 100;
     const indicatorLabel =
       indicator && indicator.label ? indicator.label : null;
 
     const params = {
       location: locationName !== 'global' ? `${locationName}'s` : locationName,
       indicator: indicatorLabel,
-      percentage:
-        intactPercentage < 0.1
-          ? '< 0.1%'
-          : `${format('.2r')(intactPercentage)}%`
+      percentage: formatNumber({ num: intactPercentage, unit: '%' }),
     };
 
     let sentence = indicator ? withIndicator : initial;
@@ -75,7 +73,7 @@ export const parseSentence = createSelector(
 
     return {
       sentence,
-      params
+      params,
     };
   }
 );
@@ -94,5 +92,5 @@ export const parseTitle = createSelector(
 export default createStructuredSelector({
   data: parseData,
   sentence: parseSentence,
-  title: parseTitle
+  title: parseTitle,
 });

--- a/components/widgets/land-cover/primary-forest/selectors.js
+++ b/components/widgets/land-cover/primary-forest/selectors.js
@@ -1,14 +1,14 @@
 import { createSelector, createStructuredSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
-import { format } from 'd3-format';
+import { formatNumber } from 'utils/format';
 
 // get list data
-const getData = state => state.data;
-const getSettings = state => state.settings;
-const getLocationName = state => state.locationLabel;
-const getIndicator = state => state.indicator;
-const getColors = state => state.colors;
-const getSentences = state => state.sentences;
+const getData = (state) => state.data;
+const getSettings = (state) => state.settings;
+const getLocationName = (state) => state.locationLabel;
+const getIndicator = (state) => state.indicator;
+const getColors = (state) => state.colors;
+const getSentences = (state) => state.sentences;
 
 // get lists selected
 export const parseData = createSelector(
@@ -22,20 +22,20 @@ export const parseData = createSelector(
         label: 'Primary Forest',
         value: extent,
         color: colors.primaryForest,
-        percentage: extent / totalArea * 100
+        percentage: (extent / totalArea) * 100,
       },
       {
         label: 'Other Tree Cover',
         value: secondaryExtent,
         color: colors.otherCover,
-        percentage: secondaryExtent / totalArea * 100
+        percentage: (secondaryExtent / totalArea) * 100,
       },
       {
         label: 'Non-Forest',
         value: totalArea - totalExtent,
         color: colors.nonForest,
-        percentage: (totalArea - totalExtent) / totalArea * 100
-      }
+        percentage: ((totalArea - totalExtent) / totalArea) * 100,
+      },
     ];
     return parsedData;
   }
@@ -47,34 +47,31 @@ export const parseSentence = createSelector(
     if (!parsedData || !locationName) return null;
     const { initial, withIndicator } = sentences;
     const totalExtent = parsedData
-      .filter(d => d.label !== 'Non-Forest')
-      .map(d => d.value)
+      .filter((d) => d.label !== 'Non-Forest')
+      .map((d) => d.value)
       .reduce((sum, d) => sum + d);
-    const primaryData = parsedData.find(d => d.label === 'Primary Forest')
+    const primaryData = parsedData.find((d) => d.label === 'Primary Forest')
       .value;
-    const primaryPercentage = primaryData && primaryData / totalExtent * 100;
+    const primaryPercentage = primaryData && (primaryData / totalExtent) * 100;
     const indicatorLabel =
       indicator && indicator.label ? indicator.label : null;
 
     const params = {
       location: `${locationName}'s`,
       indicator: indicatorLabel,
-      percentage:
-        primaryPercentage < 0.1
-          ? '< 0.1%'
-          : `${format('.2r')(primaryPercentage)}%`,
-      extentYear: settings.extentYear
+      percentage: formatNumber({ num: primaryPercentage, unit: '%' }),
+      extentYear: settings.extentYear,
     };
     const sentence = indicator ? withIndicator : initial;
 
     return {
       sentence,
-      params
+      params,
     };
   }
 );
 
 export default createStructuredSelector({
   data: parseData,
-  sentence: parseSentence
+  sentence: parseSentence,
 });

--- a/components/widgets/land-cover/ranked-forest-types/selectors.js
+++ b/components/widgets/land-cover/ranked-forest-types/selectors.js
@@ -1,5 +1,4 @@
 import { createSelector, createStructuredSelector } from 'reselect';
-import { format } from 'd3-format';
 import { formatNumber } from 'utils/format';
 import maxBy from 'lodash/maxBy';
 
@@ -59,7 +58,12 @@ export const parseData = createSelector([getData], (data) => {
       label,
       // extentPercent is not needed for the infoList; we'll use it to mitigate percentage
       // sum above 100% later on.
-      extentPercent: Number(format('.2r')(extentPercent)),
+      extentPercent: Number(
+        formatNumber({
+          num: extentPercent,
+          specialSpecifier: '.2r',
+        })
+      ),
       text: `${formatNumber({
         num: extentPercent,
         unit: '%',
@@ -85,9 +89,11 @@ export const parseData = createSelector([getData], (data) => {
     const extraPercentage = percentagesSum - 100;
     const highestPercentEntry = maxBy(ipccClassesDetails, 'extentPercent');
 
-    highestPercentEntry.text = `${format('.2r')(
-      highestPercentEntry.extentPercent - extraPercentage
-    )}%`;
+    highestPercentEntry.text = formatNumber({
+      num: highestPercentEntry.extentPercent - extraPercentage,
+      unit: '%',
+      specialSpecifier: '.2r',
+    });
   }
 
   // Return only the properties the infoList actually needs, to prevent future confusion.

--- a/components/widgets/land-cover/ranked-plantations/selectors.js
+++ b/components/widgets/land-cover/ranked-plantations/selectors.js
@@ -4,7 +4,7 @@ import maxBy from 'lodash/maxBy';
 import remove from 'lodash/remove';
 import groupBy from 'lodash/groupBy';
 import sumBy from 'lodash/sumBy';
-import { format } from 'd3-format';
+import { formatNumber } from 'utils/format';
 import sortBy from 'lodash/sortBy';
 import endsWith from 'lodash/endsWith';
 
@@ -89,8 +89,7 @@ export const parseConfig = createSelector(
         key: item,
         label: item,
         color: colorsByType[item],
-        unit: '%',
-        unitFormat: (value) => format('.1f')(value),
+        unitFormat: (value) => formatNumber({ num: value, unit: '%' }),
       })),
     };
   }
@@ -117,7 +116,7 @@ export const parseSentence = createSelector(
       location: locationName,
       region: topRegion.region,
       topType: `${plantationLabel}${isPlural ? 's' : ''} plantations`,
-      percentage: `${format('.2r')(data[0].total)}%`,
+      percentage: formatNumber({ num: data[0].total, unit: '%' }),
     };
 
     return {

--- a/components/widgets/land-cover/tree-cover-density/selectors.js
+++ b/components/widgets/land-cover/tree-cover-density/selectors.js
@@ -46,7 +46,8 @@ const parseConfig = createSelector([getColors], (colors) => ({
   tooltip: [
     {
       key: 'area',
-      unitFormat: (value) => formatNumber({ num: value, unit: 'ha' }),
+      unitFormat: (value) =>
+        formatNumber({ num: value, unit: 'ha', spaceUnit: true }),
       label: 'Land area',
       color: colors.primaryForestLoss,
       dashline: true,
@@ -77,6 +78,7 @@ const parseSentence = createSelector(
       areasOverTenPercent: formatNumber({
         num: areasOverTenPercent,
         unit: 'ha',
+        spaceUnit: true,
       }),
       areaInPercent: `${areasOverTenPercentByTotalArea}%`,
     };

--- a/components/widgets/land-cover/tree-cover-located/selectors.js
+++ b/components/widgets/land-cover/tree-cover-located/selectors.js
@@ -90,8 +90,16 @@ export const parseSentence = createSelector(
     const topExtent =
       (totalExtent > 0 && (percentileExtent / totalExtent) * 100) || 0;
 
-    const topRegionExtent = formatNumber({ num: topRegion.extent, unit: 'ha' });
-    const aveRegionExtent = formatNumber({ num: avgExtent, unit: 'ha' });
+    const topRegionExtent = formatNumber({
+      num: topRegion.extent,
+      unit: 'ha',
+      spaceUnit: true,
+    });
+    const aveRegionExtent = formatNumber({
+      num: avgExtent,
+      unit: 'ha',
+      spaceUnit: true,
+    });
     const topRegionPercent = formatNumber({
       num: topRegion.percentage,
       unit: '%',

--- a/components/widgets/land-cover/tree-cover-plantations/selectors.js
+++ b/components/widgets/land-cover/tree-cover-plantations/selectors.js
@@ -2,7 +2,7 @@ import { createSelector, createStructuredSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
 import sumBy from 'lodash/sumBy';
 import sortBy from 'lodash/sortBy';
-import { format } from 'd3-format';
+import { formatNumber } from 'utils/format';
 import endsWith from 'lodash/endsWith';
 
 // get list data
@@ -52,17 +52,11 @@ export const parseSentence = createSelector(
       firstSpecies: top[0].label.toLowerCase(),
       secondSpecies: top.length > 1 && top[1].label.toLowerCase(),
       type: settings.type === 'bound2' ? 'species' : 'type',
-      extent:
-        topExtent < 1
-          ? `${format('.3r')(topExtent)}ha`
-          : `${format('.3s')(topExtent)}ha`,
-      other:
-        otherExtent < 1
-          ? `${format('.3r')(otherExtent)}ha`
-          : `${format('.3s')(otherExtent)}ha`,
+      extent: formatNumber({ num: topExtent, unit: 'ha', spaceUnit: true }),
+      other: formatNumber({ num: otherExtent, unit: 'ha', spaceUnit: true }),
       count: data.length - top.length,
       topType: `${top[0].label}${endsWith(top[0].label, 's') ? '' : 's'}`,
-      percent: areaPerc >= 0.1 ? `${format('.2r')(areaPerc)}%` : '< 0.1%',
+      percent: formatNumber({ num: areaPerc, unit: '%' }),
     };
     const sentence =
       settings.type === 'bound1'

--- a/components/widgets/land-cover/tree-cover-ranked/selectors.js
+++ b/components/widgets/land-cover/tree-cover-ranked/selectors.js
@@ -2,7 +2,7 @@ import { createSelector, createStructuredSelector } from 'reselect';
 import uniqBy from 'lodash/uniqBy';
 import findIndex from 'lodash/findIndex';
 import sortBy from 'lodash/sortBy';
-import { format } from 'd3-format';
+import { formatNumber } from 'utils/format';
 import sumBy from 'lodash/sumBy';
 
 // get list data
@@ -84,15 +84,10 @@ export const parseSentence = createSelector(
     const params = {
       extentYear: settings.extentYear,
       location: locationObject.label,
-      extent:
-        extent < 1
-          ? `${format('.3r')(extent)}ha`
-          : `${format('.3s')(extent)}ha`,
+      extent: formatNumber({ num: extent, unit: 'ha', spaceUnit: true }),
       indicator: indicator && indicator.label,
-      landPercentage:
-        landPercent >= 0.1 ? `${format('.2r')(landPercent)}%` : '< 0.1%',
-      globalPercentage:
-        globalPercent >= 0.1 ? `${format('.2r')(globalPercent)}%` : '< 0.1%',
+      landPercentage: formatNumber({ num: landPercent, unit: '%' }),
+      globalPercentage: formatNumber({ num: globalPercent, unit: '%' }),
     };
 
     let sentence = indicator ? withInd : initial;

--- a/components/widgets/land-cover/tree-cover/selectors.js
+++ b/components/widgets/land-cover/tree-cover/selectors.js
@@ -1,6 +1,6 @@
 import { createSelector, createStructuredSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
-import { format } from 'd3-format';
+import { formatNumber } from 'utils/format';
 
 // get list data
 const getData = (state) => state.data;
@@ -117,8 +117,7 @@ export const parseSentence = createSelector(
     const bottom = indicator ? totalCover : totalArea;
     const percentCover = (100 * top) / bottom;
 
-    const formattedPercentage =
-      percentCover >= 0.1 ? `${format('.2r')(percentCover)}%` : '<0.1%';
+    const formattedPercentage = formatNumber({ num: percentCover, unit: '%' });
 
     const thresholdLabel = `>${decileThreshold}%`;
 

--- a/components/widgets/land-cover/us-land-cover/selectors.js
+++ b/components/widgets/land-cover/us-land-cover/selectors.js
@@ -8,10 +8,10 @@ import findIndex from 'lodash/findIndex';
 
 import { formatNumber } from 'utils/format';
 
-const getData = state => state.data;
-const getSettings = state => state.settings;
-const getColors = state => state.colors;
-const getSentences = state => state.sentences;
+const getData = (state) => state.data;
+const getSettings = (state) => state.settings;
+const getColors = (state) => state.colors;
+const getSentences = (state) => state.sentences;
 
 export const cleanData = createSelector(
   [getData, getSettings],
@@ -22,7 +22,7 @@ export const cleanData = createSelector(
     if (!source) source = 'ipcc';
     if (variable === 'changes_only') {
       return data.filter(
-        d => d[`from_class_${source}`] !== d[`to_class_${source}`]
+        (d) => d[`from_class_${source}`] !== d[`to_class_${source}`]
       );
     }
     return data;
@@ -42,7 +42,7 @@ export const parseData = createSelector(
         settlement: 'Settlement',
         cropland: 'Agriculture',
         grassland: 'Grassland',
-        wetland: 'Wetland'
+        wetland: 'Wetland',
       },
       nlcd: {
         deciduous_forest: 'Deciduous forest',
@@ -60,8 +60,8 @@ export const parseData = createSelector(
         emergent_herbaceous_wetlands: 'Emergent herbaceous wetlands',
         barren: 'Barren land (rock/sand/clay)',
         perennial_ice_snow: 'Perennial ice/snow',
-        open_water: 'Water Body'
-      }
+        open_water: 'Water Body',
+      },
     };
 
     // SANKEY NODES
@@ -73,7 +73,7 @@ export const parseData = createSelector(
           color: categories[source][key]
             ? colors.categories[categories[source][key]]
             : colors.categories.Other,
-          value: sumBy(group, 'area')
+          value: sumBy(group, 'area'),
         })
       ),
       'value',
@@ -87,35 +87,35 @@ export const parseData = createSelector(
       color: categories[source][key]
         ? colors.categories[categories[source][key]]
         : colors.categories.Other,
-      value: sumBy(group, 'area')
+      value: sumBy(group, 'area'),
     }));
     const endNodes = [
       // nodes already in startNodes
       ...startNodes
-        .map(startNode => ({
+        .map((startNode) => ({
           ...startNode,
-          key: startNode.key.replace('start', 'end')
+          key: startNode.key.replace('start', 'end'),
         }))
         .filter(
-          startNode => findIndex(uniqueEndNodes, { key: startNode.key }) >= 0
+          (startNode) => findIndex(uniqueEndNodes, { key: startNode.key }) >= 0
         ),
       // 'new' nodes
       ...uniqueEndNodes.filter(
-        endNode =>
+        (endNode) =>
           findIndex(startNodes, {
-            key: endNode.key.replace('end', 'start')
+            key: endNode.key.replace('end', 'start'),
           }) === -1
-      )
+      ),
     ];
 
     const nodes = [...startNodes, ...endNodes];
     // SANKEY LINKS
-    const allLinks = data.map(d => {
+    const allLinks = data.map((d) => {
       const sourceIndex = findIndex(nodes, {
-        key: `${d[`from_class_${source}`]}-start`
+        key: `${d[`from_class_${source}`]}-start`,
       });
       const targetIndex = findIndex(nodes, {
-        key: `${d[`to_class_${source}`]}-end`
+        key: `${d[`to_class_${source}`]}-end`,
       });
       return {
         source: sourceIndex,
@@ -123,21 +123,21 @@ export const parseData = createSelector(
         value: d.area,
         key: `${sourceIndex}_${targetIndex}`,
         startKey: d[`from_class_${source}`],
-        endKey: d[`to_class_${source}`]
+        endKey: d[`to_class_${source}`],
       };
     });
-    const links = Object.values(groupBy(allLinks, 'key')).map(group => {
+    const links = Object.values(groupBy(allLinks, 'key')).map((group) => {
       const link = group[0] || {};
       return {
         ...link,
-        value: sumBy(group, 'value')
+        value: sumBy(group, 'value'),
       };
     });
     const biggestLink = maxBy(links, 'value');
     const selectedElement = {
       ...biggestLink,
       source: nodes[biggestLink.source],
-      target: nodes[biggestLink.target]
+      target: nodes[biggestLink.target],
     };
 
     return { nodes, links, selectedElement };
@@ -152,10 +152,10 @@ export const parseDataConfig = createSelector(
     const { source } = settings;
     const threshold = 3;
     const topNNodes = [
-      ...nodes.filter(n => n.key.includes('start')).slice(0, threshold),
-      ...nodes.filter(n => n.key.includes('end')).slice(0, threshold)
+      ...nodes.filter((n) => n.key.includes('start')).slice(0, threshold),
+      ...nodes.filter((n) => n.key.includes('end')).slice(0, threshold),
     ];
-    const shouldShowLabel = node => {
+    const shouldShowLabel = (node) => {
       if (source === 'nlcd') {
         return findIndex(topNNodes, { key: node.key }) >= 0;
       }
@@ -184,46 +184,50 @@ export const parseSentence = createSelector(
       // nothing selected, init sentence
       firstCategory = selectedElement.source && selectedElement.source.name;
       secondCategory = selectedElement.target && selectedElement.target.name;
-      amount = formatNumber({ num: selectedElement.value, unit: 'ha' });
+      amount = formatNumber({
+        num: selectedElement.value,
+        unit: 'ha',
+        spaceUnit: true,
+      });
       percentage = formatNumber({
-        num: selectedElement.value / total * 100,
-        unit: '%'
+        num: (selectedElement.value / total) * 100,
+        unit: '%',
       });
     } else if (interaction.source && interaction.target) {
       // link selected
-      const link = links.find(l => l.key === interaction.key);
+      const link = links.find((l) => l.key === interaction.key);
       firstCategory = interaction.source.name;
       secondCategory = interaction.target.name;
       const change = link && link.value;
-      amount = formatNumber({ num: change, unit: 'ha' });
-      percentage = formatNumber({ num: change / total * 100, unit: '%' });
+      amount = formatNumber({ num: change, unit: 'ha', spaceUnit: true });
+      percentage = formatNumber({ num: (change / total) * 100, unit: '%' });
     } else if (interaction.key && interaction.key.includes('start')) {
       // start node
-      const sourceNode = nodes.find(n => n.key === interaction.key);
+      const sourceNode = nodes.find((n) => n.key === interaction.key);
       firstCategory = sourceNode && sourceNode.name;
       secondCategory = 'other types';
       const change = sumBy(
         links.filter(
-          l =>
+          (l) =>
             `${l.startKey}-start` === sourceNode.key && l.startKey !== l.endKey
         ),
         'value'
       );
-      amount = formatNumber({ num: change, unit: 'ha' });
-      percentage = formatNumber({ num: change / total * 100, unit: '%' });
+      amount = formatNumber({ num: change, unit: 'ha', spaceUnit: true });
+      percentage = formatNumber({ num: (change / total) * 100, unit: '%' });
     } else if (interaction.key && interaction.key.includes('end')) {
       // end node
-      const endNode = nodes.find(n => n.key === interaction.key);
+      const endNode = nodes.find((n) => n.key === interaction.key);
       firstCategory = 'other types';
       secondCategory = endNode && endNode.name;
       const change = sumBy(
         links.filter(
-          l => `${l.endKey}-end` === endNode.key && l.startKey !== l.endKey
+          (l) => `${l.endKey}-end` === endNode.key && l.startKey !== l.endKey
         ),
         'value'
       );
-      amount = formatNumber({ num: change, unit: 'ha' });
-      percentage = formatNumber({ num: change / total * 100, unit: '%' });
+      amount = formatNumber({ num: change, unit: 'ha', spaceUnit: true });
+      percentage = formatNumber({ num: (change / total) * 100, unit: '%' });
     }
 
     const params = {
@@ -232,14 +236,14 @@ export const parseSentence = createSelector(
       firstCategory,
       secondCategory,
       amount,
-      percentage
+      percentage,
     };
 
     let sentence = isEmpty(interaction) ? initial : interactionSentence;
     if (firstCategory === secondCategory) sentence = noChange;
     return {
       sentence,
-      params
+      params,
     };
   }
 );
@@ -247,5 +251,5 @@ export const parseSentence = createSelector(
 export default createStructuredSelector({
   data: parseData,
   config: parseDataConfig,
-  sentence: parseSentence
+  sentence: parseSentence,
 });

--- a/components/widgets/land-use/economic-impact/selectors.js
+++ b/components/widgets/land-use/economic-impact/selectors.js
@@ -1,9 +1,8 @@
 import { createSelector, createStructuredSelector } from 'reselect';
 import findIndex from 'lodash/findIndex';
 import isEmpty from 'lodash/isEmpty';
-import { format } from 'd3-format';
 import sortBy from 'lodash/sortBy';
-import { formatUSD } from 'utils/format';
+import { formatUSD, formatNumber } from 'utils/format';
 
 // get list data
 const getData = (state) => state.data && state.data.data;
@@ -173,10 +172,7 @@ export const parseSentence = createSelector(
     const params = {
       location: `${locationObject && locationObject && locationObject.label}'s`,
       value: `${formatUSD(selectedFAO[0].net_usd, false)} USD`,
-      percentage:
-        selectedFAO[0].net_perc >= 0.1
-          ? `${format('2r')(selectedFAO[0].net_perc)}%`
-          : '< 0.1%',
+      percentage: formatNumber({ num: selectedFAO[0].net_perc, unit: '%' }),
       year: settings.year,
     };
 

--- a/components/widgets/land-use/forestry-employment/selectors.js
+++ b/components/widgets/land-use/forestry-employment/selectors.js
@@ -1,13 +1,13 @@
 import { createSelector, createStructuredSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
-import { format } from 'd3-format';
+import { formatNumber } from 'utils/format';
 
 // get list data
-const getData = state => state.data;
-const getSettings = state => state.settings;
-const getLocationObject = state => state.location;
-const getColors = state => state.colors;
-const getSentences = state => state.sentences;
+const getData = (state) => state.data;
+const getSettings = (state) => state.settings;
+const getLocationObject = (state) => state.location;
+const getColors = (state) => state.colors;
+const getSentences = (state) => state.sentences;
 
 // get lists selected
 export const getFilteredData = createSelector(
@@ -16,14 +16,14 @@ export const getFilteredData = createSelector(
     if (isEmpty(data) || !locationObject) return null;
     return data
       .filter(
-        item => item.country === locationObject.value && item.year !== 9999
+        (item) => item.country === locationObject.value && item.year !== 9999
       )
-      .map(item => ({
+      .map((item) => ({
         male: item.femempl
           ? (item.forempl - item.femempl) * 1000
           : item.forempl * 1000,
         female: item.femempl ? item.femempl * 1000 : null,
-        year: item.year
+        year: item.year,
       }));
   }
 );
@@ -34,7 +34,7 @@ export const parseData = createSelector(
     if (isEmpty(data)) return null;
 
     const { year } = settings;
-    const selectedFAO = data.filter(item => item.year === year);
+    const selectedFAO = data.filter((item) => item.year === year);
     const { male, female } =
       selectedFAO && selectedFAO.length && selectedFAO[0];
     if (!female) return null;
@@ -45,14 +45,14 @@ export const parseData = createSelector(
         label: 'Male',
         value: male,
         color: colors.male,
-        percentage: male / total * 100
+        percentage: (male / total) * 100,
       },
       {
         label: 'Female',
         value: female,
         color: colors.female,
-        percentage: female / total * 100
-      }
+        percentage: (female / total) * 100,
+      },
     ];
     return formatedData;
   }
@@ -64,7 +64,7 @@ export const parseSentence = createSelector(
     if (!data) return null;
     const { year } = settings;
     const { initial, withFemales } = sentences;
-    const selectedFAO = data.find(item => item.year === year);
+    const selectedFAO = data.find((item) => item.year === year);
     let employees = 0;
     let females = 0;
     if (selectedFAO) {
@@ -73,23 +73,25 @@ export const parseSentence = createSelector(
         : selectedFAO.male;
       females = parseInt(selectedFAO.female, 10);
     }
-    const percentage = 100 * females / employees;
+    const percentage = (100 * females) / employees;
 
     const params = {
       location: `${locationObject && locationObject && locationObject.label}'s`,
-      value: `${employees ? format('.3s')(employees) : 'no'}`,
-      percent: percentage >= 0.1 ? `${format('.2r')(percentage)}%` : '< 0.1%',
-      year
+      value: `${
+        employees ? formatNumber({ num: employees, spaceUnit: true }) : 'no'
+      }`,
+      percent: formatNumber({ num: percentage, unit: '%' }),
+      year,
     };
 
     return {
       sentence: females ? withFemales : initial,
-      params
+      params,
     };
   }
 );
 
 export default createStructuredSelector({
   data: parseData,
-  sentence: parseSentence
+  sentence: parseSentence,
 });

--- a/components/widgets/land-use/forestry-employment/selectors.js
+++ b/components/widgets/land-use/forestry-employment/selectors.js
@@ -77,9 +77,7 @@ export const parseSentence = createSelector(
 
     const params = {
       location: `${locationObject && locationObject && locationObject.label}'s`,
-      value: `${
-        employees ? formatNumber({ num: employees, spaceUnit: true }) : 'no'
-      }`,
+      value: `${employees ? formatNumber({ num: employees }) : 'no'}`,
       percent: formatNumber({ num: percentage, unit: '%' }),
       year,
     };

--- a/components/widgets/land-use/trase-commodities/selectors.js
+++ b/components/widgets/land-use/trase-commodities/selectors.js
@@ -4,18 +4,18 @@ import capitalize from 'lodash/capitalize';
 import { formatNumber } from 'utils/format';
 
 // get list data
-const getData = state => state.data && state.data.data;
-const getSettings = state => state.settings;
-const getLocationName = state => state.locationLabel;
-const getColors = state => state.colors;
-const getSentences = state => state.sentence;
+const getData = (state) => state.data && state.data.data;
+const getSettings = (state) => state.settings;
+const getLocationName = (state) => state.locationLabel;
+const getColors = (state) => state.colors;
+const getSentences = (state) => state.sentence;
 
 export const parseData = createSelector(
   [getData, getColors, getSettings],
   (data, colors, settings) => {
     if (isEmpty(data)) return null;
     const list = data.topNodes.targetNodes;
-    const rankedList = list.map(l => ({
+    const rankedList = list.map((l) => ({
       label: capitalize(l.name),
       value: settings.unit === 't' ? l.value : l.height * 100,
       id: l.id,
@@ -23,11 +23,11 @@ export const parseData = createSelector(
       percentage: l.height * 100,
       unit: settings.unit,
       iso: l.geo_id,
-      color: colors.main
+      color: colors.main,
     }));
     return {
       ...data,
-      rankedData: rankedList
+      rankedData: rankedList,
     };
   }
 );
@@ -43,19 +43,23 @@ export const parseSentence = createSelector(
       endYear,
       commodity: `${locationName} ${commodity.toLowerCase()}`,
       source: topLocation.label,
-      volume: formatNumber({ num: topLocation.volume, unit: 't' }),
+      volume: formatNumber({
+        num: topLocation.volume,
+        unit: 't',
+        spaceUnit: true,
+      }),
       percentage: formatNumber({ num: topLocation.percentage, unit: '%' }),
-      location: locationName
+      location: locationName,
     };
 
     return {
       sentence,
-      params
+      params,
     };
   }
 );
 
 export default createStructuredSelector({
   data: parseData,
-  sentence: parseSentence
+  sentence: parseSentence,
 });

--- a/providers/geodescriber-provider/selectors.js
+++ b/providers/geodescriber-provider/selectors.js
@@ -141,6 +141,8 @@ export const getGeodescriberDescription = createSelector(
     getAdminDescription,
   ],
   (geodescriber, location, wdpaLocation, adminSentence) => {
+    const { description, description_params } = geodescriber;
+
     if (isEmpty(geodescriber)) return null;
     if (location.type === 'wdpa' && wdpaLocation) {
       const status = wdpaLocation?.status;
@@ -160,9 +162,18 @@ export const getGeodescriberDescription = createSelector(
     }
     // if not an admin we can use geodescriber
     if (!['global', 'country'].includes(location.type)) {
+      // adding space between number and unit
+      const areaFormatted = description_params?.area_0.replace(
+        /([\d|.|,]+)/,
+        '$1 '
+      );
+
       return {
-        sentence: geodescriber.description,
-        params: geodescriber.description_params,
+        sentence: description,
+        params: {
+          ...description_params,
+          area_0: areaFormatted,
+        },
       };
     }
 

--- a/services/sentences.js
+++ b/services/sentences.js
@@ -1,5 +1,5 @@
 import { all, spread } from 'axios';
-import { format } from 'd3-format';
+import { formatNumber } from 'utils/format';
 
 import sortBy from 'lodash/sortBy';
 import groupBy from 'lodash/groupBy';
@@ -35,8 +35,7 @@ export const adminSentences = {
   withPlantationLoss:
     'In 2010, {location} had {naturalForest} of natural forest, extending over {percentage} of its land area. In {year}, it lost {naturalLoss} of natural forest',
   countrySpecific: {
-    IDN:
-      'In 2001, {location} had {primaryForest} of primary forest*, extending over {percentagePrimaryForest} of its land area. In {year}, it lost {primaryLoss} of primary forest*, equivalent to {emissionsPrimary} of CO₂ emissions.',
+    IDN: 'In 2001, {location} had {primaryForest} of primary forest*, extending over {percentagePrimaryForest} of its land area. In {year}, it lost {primaryLoss} of primary forest*, equivalent to {emissionsPrimary} of CO₂ emissions.',
   },
   co2Emissions: ', equivalent to {emissions} of CO\u2082 emissions.',
   end: '.',
@@ -190,52 +189,94 @@ export const parseSentence = (
   const { area: areaPlantations, emissions: emissionsPlantations } =
     plantationsLoss || {};
   const { area: areaPrimary, emissions: emissionsPrimary } = primaryLoss || {};
+  const extentSubtractByPlantationsExtent = extent - plantationsExtent;
 
-  const extentFormatted =
-    extent < 1 ? format('.3r')(extent) : format('.3s')(extent);
-  const naturalForest =
-    extent - plantationsExtent < 1
-      ? format('.3r')(extent - plantationsExtent)
-      : format('.3s')(extent - plantationsExtent);
-  const primaryForest =
-    primaryExtent < 1
-      ? format('.3r')(primaryExtent)
-      : format('.3s')(primaryExtent);
+  const extentFormatted = formatNumber({
+    num: extent,
+    unit: 'ha',
+    spaceUnit: true,
+  });
+
+  const naturalForest = formatNumber({
+    num: extentSubtractByPlantationsExtent,
+    unit: 'ha',
+    spaceUnit: true,
+  });
+
+  const primaryForest = formatNumber({
+    num: primaryExtent,
+    unit: 'ha',
+    spaceUnit: true,
+  });
+
   const percentageCover =
-    extent && totalArea ? format('.2r')((extent / totalArea) * 100) : 0;
-  const percentageNatForest = format('.2r')(
-    ((extent - plantationsExtent) / totalArea) * 100
-  );
-  const percentagePrimaryForest = format('.2r')(
-    (primaryExtent / totalArea) * 100
-  );
-  const naturalLoss = format('.3s')((area || 0) - (areaPlantations || 0));
-  const emissionsNaturalForest = format('.3s')(
-    (emissions || 0) - (emissionsPlantations || 0)
-  );
-  const emissionsFormatted = format('.3s')(emissions);
-  const emissionsPrimaryFormatted = format('.3s')(emissionsPrimary || 0);
-  const primaryLossFormatted = format('.3s')(areaPrimary || 0);
-  const loss = format('.3s')(area || 0);
+    extent && totalArea
+      ? formatNumber({ num: (extent / totalArea) * 100, unit: '%' })
+      : 0;
+
+  const percentageNatForest = formatNumber({
+    num: ((extent - plantationsExtent) / totalArea) * 100,
+    unit: '%',
+  });
+
+  const percentagePrimaryForest = formatNumber({
+    num: (primaryExtent / totalArea) * 100,
+    unit: '%',
+  });
+
+  const naturalLoss = formatNumber({
+    num: (area || 0) - (areaPlantations || 0),
+    unit: 'ha',
+    spaceUnit: true,
+  });
+
+  const emissionsNaturalForest = formatNumber({
+    num: (emissions || 0) - (emissionsPlantations || 0),
+    unit: 't',
+    spaceUnit: true,
+  });
+
+  const emissionsFormatted = formatNumber({
+    num: emissions,
+    unit: 't',
+    spaceUnit: true,
+  });
+  const emissionsPrimaryFormatted = formatNumber({
+    num: emissionsPrimary || 0,
+    unit: 't',
+    spaceUnit: true,
+  });
+
+  const primaryLossFormatted = formatNumber({
+    num: areaPrimary || 0,
+    unit: 'ha',
+    spaceUnit: true,
+  });
+
+  const loss = formatNumber({
+    num: area || 0,
+    unit: 'ha',
+    spaceUnit: true,
+  });
   const location = locationNames && locationNames.label;
   const { adm0 } = locationObj || {};
 
   const params = {
-    extent: `${extentFormatted}ha`,
-    naturalForest: `${naturalForest}ha`,
-    primaryForest: `${primaryForest}ha`,
+    extent: `${extentFormatted}`,
+    naturalForest: `${naturalForest}`,
+    primaryForest: `${primaryForest}`,
     location: location || 'the world',
-    percentage: `${percentageCover}%`,
-    percentageNatForest: `${percentageNatForest}%`,
-    percentagePrimaryForest: `${percentagePrimaryForest}%`,
-    loss: `${loss}ha`,
-    emissions: `${emissionsNaturalForest}t`,
-    emissionsTreeCover: `${emissionsFormatted}t`,
-    emissionsPrimary: `${emissionsPrimaryFormatted}t`,
+    percentage: `${percentageCover}`,
+    percentageNatForest: `${percentageNatForest}`,
+    percentagePrimaryForest: `${percentagePrimaryForest}`,
+    loss: `${loss}`,
+    emissions: `${emissionsNaturalForest}`,
+    emissionsTreeCover: `${emissionsFormatted}`,
+    emissionsPrimary: `${emissionsPrimaryFormatted}`,
     year,
-    treeCoverLoss: `${loss}ha`,
-    primaryLoss: `${primaryLossFormatted}ha`,
-    naturalLoss: `${naturalLoss}ha`,
+    treeCoverLoss: `${loss}`,
+    primaryLoss: `${primaryLossFormatted}`,
+    naturalLoss: `${naturalLoss}`,
   };
 
   let sentence = adminSentences.default;

--- a/utils/format.js
+++ b/utils/format.js
@@ -69,11 +69,7 @@ export const formatNumber = (args) => {
     formattedNumber = String(formattedNumber).replace(/([\d|.|,]+)/, '$1 ');
   }
 
-<<<<<<< HEAD
-  return `${formattedNum}${
-=======
   return `${formattedNumber}${
->>>>>>> fdf4c331fc (chore(format-number): refactor formatNumber method to improve readability and maintainability)
     returnUnit && unit && unit !== 'counts' && unit !== 'countsK' ? unit : ''
   }`;
 };

--- a/utils/format.js
+++ b/utils/format.js
@@ -35,6 +35,10 @@ const formatWithProperSpecifier = ({
     return format(specialSpecifier)(num);
   }
 
+  if (unit === 'tCO2') {
+    return format('.3s')(num);
+  }
+
   if (num < threshold && num > 0) {
     return `< ${threshold}`;
   }
@@ -59,9 +63,12 @@ export const formatNumber = (args) => {
 
   if (unit === '') return format('.2f')(num);
   if (unit === ',') return format(',')(num);
-  if (unit === 'tCO2') return `${format('.3s')(num)}tCO\u2082e`;
 
   let formattedNumber = formatWithProperSpecifier(args);
+
+  if (unit === 'tCO2') {
+    formattedNumber = `${formattedNumber}tCO\u2082e`;
+  }
 
   if (spaceUnit) {
     // Capture group until first occurrence of a non digit or dot or comma.
@@ -70,6 +77,12 @@ export const formatNumber = (args) => {
   }
 
   return `${formattedNumber}${
-    returnUnit && unit && unit !== 'counts' && unit !== 'countsK' ? unit : ''
+    returnUnit &&
+    unit &&
+    unit !== 'counts' &&
+    unit !== 'tCO2' &&
+    unit !== 'countsK'
+      ? unit
+      : ''
   }`;
 };


### PR DESCRIPTION
## Overview

There are spaces after numbers or before units (which means hectare amount) of measurement all across the website, starting with the dashboards.

The solution is in place going forward - this means that all numbers will have a space before its relevant unit. Widgets will be set up with spaces between numbers/units going forward. 

Add a warning in Notion to ensure devs add a space between numbers/units

## Demo
<img width="761" alt="Screenshot 2023-06-29 at 16 32 53" src="https://github.com/wri/gfw/assets/23243868/e4f629cf-acde-4d0a-9974-bebfe74487f7">


## Notes

Just the widgets in Dashboard page were changed so far.

## Testing

- Open the [Dashboard](https://gfw-staging-pr-4585.herokuapp.com/dashboards/country/BRA/?category=summary)
- Look into every widget in every tab (Summary, Land Use, Forest Change, etc)
- Every single widget should have numbers separated from its unit (it doesn't apply to % unit)

