### PR TITLE
[FLAG-791] Issues turning the satellite imagery toggle on and off 

### DIFF
--- a/components/map/components/layer-manager/component.jsx
+++ b/components/map/components/layer-manager/component.jsx
@@ -32,7 +32,7 @@ class LayerManagerComponent extends PureComponent {
           }
         : null;
 
-    const allLayers = layers.filter((l) => l);
+    const allLayers = [basemapLayer, ...layers].filter((l) => l);
 
     return (
       <LayerManager
@@ -69,9 +69,6 @@ class LayerManagerComponent extends PureComponent {
           },
         }}
       >
-        {basemapLayer && (
-          <Layer key="basemap" {...basemapLayer} {...basemapLayer?.config} />
-        )}
         {allLayers &&
           allLayers.map((l) => {
             const config = l.config ? l.config : l.layerConfig;


### PR DESCRIPTION
## Overview

This PR fixes an issue in sattelite imagery basemaps "stick". 

From what I've gathered the issue was due to the `key="basemap"` when adding the basemap layer; switching to `key={basemap.url}` also solves it.

I've chosen to merge the basemap back into the `allLayers` instead for a couple reasons: 
- I feel like it's clearer to pass an array of layers (basemap or not) to the LayerManager and let it handle them  
- Avoiding issues with keys in the future  
- It was done that way in the past. It was changed in an attempt to fix basemap issues in [#4533](https://github.com/wri/gfw/pull/4533), though it turned out that change only made the issue more frequent. The ultimate solution was found later on, with [#4633](https://github.com/wri/gfw/pull/4633), in which we finally figured out it was due to z-fighting issues when rendering decoded layers. 

## Demo

**Bug:**
https://github.com/wri/gfw/assets/6273795/98278616-5b1f-4f41-8fa2-f367f9b3e251

**Fix:**
https://github.com/wri/gfw/assets/6273795/d4071770-87e2-495e-b461-4f3d7baae422

## Notes

When rendering the PlanetAPI basemap/tiles, I did notice that they render a bit funny.
I've debugged this for a bit and it looks like a separate issue; the tiles come like that from the Planet API. I don't remember if it was like that before, though it is an unrelated issue. I've also tried to switch versions to past ones but they displayed the same way. 

## Tracking

[FLAG-791](https://gfw.atlassian.net/browse/FLAG-791)
