### PR TITLE
[FLAG-943] Tropical Tree Cover analysis malfunctioning

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,7 @@ module.exports = {
     '!<rootDir>/coverage/**',
     '!<rootDir>/cypress/**',
   ],
+  moduleDirectories: ['node_modules', '<rootDir>'],
   moduleNameMapper: {
     // Handle CSS imports (with CSS modules)
     // https://jestjs.io/docs/webpack#mocking-css-modules

--- a/services/__tests__/get-where-query.spec.js
+++ b/services/__tests__/get-where-query.spec.js
@@ -33,7 +33,9 @@ describe('getWHEREQuery', () => {
 
     const query = getWHEREQuery(params);
     const expected = "WHERE iso = 'PER' ";
+    const notExpected = 'AND umd_tree_cover_density_2000__threshold = 40 ';
 
     expect(query).toEqual(expected);
+    expect(query).not.toEqual(notExpected);
   });
 });

--- a/services/__tests__/get-where-query.spec.js
+++ b/services/__tests__/get-where-query.spec.js
@@ -1,36 +1,39 @@
 import { getWHEREQuery } from '../get-where-query';
 
 describe('getWHEREQuery', () => {
-  describe('Tree Cover Density query', () => {
-    let params;
+  it('should return an string with each parameter separated by AND', () => {
+    const params = {
+      type: 'country',
+      adm0: 'BRA',
+      locationType: 'country',
+      extentYear: 2000,
+      thresh: 30,
+      threshold: 30,
+      forestType: 'plantations',
+      dataset: 'annual',
+    };
+    const query = getWHEREQuery(params);
+    const expected =
+      "WHERE iso = 'BRA' AND umd_tree_cover_density_2000__threshold = 30 AND gfw_planted_forests__type IS NOT NULL ";
 
-    beforeEach(() => {
-      params = {
-        type: 'country',
-        adm0: 'PER',
-        pathname: '/map/[[...location]]',
-        locationType: 'country',
-        extentYear: 2020,
-        url: 'https://tiles.globalforestwatch.org/wri_tropical_tree_cover/v2020/ttcd_{thresh}/{z}/{x}/{y}.png',
-        thresh: '40',
-        threshold: 40,
-        confirmedOnly: 0,
-        gladLOnly: 0,
-        gladSOnly: 0,
-        raddOnly: 0,
-        startDayIndex: 0,
-        endDayIndex: null,
-        numberOfDays: null,
-        dataset: 'treeCoverDensity',
-      };
-    });
+    expect(query).toEqual(expected);
+  });
 
-    // Tree Cover Density has a default threshold
-    it('should return the default threshold even when user set a different threshold', () => {
-      const query = getWHEREQuery(params);
-      const expected = "WHERE iso = 'PER' ";
+  // Tree Cover Density has a default threshold
+  it('should not return threshold for Tree Cover Density', () => {
+    const params = {
+      type: 'country',
+      adm0: 'PER',
+      locationType: 'country',
+      extentYear: 2020,
+      thresh: '40',
+      threshold: 40, // passing threshold as parameter from tropical tree cover layer
+      dataset: 'treeCoverDensity',
+    };
 
-      expect(query).toEqual(expected);
-    });
+    const query = getWHEREQuery(params);
+    const expected = "WHERE iso = 'PER' ";
+
+    expect(query).toEqual(expected);
   });
 });

--- a/services/__tests__/get-where-query.spec.js
+++ b/services/__tests__/get-where-query.spec.js
@@ -1,0 +1,36 @@
+import { getWHEREQuery } from '../get-where-query';
+
+describe('getWHEREQuery', () => {
+  describe('Tree Cover Density query', () => {
+    let params;
+
+    beforeEach(() => {
+      params = {
+        type: 'country',
+        adm0: 'PER',
+        pathname: '/map/[[...location]]',
+        locationType: 'country',
+        extentYear: 2020,
+        url: 'https://tiles.globalforestwatch.org/wri_tropical_tree_cover/v2020/ttcd_{thresh}/{z}/{x}/{y}.png',
+        thresh: '40',
+        threshold: 40,
+        confirmedOnly: 0,
+        gladLOnly: 0,
+        gladSOnly: 0,
+        raddOnly: 0,
+        startDayIndex: 0,
+        endDayIndex: null,
+        numberOfDays: null,
+        dataset: 'treeCoverDensity',
+      };
+    });
+
+    // Tree Cover Density has a default threshold
+    it('should return the default threshold even when user set a different threshold', () => {
+      const query = getWHEREQuery(params);
+      const expected = "WHERE iso = 'PER' ";
+
+      expect(query).toEqual(expected);
+    });
+  });
+});

--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -85,6 +85,14 @@ const SQL_QUERIES = {
 
 const ALLOWED_PARAMS = {
   annual: ['adm0', 'adm1', 'adm2', 'threshold', 'forestType', 'landCategory'],
+  treeCoverDensity: [
+    'adm0',
+    'adm1',
+    'adm2',
+    'threshold',
+    'forestType',
+    'landCategory',
+  ],
   integrated_alerts: [
     'adm0',
     'adm1',
@@ -340,6 +348,8 @@ export const getWHEREQuery = (params) => {
         (!isNaN(value) && !['adm0', 'confidence'].includes(p))
       );
 
+      const isTreeCoverDensity = dataset === 'treeCoverDensity';
+
       let paramKey = p;
       if (p === 'confidence') paramKey = 'confidence__cat';
       if (p === 'threshold') {
@@ -386,12 +396,12 @@ export const getWHEREQuery = (params) => {
             }`
           : ''
       }${
-        !isPolyname
-          ? `${paramKey}${comparisonString}${
+        !isPolyname && isTreeCoverDensity && p === 'threshold'
+          ? ''
+          : `${paramKey}${comparisonString}${
               isNumericValue ? value : `'${value}'`
             }`
-          : ''
-      }${isLast ? '' : ' AND '}`;
+      }${isLast || isTreeCoverDensity ? '' : ' AND '}`;
 
       paramString = paramString.concat(polynameString);
     });
@@ -2065,7 +2075,10 @@ export const getTreeCoverDensity = (params) => {
         getLocationSelect({ ...params, cast: false })
       )
       .replace(/{location}/g, getLocationSelect({ ...params }))
-      .replace('{WHERE}', getWHEREQuery({ ...params, dataset: 'annual' }))
+      .replace(
+        '{WHERE}',
+        getWHEREQuery({ ...params, dataset: 'treeCoverDensity' })
+      )
   );
 
   return dataRequest.get(url).then((response) => response.data);

--- a/services/get-where-query.js
+++ b/services/get-where-query.js
@@ -1,0 +1,102 @@
+import ALLOWED_PARAMS from 'utils/get-where-query-allowed-params';
+import { translateParameterKey } from 'utils/get-where-query-translation';
+
+import forestTypes from 'data/forest-types';
+import landCategories from 'data/land-categories';
+
+const isNumber = (value) => !!(typeof value === 'number' || !isNaN(value));
+
+// build {where} statement for query
+export const getWHEREQuery = (params = {}) => {
+  const { type, dataset } = params || {};
+
+  const allFilterOptions = forestTypes.concat(landCategories);
+  const allowedParams = ALLOWED_PARAMS[params.dataset || 'annual'];
+  const isTreeCoverDensity = dataset === 'treeCoverDensity';
+  const comparisonString = ' = ';
+
+  let paramString = 'WHERE ';
+  let paramKeys = Object.keys(params).filter((parameterName) => {
+    return (
+      (params[parameterName] || parameterName === 'threshold') &&
+      allowedParams.includes(parameterName)
+    );
+  });
+
+  if (!paramKeys?.length) {
+    return '';
+  }
+
+  /*
+   * Removing threshold from Tree Cover Density request
+   * Tree Cover Density has a default threshold >=10
+   */
+  if (isTreeCoverDensity && paramKeys.includes('threshold')) {
+    paramKeys = paramKeys.filter((item) => item !== 'threshold');
+  }
+
+  paramKeys.forEach((parameter, index) => {
+    const isLastParameter = paramKeys.length - 1 === index;
+    const hasFilterOption = ['forestType', 'landCategory'].includes(parameter);
+    const value = hasFilterOption ? 1 : params[parameter];
+    const polynameMeta = allFilterOptions.find(
+      (pname) => pname.value === params[parameter]
+    );
+    const tableKey =
+      polynameMeta &&
+      (polynameMeta.tableKey || polynameMeta.tableKeys[dataset || 'annual']);
+    let isNumericValue = isNumber(value);
+
+    const paramKey = translateParameterKey(parameter, params);
+
+    if (parameter === 'adm0' && type === 'wdpa') {
+      isNumericValue = false;
+    }
+
+    if (dataset === 'net_change') {
+      isNumericValue = false;
+    }
+
+    const hasPrefixIs__ = hasFilterOption && tableKey.includes('is__');
+    let WHERE = '';
+
+    if (hasFilterOption) {
+      if (hasPrefixIs__) {
+        WHERE = `${WHERE}${tableKey} = 'true'`;
+      }
+
+      if (!hasPrefixIs__) {
+        WHERE = `${WHERE}${tableKey} IS NOT NULL`;
+      }
+
+      if (
+        polynameMeta &&
+        !hasPrefixIs__ &&
+        polynameMeta.default &&
+        polynameMeta.categories
+      ) {
+        WHERE = `${WHERE} AND ${tableKey} ${polynameMeta.comparison || '='} ${
+          polynameMeta?.dataType === 'keyword'
+            ? `'${polynameMeta?.default}'`
+            : `${polynameMeta?.default}`
+        }`;
+      }
+    }
+
+    if (!hasFilterOption) {
+      WHERE = `${WHERE}${paramKey}${comparisonString}${
+        isNumericValue ? value : `'${value}'`
+      }`;
+    }
+
+    if (isLastParameter) {
+      WHERE = `${WHERE} `;
+    } else {
+      WHERE = `${WHERE} AND `;
+    }
+
+    paramString = paramString.concat(WHERE);
+  });
+
+  return paramString;
+};

--- a/services/get-where-query.js
+++ b/services/get-where-query.js
@@ -39,12 +39,13 @@ export const getWHEREQuery = (params = {}) => {
     const isLastParameter = paramKeys.length - 1 === index;
     const hasFilterOption = ['forestType', 'landCategory'].includes(parameter);
     const value = hasFilterOption ? 1 : params[parameter];
-    const polynameMeta = allFilterOptions.find(
+    const filterOption = allFilterOptions.find(
       (pname) => pname.value === params[parameter]
     );
+
     const tableKey =
-      polynameMeta &&
-      (polynameMeta.tableKey || polynameMeta.tableKeys[dataset || 'annual']);
+      filterOption &&
+      (filterOption.tableKey || filterOption.tableKeys[dataset || 'annual']);
     let isNumericValue = isNumber(value);
 
     const paramKey = translateParameterKey(parameter, params);
@@ -70,15 +71,15 @@ export const getWHEREQuery = (params = {}) => {
       }
 
       if (
-        polynameMeta &&
+        filterOption &&
         !hasPrefixIs__ &&
-        polynameMeta.default &&
-        polynameMeta.categories
+        filterOption.default &&
+        filterOption.categories
       ) {
-        WHERE = `${WHERE} AND ${tableKey} ${polynameMeta.comparison || '='} ${
-          polynameMeta?.dataType === 'keyword'
-            ? `'${polynameMeta?.default}'`
-            : `${polynameMeta?.default}`
+        WHERE = `${WHERE} AND ${tableKey} ${filterOption.comparison || '='} ${
+          filterOption?.dataType === 'keyword'
+            ? `'${filterOption?.default}'`
+            : `${filterOption?.default}`
         }`;
       }
     }

--- a/utils/get-where-query-allowed-params.js
+++ b/utils/get-where-query-allowed-params.js
@@ -1,0 +1,50 @@
+const ALLOWED_PARAMS = {
+  annual: ['adm0', 'adm1', 'adm2', 'threshold', 'forestType', 'landCategory'],
+  treeCoverDensity: [
+    'adm0',
+    'adm1',
+    'adm2',
+    'threshold',
+    'forestType',
+    'landCategory',
+  ],
+  integrated_alerts: [
+    'adm0',
+    'adm1',
+    'adm2',
+    'forestType',
+    'landCategory',
+    'is__confirmed_alert',
+  ],
+  glad: [
+    'adm0',
+    'adm1',
+    'adm2',
+    'forestType',
+    'landCategory',
+    'is__confirmed_alert',
+  ],
+  viirs: ['adm0', 'adm1', 'adm2', 'forestType', 'landCategory', 'confidence'],
+  modis: ['adm0', 'adm1', 'adm2', 'forestType', 'landCategory', 'confidence'],
+  modis_burned_area: [
+    'adm0',
+    'adm1',
+    'adm2',
+    'threshold',
+    'forestType',
+    'landCategory',
+    'confidence',
+  ],
+  net_change: [
+    'adm0',
+    'adm1',
+    'adm2',
+    'threshold',
+    'forestType',
+    'landCategory',
+    'confidence',
+  ],
+  tropicalTreeCover: ['adm0', 'adm1', 'adm2', 'threshold', 'forestType'],
+};
+
+export default ALLOWED_PARAMS;

--- a/utils/get-where-query-translation.js
+++ b/utils/get-where-query-translation.js
@@ -1,0 +1,23 @@
+export const translateParameterKey = (parameterKey, { type, dataset }) => {
+  let paramKey = '';
+
+  if (parameterKey === 'confidence') paramKey = 'confidence__cat';
+  if (parameterKey === 'adm0' && type === 'country') paramKey = 'iso';
+  if (parameterKey === 'adm1' && type === 'country') paramKey = 'adm1';
+  if (parameterKey === 'adm2' && type === 'country') paramKey = 'adm2';
+  if (parameterKey === 'adm0' && type === 'geostore') paramKey = 'geostore__id';
+  if (parameterKey === 'adm0' && type === 'wdpa')
+    paramKey = 'wdpa_protected_area__id';
+
+  if (parameterKey === 'threshold') {
+    if (dataset === 'tropicalTreeCover') {
+      paramKey = 'wri_tropical_tree_cover__decile';
+    } else {
+      paramKey = 'umd_tree_cover_density_2000__threshold';
+    }
+  }
+
+  return paramKey;
+};
+
+export default translateParameterKey;


### PR DESCRIPTION
## Overview

Tree Cover Density widget doesn't work correctly on Analysis when threshold is added as parameter. 
This widget has its own threshold (>10 as default), but when a user selects Tropical Tree Cover layer and changes the threshold, a new parameter was added to the query, making the request fail.

We did a major refactor at the `getWHEREQuery` to improve readability and add some new validations.

## Demo

![Screenshot 2023-10-17 at 15 45 47](https://github.com/wri/gfw/assets/23243868/02d2e12c-2e10-4ffd-9121-735b05c00658)


![Screenshot 2023-09-07 at 17 49 47](https://github.com/wri/gfw/assets/23243868/9033d0e1-4688-4cea-aceb-a5f3003fc85c)

## Testing

- Open the map
- Select Tropical Tree Cover
- Change the threshold
- Try to see Tree Cover Density Widget (it should work normally)

