### PR TITLE
Widgets priority 3 and 5 should show in analysis

### DIFF
--- a/components/widget/component.jsx
+++ b/components/widget/component.jsx
@@ -19,6 +19,7 @@ class Widget extends PureComponent {
     filterSelected: PropTypes.bool,
     maxSize: PropTypes.number,
     embed: PropTypes.bool,
+    analysis: PropTypes.bool,
     large: PropTypes.bool,
     autoHeight: PropTypes.bool,
     colors: PropTypes.object,
@@ -91,6 +92,7 @@ class Widget extends PureComponent {
       large,
       autoHeight,
       embed,
+      analysis,
       simple,
       datasets,
       settings,
@@ -203,6 +205,7 @@ class Widget extends PureComponent {
           large={large}
           autoHeight={autoHeight}
           embed={embed}
+          analysis={analysis}
           location={location}
           locationName={locationLabelFull}
           active={active}

--- a/components/widget/components/widget-info-list/component.jsx
+++ b/components/widget/components/widget-info-list/component.jsx
@@ -20,7 +20,7 @@ const ICONS = {
   ipccOther: ipccOtherIcon,
 };
 
-export const WidgetInfoList = ({ data, large, embed }) => {
+export const WidgetInfoList = ({ data, large, embed, analysis }) => {
   if (!data) return null;
 
   const containsIcons =
@@ -29,8 +29,8 @@ export const WidgetInfoList = ({ data, large, embed }) => {
   return (
     <div
       className={cx('c-info-list-widget', {
-        '-large': large || embed,
-        '-small': !large && !embed,
+        '-large': (large || embed) && !analysis,
+        '-small': (!large && !embed) || analysis,
         '-center-items': !containsIcons,
       })}
     >
@@ -70,6 +70,7 @@ WidgetInfoList.propTypes = {
   ),
   large: PropTypes.bool,
   embed: PropTypes.bool,
+  analysis: PropTypes.bool,
 };
 
 export default WidgetInfoList;

--- a/components/widgets/component.jsx
+++ b/components/widgets/component.jsx
@@ -33,6 +33,7 @@ class Widgets extends PureComponent {
     handleClickWidget: PropTypes.func.isRequired,
     embed: PropTypes.bool,
     dashboard: PropTypes.bool,
+    analysis: PropTypes.bool,
     groupBySubcategory: PropTypes.bool,
     modalClosing: PropTypes.bool,
     activeWidget: PropTypes.object,
@@ -61,6 +62,7 @@ class Widgets extends PureComponent {
       groupBySubcategory = false,
       embed,
       dashboard,
+      analysis,
       simple,
       modalClosing,
       noDataMessage,
@@ -114,6 +116,7 @@ class Widgets extends PureComponent {
                     active={activeWidget && activeWidget.widget === w.widget}
                     embed={embed}
                     dashboard={dashboard}
+                    analysis={analysis}
                     simple={simple}
                     location={location}
                     geostore={geostore}

--- a/components/widgets/land-cover/ranked-forest-types/index.js
+++ b/components/widgets/land-cover/ranked-forest-types/index.js
@@ -57,7 +57,7 @@ export default {
       layers: [TROPICAL_TREE_COVER_HECTARE],
     },
   ],
-  visible: ['dashboard'],
+  visible: ['dashboard', 'analysis'],
   sortOrder: {
     landCover: 2,
   },

--- a/components/widgets/land-cover/tree-cover-density/index.js
+++ b/components/widgets/land-cover/tree-cover-density/index.js
@@ -19,7 +19,7 @@ export default {
   types: ['country', 'wdpa', 'aoi'],
   admins: ['adm0', 'adm1', 'adm2'],
   large: true,
-  visible: ['dashboard'],
+  visible: ['dashboard', 'analysis'],
   chartType: 'composedChart',
   colors: 'density',
   settingsConfig: [

--- a/components/widgets/land-cover/tree-cover/index.js
+++ b/components/widgets/land-cover/tree-cover/index.js
@@ -13,7 +13,7 @@ import {
   POLITICAL_BOUNDARIES,
   FOREST_EXTENT,
   TREE_COVER,
-  TROPICAL_TREE_COVER_METERS,
+  TROPICAL_TREE_COVER_HECTARE,
 } from 'data/layers';
 
 import getWidgetProps from './selectors';
@@ -119,7 +119,7 @@ export default {
         2000: FOREST_EXTENT_DATASET,
       },
       layers: {
-        2020: TROPICAL_TREE_COVER_METERS,
+        2020: TROPICAL_TREE_COVER_HECTARE,
         2010: FOREST_EXTENT,
         2000: TREE_COVER,
       },


### PR DESCRIPTION
## Overview

- Switch treeCover widget from meters to hectare
  - Undetected issue
- Show treeCoverDensity widget in analysis
- Show rankedForestTypes widget in analysis
  - Widget body now has a propType set to true if the widget is being shown in analysis  
  - `WidgetInfoList` "chart" type can now display correctly in analysis  