### PR TITLE
FLAG-894: page reload with incorrect query params

### DIFF
--- a/pages/dashboards/[[...location]].js
+++ b/pages/dashboards/[[...location]].js
@@ -22,8 +22,6 @@ import {
 import PageLayout from 'wrappers/page';
 import Dashboards from 'layouts/dashboards';
 
-import DashboardsUrlProvider from 'providers/dashboards-url-provider';
-
 import { setCountriesSSR } from 'providers/country-data-provider/actions';
 
 import {
@@ -58,8 +56,9 @@ const isServer = typeof window === 'undefined';
 function getLabel(location, countryData) {
   let country;
   if (location.adm0) {
-    country = countryData?.countries.find((c) => c.value === location.adm0)
-      ?.label;
+    country = countryData?.countries.find(
+      (c) => c.value === location.adm0
+    )?.label;
   }
 
   if (location.adm2) {
@@ -334,7 +333,6 @@ const DashboardsPage = (props) => {
       <Head>
         <link rel="canonical" href={getCanonical(props, query)} />
       </Head>
-      <DashboardsUrlProvider />
       <Dashboards
         basePath={basePath}
         ssrLocation={handleSSRLocation}


### PR DESCRIPTION
## Overview

Fixing issue when trying to paste a url in the browser with query params, the app replaced those query params incorrectly:

original url (it has `category=forest-change`):  
```
https://www.globalforestwatch.org/dashboards/global/?category=forest-change&location=WyJnbG9iYWwiXQ%3D%3D&map=eyJkYXRhc2V0cyI6W3siZGF0YXNldCI6InBvbGl0aWNhbC1ib3VuZGFyaWVzIiwibGF5ZXJzIjpbImRpc3B1dGVkLXBvbGl0aWNhbC1ib3VuZGFyaWVzIiwicG9saXRpY2FsLWJvdW5kYXJpZXMiXSwiYm91bmRhcnkiOnRydWUsIm9wYWNpdHkiOjEsInZpc2liaWxpdHkiOnRydWV9LHsiZGF0YXNldCI6Ik5ldC1DaGFuZ2UtU1RBR0lORyIsImxheWVycyI6WyJmb3Jlc3QtbmV0LWNoYW5nZSJdLCJvcGFjaXR5IjoxLCJ2aXNpYmlsaXR5Ijp0cnVlLCJwYXJhbXMiOnsidmlzaWJpbGl0eSI6dHJ1ZSwiYWRtX2xldmVsIjoiYWRtMCJ9fV19&scrollTo=treeLossPct&showMap=false&treeLossPct=eyJoaWdobGlnaHRlZCI6ZmFsc2V9&widget=treeLossPct
```

server replaces with (it now has `category=summary` which is incorrect):
```
https://www.globalforestwatch.org/dashboards/global/?category=summary&map=eyJkYXRhc2V0cyI6W3sib3BhY2l0eSI6MC43LCJ2aXNpYmlsaXR5Ijp0cnVlLCJkYXRhc2V0IjoicHJpbWFyeS1mb3Jlc3RzIiwibGF5ZXJzIjpbInByaW1hcnktZm9yZXN0cy0yMDAxIl19LHsiZGF0YXNldCI6InBvbGl0aWNhbC1ib3VuZGFyaWVzIiwibGF5ZXJzIjpbImRpc3B1dGVkLXBvbGl0aWNhbC1ib3VuZGFyaWVzIiwicG9saXRpY2FsLWJvdW5kYXJpZXMiXSwiYm91bmRhcnkiOnRydWUsIm9wYWNpdHkiOjEsInZpc2liaWxpdHkiOnRydWV9LHsiZGF0YXNldCI6InRyZWUtY292ZXItbG9zcyIsImxheWVycyI6WyJ0cmVlLWNvdmVyLWxvc3MiXSwib3BhY2l0eSI6MSwidmlzaWJpbGl0eSI6dHJ1ZSwidGltZWxpbmVQYXJhbXMiOnsic3RhcnREYXRlIjoiMjAwMi0wMS0wMSIsImVuZERhdGUiOiIyMDIyLTEyLTMxIiwidHJpbUVuZERhdGUiOiIyMDIyLTEyLTMxIn0sInBhcmFtcyI6eyJ0aHJlc2hvbGQiOjMwLCJ2aXNpYmlsaXR5Ijp0cnVlLCJhZG1fbGV2ZWwiOiJhZG0wIn19XX0%3D&showMap=true&treeLossPct=eyJoaWdobGlnaHRlZCI6ZmFsc2V9&widget=treeLossPct
```

It seems the issue is related to the `shallow` property in the router `replace` function (see: [https://nextjs.org/docs/pages/api-reference/functions/use-router#routerreplace](https://nextjs.org/docs/pages/api-reference/functions/use-router#routerreplace))

## Demo

If applicable: screenshots, gifs, etc.

## Notes

If applicable: ancilary topics, caveats, alternative strategies that didn't work out, etc.

## Testing

- Include any steps to verify the features this PR introduces.
- If this fixes a bug, include bug reproduction steps.

