### PR TITLE
[FLAG-895] Add API Key validation to switch between Prod and Staging environments

### DIFF
--- a/pages/api/data/[...params].js
+++ b/pages/api/data/[...params].js
@@ -3,8 +3,16 @@ import httpProxyMiddleware from 'next-http-proxy-middleware';
 import { GFW_DATA_API, GFW_STAGING_DATA_API } from 'utils/apis';
 import { PROXIES } from 'utils/proxies';
 
-const ENVIRONMENT = process.env.NEXT_PUBLIC_FEATURE_ENV;
-const GFW_API_KEY = process.env.NEXT_PUBLIC_GFW_API_KEY;
+const {
+  NEXT_PUBLIC_FEATURE_ENV: ENVIRONMENT,
+  NEXT_PUBLIC_GFW_API_KEY,
+  NEXT_PUBLIC_GFW_API_KEY_STG,
+} = process.env;
+
+const GFW_API_KEY =
+  ENVIRONMENT === 'staging'
+    ? NEXT_PUBLIC_GFW_API_KEY_STG
+    : NEXT_PUBLIC_GFW_API_KEY;
 const DATA_API_URL =
   ENVIRONMENT === 'staging' ? GFW_STAGING_DATA_API : GFW_DATA_API;
 

--- a/pages/api/gfw/[...params].js
+++ b/pages/api/gfw/[...params].js
@@ -3,7 +3,16 @@ import httpProxyMiddleware from 'next-http-proxy-middleware';
 import { GFW_API } from 'utils/apis';
 import { PROXIES } from 'utils/proxies';
 
-const GFW_API_KEY = process.env.NEXT_PUBLIC_GFW_API_KEY;
+const {
+  NEXT_PUBLIC_FEATURE_ENV: ENVIRONMENT,
+  NEXT_PUBLIC_GFW_API_KEY,
+  NEXT_PUBLIC_GFW_API_KEY_STG,
+} = process.env;
+
+const GFW_API_KEY =
+  ENVIRONMENT === 'staging'
+    ? NEXT_PUBLIC_GFW_API_KEY_STG
+    : NEXT_PUBLIC_GFW_API_KEY;
 
 // We never use the `staging-api.resourcewatch.org`
 const GFW_API_URL = GFW_API;

--- a/utils/request.js
+++ b/utils/request.js
@@ -14,7 +14,11 @@ import {
 } from 'utils/apis';
 import { PROXIES } from './proxies';
 
-const ENVIRONMENT = process.env.NEXT_PUBLIC_FEATURE_ENV;
+const {
+  NEXT_PUBLIC_FEATURE_ENV: ENVIRONMENT,
+  NEXT_PUBLIC_GFW_API_KEY,
+  NEXT_PUBLIC_GFW_API_KEY_STG,
+} = process.env;
 
 const GFW_API_URL = ENVIRONMENT === 'staging' ? GFW_STAGING_API : GFW_API;
 const GFW_METADATA_API_URL =
@@ -25,8 +29,10 @@ const DATA_API_URL =
 // We never use the `staging-api.resourcewatch.org`.
 const RESOURCE_WATCH_API_URL = RESOURCE_WATCH_API;
 
-// At the moment, the API key is the same
-const GFW_API_KEY = process.env.NEXT_PUBLIC_GFW_API_KEY;
+const GFW_API_KEY =
+  ENVIRONMENT === 'staging'
+    ? NEXT_PUBLIC_GFW_API_KEY_STG
+    : NEXT_PUBLIC_GFW_API_KEY;
 const GFW_METADATA_API_KEY = GFW_API_KEY;
 const DATA_API_KEY = GFW_API_KEY;
 const RESOURCE_WATCH_API_KEY = GFW_API_KEY;


### PR DESCRIPTION
## Overview

After some investigation on https://gfw.atlassian.net/browse/FLAG-860  we have found same API Key for both environments, Prod and Staging. 

So we need to change it to use the right key depending on which environment we are. 

## Demo

![Screenshot 2023-09-27 at 14 03 42](https://github.com/wri/gfw/assets/23243868/1b272f7e-4465-400d-86d8-4b2848af56f2)

## Notes

We need to add a new env property on Heroku

## Testing

- Open [the dashboard](https://gfw-staging-pr-4698.herokuapp.com/) to use any request you want
- Check in the logs if the api key is the right one

