### PR TITLE
[FLAG-692] Remove IFL 2016 from rankedForestTypes

### DIFF
--- a/components/widgets/land-cover/ranked-forest-types/index.js
+++ b/components/widgets/land-cover/ranked-forest-types/index.js
@@ -64,7 +64,6 @@ export default {
   settings: {
     decile: 30,
     extentYear: 2020,
-    ifl: 2016,
   },
   getData: (params) => {
     return getTreeCoverByLandCoverClass(params);


### PR DESCRIPTION
## Overview

For some reason when we add ifl 2016 the extent year changes to 2010 we dont need ifl 2016 for this widget

## Demo

<img width="752" alt="Screenshot 2023-06-23 at 15 28 35" src="https://github.com/wri/gfw/assets/23243868/8c2778c2-d95f-47af-87ad-f13a5b7902f8">


