### PR TITLE
FLAG-876: Fix map legend circles being squished

### DIFF
--- a/components/legend/components/legend-item-types/legend-item-type-basic/legend-item-type-basic-item/index.js
+++ b/components/legend/components/legend-item-types/legend-item-type-basic/legend-item-type-basic-item/index.js
@@ -52,7 +52,12 @@ class LegendItem extends React.PureComponent {
       return (
         <div
           className={`icon-${icon}`}
-          style={{ width: size, height: size, backgroundColor: color }}
+          style={{
+            width: size,
+            height: size,
+            backgroundColor: color,
+            minWidth: size,
+          }}
         />
       );
     }


### PR DESCRIPTION
## Overview

The map legend's colored circles are being squished in some legend items, independently of the layer and/or legend in question. 

It looks like this happens when the text next to the circle is too long, causing the circle's element to get squished. Setting a `minWidth` alongside the `width` seems to fix the issue. 


## Demo

![circles_fixed](https://github.com/wri/gfw/assets/6273795/4383ed3f-8662-4f17-acd2-0e335a3764e9)


## Notes

N/A

## Testing

1. Visit the corresponding [JIRA task](https://gfw.atlassian.net/browse/FLAG-876)  
2. Review that the items/links in the description now work correctly

## Tracking 

https://gfw.atlassian.net/browse/FLAG-876

