### PR TITLE
[FLAG-487/840] Move download button and remove open map 

### DIFF
--- a/layouts/dashboards/components/header/component.jsx
+++ b/layouts/dashboards/components/header/component.jsx
@@ -146,6 +146,7 @@ class Header extends PureComponent {
       setShareModal,
       shareData,
       location: runtimeLocation,
+      locationNames,
       handleSSRLocation,
       forestAtlasLink,
       globalSentence,
@@ -235,11 +236,11 @@ class Header extends PureComponent {
                   extLink={this.props.downloadLink}
                   tooltip={{
                     text: `Download the data${
-                      this.props.locationNames.adm0
+                      locationNames.adm0
                         ? ` for ${
-                            this.locationNames &&
-                            this.props.locationNames.adm0 &&
-                            this.props.locationNames.adm0.label
+                            locationNames &&
+                            locationNames.adm0 &&
+                            locationNames.adm0.label
                           }`
                         : ''
                     }`,
@@ -250,9 +251,9 @@ class Header extends PureComponent {
                       category: 'Dashboards page',
                       action: 'Download page',
                       label:
-                        (this.props.locationNames &&
-                          this.props.locationNames.adm0 &&
-                          this.props.locationNames.adm0.label) ||
+                        (locationNames &&
+                          locationNames.adm0 &&
+                          locationNames.adm0.label) ||
                         'Global',
                     });
                   }}

--- a/layouts/dashboards/components/header/component.jsx
+++ b/layouts/dashboards/components/header/component.jsx
@@ -15,7 +15,6 @@ import AreaOfInterestModal from 'components/modals/area-of-interest';
 
 import editIcon from 'assets/icons/edit.svg?sprite';
 import hiddenIcon from 'assets/icons/hidden.svg?sprite';
-import dashboardIcon from 'assets/icons/dashboard.svg?sprite';
 import tagIcon from 'assets/icons/tag.svg?sprite';
 import downloadIcon from 'assets/icons/download.svg?sprite';
 import saveUserIcon from 'assets/icons/save-user.svg?sprite';
@@ -65,19 +64,6 @@ class Header extends PureComponent {
         onChange={this.handleAreaActions}
         theme={cx('theme-button-medium theme-dropdown-no-border small square')}
         options={[
-          {
-            value: 'open_map',
-            component: (
-              <Button
-                id="button-open-map"
-                theme={btnTheme}
-                link={activeArea && `/map/aoi/${activeArea.id}`}
-              >
-                <Icon icon={dashboardIcon} />
-                Open Map
-              </Button>
-            ),
-          },
           activeArea &&
             activeArea.userArea && {
               value: 'edit_area',

--- a/layouts/dashboards/components/header/component.jsx
+++ b/layouts/dashboards/components/header/component.jsx
@@ -259,7 +259,6 @@ class Header extends PureComponent {
                   }}
                 >
                   <Icon icon={downloadIcon} />
-                  Download data
                 </Button>
               )}
 

--- a/layouts/dashboards/components/header/component.jsx
+++ b/layouts/dashboards/components/header/component.jsx
@@ -47,9 +47,8 @@ class Header extends PureComponent {
     firstArea: PropTypes.object,
   };
 
-  renderAreaActions({ isCountryDashboard, isAreaAndCountryDashboard }) {
+  renderAreaActions() {
     const {
-      downloadLink,
       locationNames,
       setAreaOfInterestModalSettings,
       activeArea,
@@ -115,42 +114,6 @@ class Header extends PureComponent {
               >
                 <Icon icon={saveUserIcon} />
                 Save area
-              </Button>
-            ),
-          },
-          (isCountryDashboard || isAreaAndCountryDashboard) && {
-            value: 'download_data',
-            component: (
-              <Button
-                id="button-download-data"
-                theme={btnTheme}
-                extLink={downloadLink}
-                tooltip={{
-                  text: `Download the data${
-                    locationNames.adm0
-                      ? ` for ${
-                          locationNames &&
-                          locationNames.adm0 &&
-                          locationNames.adm0.label
-                        }`
-                      : ''
-                  }`,
-                  position: 'bottom',
-                }}
-                onClick={() => {
-                  trackEvent({
-                    category: 'Dashboards page',
-                    action: 'Download page',
-                    label:
-                      (locationNames &&
-                        locationNames.adm0 &&
-                        locationNames.adm0.label) ||
-                      'Global',
-                  });
-                }}
-              >
-                <Icon icon={downloadIcon} />
-                Download data
               </Button>
             ),
           },
@@ -278,10 +241,42 @@ class Header extends PureComponent {
               >
                 {shareMeta}
               </Button>
-              {this.renderAreaActions({
-                isCountryDashboard,
-                isAreaAndCountryDashboard,
-              })}
+
+              {(isCountryDashboard || isAreaAndCountryDashboard) && (
+                <Button
+                  id="button-download-data"
+                  theme="theme-button-small"
+                  extLink={this.props.downloadLink}
+                  tooltip={{
+                    text: `Download the data${
+                      this.props.locationNames.adm0
+                        ? ` for ${
+                            this.locationNames &&
+                            this.props.locationNames.adm0 &&
+                            this.props.locationNames.adm0.label
+                          }`
+                        : ''
+                    }`,
+                    position: 'bottom',
+                  }}
+                  onClick={() => {
+                    trackEvent({
+                      category: 'Dashboards page',
+                      action: 'Download page',
+                      label:
+                        (this.props.locationNames &&
+                          this.props.locationNames.adm0 &&
+                          this.props.locationNames.adm0.label) ||
+                        'Global',
+                    });
+                  }}
+                >
+                  <Icon icon={downloadIcon} />
+                  Download data
+                </Button>
+              )}
+
+              {this.renderAreaActions()}
             </div>
           </div>
         )}

--- a/layouts/dashboards/components/header/component.jsx
+++ b/layouts/dashboards/components/header/component.jsx
@@ -262,7 +262,8 @@ class Header extends PureComponent {
                 </Button>
               )}
 
-              {this.renderAreaActions()}
+              {(activeArea || runtimeLocation?.type === 'country') &&
+                this.renderAreaActions()}
             </div>
           </div>
         )}

--- a/layouts/dashboards/components/header/styles.scss
+++ b/layouts/dashboards/components/header/styles.scss
@@ -212,6 +212,9 @@
 
     svg {
       margin-right: 0.3125rem;
+      margin-top: 0;
+      width: 1.0625rem;
+      height: 1.0625rem;
     }
   }
 }

--- a/layouts/dashboards/components/header/styles.scss
+++ b/layouts/dashboards/components/header/styles.scss
@@ -209,5 +209,9 @@
   #button-download-data {
     color: #fff;
     background-color: transparent;
+
+    svg {
+      margin-right: 0.3125rem;
+    }
   }
 }

--- a/layouts/dashboards/components/header/styles.scss
+++ b/layouts/dashboards/components/header/styles.scss
@@ -205,4 +205,9 @@
     margin-bottom: rem(20px);
     max-width: rem(200px);
   }
+
+  #button-download-data {
+    color: #fff;
+    background-color: transparent;
+  }
 }


### PR DESCRIPTION
## Overview

Currently, the download button is hidden behind the three dots on the dashboards (in areas dashboard and global dashboard). We are moving this button outside the dropdown.

The open Map button circled in the screenshot below doesn’t work in the [global](https://www.globalforestwatch.org/dashboards/global/?category=summary&location=WyJnbG9iYWwiXQ%3D%3D&map=eyJkYXRhc2V0cyI6W3sib3BhY2l0eSI6MC43LCJ2aXNpYmlsaXR5Ijp0cnVlLCJkYXRhc2V0IjoicHJpbWFyeS1mb3Jlc3RzIiwibGF5ZXJzIjpbInByaW1hcnktZm9yZXN0cy0yMDAxIl19LHsiZGF0YXNldCI6InBvbGl0aWNhbC1ib3VuZGFyaWVzIiwibGF5ZXJzIjpbImRpc3B1dGVkLXBvbGl0aWNhbC1ib3VuZGFyaWVzIiwicG9saXRpY2FsLWJvdW5kYXJpZXMiXSwiYm91bmRhcnkiOnRydWUsIm9wYWNpdHkiOjEsInZpc2liaWxpdHkiOnRydWV9LHsiZGF0YXNldCI6InRyZWUtY292ZXItbG9zcyIsImxheWVycyI6WyJ0cmVlLWNvdmVyLWxvc3MiXSwib3BhY2l0eSI6MSwidmlzaWJpbGl0eSI6dHJ1ZSwidGltZWxpbmVQYXJhbXMiOnsic3RhcnREYXRlIjoiMjAwMi0wMS0wMSIsImVuZERhdGUiOiIyMDIyLTEyLTMxIiwidHJpbUVuZERhdGUiOiIyMDIyLTEyLTMxIn0sInBhcmFtcyI6eyJ0aHJlc2hvbGQiOjMwLCJ2aXNpYmlsaXR5Ijp0cnVlLCJhZG1fbGV2ZWwiOiJhZG0wIn19XX0%3D&showMap=true), [country](https://www.globalforestwatch.org/dashboards/country/AFG/?category=summary&location=WyJjb3VudHJ5IiwiQUZHIl0%3D&map=eyJjZW50ZXIiOnsibGF0IjozNi45ODM4NzY4NjM0MDQzMSwibG5nIjo3Mi40Mjc4MDAwMDAwMzk0MX0sInpvb20iOjUuNzE2OTgxODAyOTc4Njg3LCJjYW5Cb3VuZCI6ZmFsc2UsImRhdGFzZXRzIjpbeyJvcGFjaXR5IjowLjcsInZpc2liaWxpdHkiOnRydWUsImRhdGFzZXQiOiJwcmltYXJ5LWZvcmVzdHMiLCJsYXllcnMiOlsicHJpbWFyeS1mb3Jlc3RzLTIwMDEiXX0seyJkYXRhc2V0IjoicG9saXRpY2FsLWJvdW5kYXJpZXMiLCJsYXllcnMiOlsiZGlzcHV0ZWQtcG9saXRpY2FsLWJvdW5kYXJpZXMiLCJwb2xpdGljYWwtYm91bmRhcmllcyJdLCJib3VuZGFyeSI6dHJ1ZSwib3BhY2l0eSI6MSwidmlzaWJpbGl0eSI6dHJ1ZX0seyJkYXRhc2V0IjoidHJlZS1jb3Zlci1sb3NzIiwibGF5ZXJzIjpbInRyZWUtY292ZXItbG9zcyJdLCJvcGFjaXR5IjoxLCJ2aXNpYmlsaXR5Ijp0cnVlLCJ0aW1lbGluZVBhcmFtcyI6eyJzdGFydERhdGUiOiIyMDAyLTAxLTAxIiwiZW5kRGF0ZSI6IjIwMjItMTItMzEiLCJ0cmltRW5kRGF0ZSI6IjIwMjItMTItMzEifSwicGFyYW1zIjp7InRocmVzaG9sZCI6MzAsInZpc2liaWxpdHkiOnRydWUsImFkbV9sZXZlbCI6ImFkbTAifX1dfQ%3D%3D&showMap=true), [region](https://www.globalforestwatch.org/dashboards/country/AFG/1/?category=summary&location=WyJjb3VudHJ5IiwiQUZHIiwiMSJd&map=eyJjZW50ZXIiOnsibGF0IjozNi45ODM4NzY4NjM0MDQzMSwibG5nIjo3Mi40Mjc4MDAwMDAwMzk0MX0sInpvb20iOjUuNzE2OTgxODAyOTc4Njg3LCJjYW5Cb3VuZCI6ZmFsc2UsImRhdGFzZXRzIjpbeyJvcGFjaXR5IjowLjcsInZpc2liaWxpdHkiOnRydWUsImRhdGFzZXQiOiJwcmltYXJ5LWZvcmVzdHMiLCJsYXllcnMiOlsicHJpbWFyeS1mb3Jlc3RzLTIwMDEiXX0seyJkYXRhc2V0IjoicG9saXRpY2FsLWJvdW5kYXJpZXMiLCJsYXllcnMiOlsiZGlzcHV0ZWQtcG9saXRpY2FsLWJvdW5kYXJpZXMiLCJwb2xpdGljYWwtYm91bmRhcmllcyJdLCJib3VuZGFyeSI6dHJ1ZSwib3BhY2l0eSI6MSwidmlzaWJpbGl0eSI6dHJ1ZX0seyJkYXRhc2V0IjoidHJlZS1jb3Zlci1sb3NzIiwibGF5ZXJzIjpbInRyZWUtY292ZXItbG9zcyJdLCJvcGFjaXR5IjoxLCJ2aXNpYmlsaXR5Ijp0cnVlLCJ0aW1lbGluZVBhcmFtcyI6eyJzdGFydERhdGUiOiIyMDAyLTAxLTAxIiwiZW5kRGF0ZSI6IjIwMjItMTItMzEiLCJ0cmltRW5kRGF0ZSI6IjIwMjItMTItMzEifSwicGFyYW1zIjp7InRocmVzaG9sZCI6MzAsInZpc2liaWxpdHkiOnRydWUsImFkbV9sZXZlbCI6ImFkbTEifX1dfQ%3D%3D&showMap=true), and [subregion](https://www.globalforestwatch.org/dashboards/country/AFG/1/1/?category=summary&location=WyJjb3VudHJ5IiwiQUZHIiwiMSIsIjEiXQ%3D%3D&map=eyJjZW50ZXIiOnsibGF0IjozNi45NDIzOTY0MDYxODQ2NCwibG5nIjo3MS4wNjE5Mjc3OTU0NDY2Nn0sInpvb20iOjguMjQwNzYzMzE2MTYxNDI3LCJjYW5Cb3VuZCI6ZmFsc2UsImRhdGFzZXRzIjpbeyJvcGFjaXR5IjowLjcsInZpc2liaWxpdHkiOnRydWUsImRhdGFzZXQiOiJwcmltYXJ5LWZvcmVzdHMiLCJsYXllcnMiOlsicHJpbWFyeS1mb3Jlc3RzLTIwMDEiXX0seyJkYXRhc2V0IjoicG9saXRpY2FsLWJvdW5kYXJpZXMiLCJsYXllcnMiOlsiZGlzcHV0ZWQtcG9saXRpY2FsLWJvdW5kYXJpZXMiLCJwb2xpdGljYWwtYm91bmRhcmllcyJdLCJib3VuZGFyeSI6dHJ1ZSwib3BhY2l0eSI6MSwidmlzaWJpbGl0eSI6dHJ1ZX0seyJkYXRhc2V0IjoidHJlZS1jb3Zlci1sb3NzIiwibGF5ZXJzIjpbInRyZWUtY292ZXItbG9zcyJdLCJvcGFjaXR5IjoxLCJ2aXNpYmlsaXR5Ijp0cnVlLCJ0aW1lbGluZVBhcmFtcyI6eyJzdGFydERhdGUiOiIyMDAyLTAxLTAxIiwiZW5kRGF0ZSI6IjIwMjItMTItMzEiLCJ0cmltRW5kRGF0ZSI6IjIwMjItMTItMzEifSwicGFyYW1zIjp7InRocmVzaG9sZCI6MzAsInZpc2liaWxpdHkiOnRydWUsImFkbV9sZXZlbCI6ImFkbTIifX1dfQ%3D%3D&showMap=true) dashboards. It’s also redundant with (and has a different icon than) the green open map button that’s featured on the right of the page.

## Demo

![Screenshot 2023-08-01 at 15 05 23](https://github.com/wri/gfw/assets/23243868/86b5d499-8332-44fc-92ba-f2e41fe5eabe)


## Testing

- [Open the dashboard ](https://gfw.global/44OWgqv) and select a country/region/subregion.
- Check if you see the download button outside the dropdown.
- Check if the open map button doesn't appear inside the dropdown.

