### PR TITLE
[FLAG-844] Add tree cover density to analysis

### DIFF
--- a/components/charts/composed-chart/axis-label.jsx
+++ b/components/charts/composed-chart/axis-label.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 
-const AxisLabel = ({ label, direction }) => (
+const AxisLabel = ({ label, direction, isSimple = false }) => (
   <>
     <foreignObject
       width="100%"
@@ -9,7 +10,13 @@ const AxisLabel = ({ label, direction }) => (
       className={`${direction}-label-container`}
     >
       <div className={`${direction}-label`}>
-        <span>{label}</span>
+        <span
+          className={cx({
+            'simple-mode-label': isSimple,
+          })}
+        >
+          {label}
+        </span>
       </div>
     </foreignObject>
   </>
@@ -18,6 +25,7 @@ const AxisLabel = ({ label, direction }) => (
 AxisLabel.propTypes = {
   label: PropTypes.string,
   direction: PropTypes.string,
+  isSimple: PropTypes.bool,
 };
 
 export default AxisLabel;

--- a/components/charts/composed-chart/component.jsx
+++ b/components/charts/composed-chart/component.jsx
@@ -177,6 +177,7 @@ class CustomComposedChart extends PureComponent {
       <div
         className={cx('c-composed-chart', className, {
           'overflow-x-visible': hasLabels,
+          'no-padding': simple,
         })}
         style={{
           height: simple ? 110 : height || 250,
@@ -237,7 +238,13 @@ class CustomComposedChart extends PureComponent {
               interval="preserveStartEnd"
               {...xAxis}
               {...(config?.xAxis?.label && {
-                label: <AxisLabel label={config?.xAxis?.label} direction="x" />,
+                label: (
+                  <AxisLabel
+                    label={config?.xAxis?.label}
+                    direction="x"
+                    isSimple={simple}
+                  />
+                ),
               })}
             />
             {(!simple || simpleNeedsAxis) && (

--- a/components/charts/composed-chart/styles.scss
+++ b/components/charts/composed-chart/styles.scss
@@ -49,6 +49,10 @@ $layout-breakpoint-3xl: 1536px;
   overflow-x: visible !important;
 }
 
+.no-padding {
+  padding: 0 !important;
+}
+
 .x-label-container,
 .y-label-container {
   position: relative;
@@ -58,6 +62,10 @@ $layout-breakpoint-3xl: 1536px;
 
   span {
     font-size: 0.8125rem;
+
+    &.simple-mode-label {
+      font-size: 0.625rem !important;
+    }
   }
 }
 

--- a/components/widget/components/widget-footer/styles.scss
+++ b/components/widget/components/widget-footer/styles.scss
@@ -23,6 +23,7 @@
   }
 
   &.simple {
+    margin-top: 1.25rem;
     font-size: rem(10px);
 
     p {

--- a/components/widgets/land-cover/tree-cover-density/index.js
+++ b/components/widgets/land-cover/tree-cover-density/index.js
@@ -19,7 +19,7 @@ export default {
   types: ['country', 'wdpa', 'aoi'],
   admins: ['adm0', 'adm1', 'adm2'],
   large: true,
-  visible: ['dashboard'],
+  visible: ['dashboard', 'analysis'],
   chartType: 'composedChart',
   colors: 'density',
   settingsConfig: [


### PR DESCRIPTION
## Overview

It makes no sense to use the “tree cover by type” widget for both tree cover 2000/2010 data and tropical tree cover analyses. Taking that into consideration, researchers are ok with us instead using the widget you created, “Tree Cover Density in [area]“, for Tropical Tree Cover analysis. 

[From user stories](https://gfw.atlassian.net/jira/software/c/projects/FLAG/issues/FLAG-693?jql=project%20%3D%20%22FLAG%22%20and%20text%20~%20%22priority%205%22%20and%20status%20%3D%20Released%20ORDER%20BY%20created%20DESC), this should appear only at the country, region, and sub-region level, as well as for saved custom areas.


## Demo

![Screenshot 2023-09-07 at 17 49 47](https://github.com/wri/gfw/assets/23243868/a40db6c9-b50d-4833-b325-d16854e40d4f)

## Testing

- Open [the map](https://gfw-staging-pr-4683.herokuapp.com/map/). 
- Select an Admin or Custom Area. 
- Click to analyse the area
- Select Tropical Tree cover Layer
- Verify if the right widget (Tree Cover Density) is showing correctly.

