### PR TITLE
[FLAG-845] adding whitelists with tropicalIsos in primary forest loss widget

### DIFF
--- a/components/widgets/forest-change/tree-loss-primary/index.js
+++ b/components/widgets/forest-change/tree-loss-primary/index.js
@@ -1,6 +1,8 @@
 import { all, spread } from 'axios';
 import compact from 'lodash/compact';
 
+import tropicalIsos from 'data/tropical-isos.json';
+
 import { getExtent, getLoss } from 'services/analysis-cached';
 import { getYearsRangeFromMinMax } from 'components/widgets/utils/data';
 
@@ -109,6 +111,9 @@ export default {
     threshold: 30,
     extentYear: 2000,
     forestType: 'primary_forest',
+  },
+  whitelists: {
+    adm0: [tropicalIsos],
   },
   placeholderImageURL: indonesiaPlaceholder,
   getData: (params = {}) => {


### PR DESCRIPTION
## Overview

Primary forest loss widget is showing up on the dashboard (with no data) outside the tropics - e.g. [Romania Deforestation Rates & Statistics | GFW](https://www.globalforestwatch.org/dashboards/country/ROU/) 

This widget should not appear on the dashboard of countries outside the tropics.

## Demo
### Before
![Screenshot 2023-07-05 at 16 57 45](https://github.com/wri/gfw/assets/23243868/d11a41df-be30-43c5-8945-e566d2a156b3)

### After
![Screenshot 2023-07-05 at 16 57 51](https://github.com/wri/gfw/assets/23243868/7705d03c-da4c-455a-9b2d-e47f08d16c56)

## Notes

We have removed whitelist from Primary Forest Loss to fix an [AOI error](https://gfw.global/3NDPD2L). Indeed we made the right choice since the whitelist was wrongly configured, however, this widget needs tropicalIsos as whitelist. 
Reference: https://github.com/wri/gfw/pull/4539

## Testing

- Open the dashboard
- Select Romania or any country outside the tropic
- Verify if Primary Forest Loss widget is hidden.

