### PR TITLE
FLAG-842: Add layer id to top level components

### DIFF
--- a/components/legend/components/legend-list-item/index.js
+++ b/components/legend/components/legend-list-item/index.js
@@ -14,6 +14,7 @@ class LegendListItem extends PureComponent {
     children: PropTypes.node,
     toolbar: PropTypes.node,
     title: PropTypes.node,
+    layerId: PropTypes.string,
   };
 
   static defaultProps = {
@@ -26,14 +27,17 @@ class LegendListItem extends PureComponent {
   };
 
   render() {
-    const { layers, sortable, children, toolbar, title, ...props } = this.props;
+    const { layers, sortable, children, toolbar, title, layerId, ...props } =
+      this.props;
     const activeLayer = layers.find((l) => l.active) || layers[0];
 
     return (
       <li
+        data-layer-id={layerId}
         className={classnames({
           'c-legend-item': true,
           '-sortable': sortable,
+          'map-widget': true,
         })}
       >
         <div

--- a/components/map/components/legend/component.jsx
+++ b/components/map/components/legend/component.jsx
@@ -2,19 +2,19 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
-import Icons from 'components/icons'
-import Legend, { 
-  LegendItemToolbar, 
-  LegendItemButtonOpacity, 
+import Icons from 'components/icons';
+import Legend, {
+  LegendItemToolbar,
+  LegendItemButtonOpacity,
   LegendListItem,
   LegendItemButtonInfo,
   LegendItemButtonRemove,
-} from 'components/legend'
+} from 'components/legend';
 
-import LegendItemTypes, { 
+import LegendItemTypes, {
   LegendItemTypeBasic,
-  LegendItemTypeProportional
-} from 'components/legend/components/legend-item-types'
+  LegendItemTypeProportional,
+} from 'components/legend/components/legend-item-types';
 
 import Loader from 'components/ui/loader';
 import NoContent from 'components/ui/no-content';
@@ -115,6 +115,7 @@ const MapLegend = ({
                 index={i}
                 key={id}
                 layerGroup={lg}
+                layerId={id}
                 toolbar={(
                   <LegendItemToolbar
                     {...rest}

--- a/components/map/components/legend/components/layer-toggle/component.jsx
+++ b/components/map/components/legend/components/layer-toggle/component.jsx
@@ -39,7 +39,10 @@ class LayerToggle extends PureComponent {
 
     return (
       <div
-        className={`c-layer-toggle ${small ? '-small' : ''} ${className || ''}`}
+        className={`c-layer-toggle ${small ? '-small' : ''} ${
+          className || ''
+        } layer-picker`}
+        data-layer-id={layer}
       >
         <Toggle
           layer={layer}

--- a/components/widget/component.jsx
+++ b/components/widget/component.jsx
@@ -154,7 +154,13 @@ class Widget extends PureComponent {
       <div
         ref={this.props.forwardRef}
         id={widget}
-        className={cx('c-widget', { large }, { embed }, { simple })}
+        className={cx(
+          'c-widget',
+          { large },
+          { embed },
+          { simple },
+          { 'dashboard-widget': true }
+        )}
         style={{
           ...(active &&
             !simple &&


### PR DESCRIPTION
## Overview

Adding layer id to top level components for GA4 / GTM tracking purposes.


<img width="1840" alt="Screenshot 2023-08-01 at 3 48 23 p m" src="https://github.com/wri/gfw/assets/127868788/0147e5c5-3652-4b2e-888b-6efb1c25a174">
<img width="1840" alt="Screenshot 2023-08-01 at 3 48 46 p m" src="https://github.com/wri/gfw/assets/127868788/0ce61127-04ef-4a6c-bf64-e59c87a6c397">
<img width="1840" alt="Screenshot 2023-08-01 at 3 48 57 p m" src="https://github.com/wri/gfw/assets/127868788/73e29b09-9be2-45f2-9265-85e96159246e">



## Demo

If applicable: screenshots, gifs, etc.

## Notes

If applicable: ancilary topics, caveats, alternative strategies that didn't work out, etc.

## Testing

- Include any steps to verify the features this PR introduces.
- If this fixes a bug, include bug reproduction steps.

