### PR TITLE
Data/tree cover gain decoding

### DIFF
--- a/providers/datasets-provider/config.js
+++ b/providers/datasets-provider/config.js
@@ -593,21 +593,17 @@ const decodes = {
     color.b = blue; 
   `,
   treeGain: `
-  float red = color.r;
-  float green = color.g;
-  float blue = color.b;
-
-  if (zoom < 12.) {
-    if (color.r == 0. && color.g == 0. && color.b == 0.) {
-      alpha = 0.;
-    } else {
-      alpha = 1.- (1.1 * pow(8. , -(12. * alpha / zoom)));
+    // Multiply alpha (opacity) by a function that drops super low opacity
+    // pixels and scales the rest to higher values
+    // TODO: Explain the various coefficients and how they effect alpha
+    
+    if (zoom < 12.) {
+      if (color.r == 0. && color.g == 0. && color.b == 0.) {
+        alpha = 0.;
+      } else {
+        alpha = 1.- (1.1 * pow(8. , -(12. * alpha / zoom)));
+      }
     }
-  }
-  
-  color.r = red;
-  color.g = green;
-  color.b = blue; 
 `,
   newCarbonFlux: `
     float red = color.r;

--- a/providers/datasets-provider/config.js
+++ b/providers/datasets-provider/config.js
@@ -601,7 +601,7 @@ const decodes = {
     if (red == 0. && green == 0. && blue == 0.) {
       alpha = 0.;
     } else {
-      alpha = alpha * 2.;
+      alpha = alpha * 8.;
     }
   }
   color.r = red;

--- a/providers/datasets-provider/config.js
+++ b/providers/datasets-provider/config.js
@@ -601,7 +601,7 @@ const decodes = {
     if (red == 0. && green == 0. && blue == 0.) {
       alpha = 0.;
     } else {
-      alpha = alpha * 8.;
+      alpha = alpha * 7.;
     }
   }
   color.r = red;

--- a/providers/datasets-provider/config.js
+++ b/providers/datasets-provider/config.js
@@ -601,7 +601,7 @@ const decodes = {
     if (red == 0. && green == 0. && blue == 0.) {
       alpha = 0.;
     } else {
-      alpha = alpha * 7.;
+      alpha = alpha * 6.;
     }
   }
   color.r = red;

--- a/providers/datasets-provider/config.js
+++ b/providers/datasets-provider/config.js
@@ -588,11 +588,26 @@ const decodes = {
         alpha = 1.;
       }
     }
-
     color.r = red;
     color.g = green;
     color.b = blue; 
   `,
+  treeGain: `
+  float red = color.r;
+  float green = color.g;
+  float blue = color.b;
+
+  if (zoom < 12.) {
+    if (red == 0. && green == 0. && blue == 0.) {
+      alpha = 0.;
+    } else {
+      alpha = alpha * 2.;
+    }
+  }
+  color.r = red;
+  color.g = green;
+  color.b = blue; 
+`,
   newCarbonFlux: `
     float red = color.r;
     float green = color.g;
@@ -1058,4 +1073,5 @@ export default {
   cumulativeCarbonGain: decodes.cumulativeCarbonGain,
   netGHGFlux: decodes.netCarbonFlux,
   formaAlerts: decodes.forma,
+  treeGain: decodes.treeGain,
 };

--- a/providers/datasets-provider/config.js
+++ b/providers/datasets-provider/config.js
@@ -598,12 +598,13 @@ const decodes = {
   float blue = color.b;
 
   if (zoom < 12.) {
-    if (red == 0. && green == 0. && blue == 0.) {
+    if (color.r == 0. && color.g == 0. && color.b == 0.) {
       alpha = 0.;
     } else {
-      alpha = alpha * 6.;
+      alpha = 1.- (1.1 * pow(8. , -(12. * alpha / zoom)));
     }
   }
+  
   color.r = red;
   color.g = green;
   color.b = blue; 


### PR DESCRIPTION
## Overview

This PR aims to improve the visibility of the Tree Cover Gain layer, especially from zoomed out views.  
To do so, a new decoding function `treeGain` is created, in which the alpha channel is multiplied by a function that drops super low opacity pixels and scales the rest to higher values

## Demo

This is the current view in production:
![Screenshot 2023-10-16 at 17 56 20](https://github.com/wri/gfw/assets/57727579/ed103f3f-feb9-476f-ac79-d084a2b775f8)

![Screenshot 2024-01-17 at 18 32 01](https://github.com/wri/gfw/assets/23243868/2c38be80-6882-4968-bbc4-2dfc5bc6c007)


## Environment

The changes of this PR can only be tested in the staging environment.

## Deploy

To deploy these changes, it requires not only merging and promoting the code changes, but also updating the `decode_function` parameter in the production layer, from "staticRemapAlpha" to "treeGain" (using postman or LMIpy)

