### PR TITLE
FLAG-901: remove MODIS Burned Areas from widgets

### DIFF
--- a/components/widgets/fires/burned-area-cumulative/index.js
+++ b/components/widgets/fires/burned-area-cumulative/index.js
@@ -151,12 +151,10 @@ export default {
   refetchKeys: ['dataset'],
   getWidget: (widgetSettings) => {
     // called when settings changes
-    if (!widgetSettings || !widgetSettings.dataset) {
-      return defaultConfig;
-    }
     if (widgetSettings?.dataset !== 'modis_burned_area') {
       return firesAlertsCumulative;
     }
+
     return defaultConfig;
   },
 };

--- a/components/widgets/fires/burned-area-cumulative/index.js
+++ b/components/widgets/fires/burned-area-cumulative/index.js
@@ -98,7 +98,7 @@ const defaultConfig = {
     fires: 3,
   },
   settings: {
-    dataset: 'modis_burned_area',
+    dataset: 'viirs',
     firesThreshold: 0,
   },
   sentences: {
@@ -154,7 +154,7 @@ export default {
     if (!widgetSettings || !widgetSettings.dataset) {
       return defaultConfig;
     }
-    if (widgetSettings.dataset !== 'modis_burned_area') {
+    if (widgetSettings?.dataset !== 'modis_burned_area') {
       return firesAlertsCumulative;
     }
     return defaultConfig;

--- a/components/widgets/fires/burned-area-ranked/index.js
+++ b/components/widgets/fires/burned-area-ranked/index.js
@@ -118,7 +118,7 @@ const defaultConfig = {
     page: 0,
     period: 'week',
     weeks: 4,
-    dataset: 'modis_burned_area',
+    dataset: 'viirs',
     layerStartDate: null,
     layerEndDate: null,
     firesThreshold: 0,
@@ -166,7 +166,7 @@ export default {
     if (!widgetSettings || !widgetSettings.dataset) {
       return defaultConfig;
     }
-    if (widgetSettings.dataset !== 'modis_burned_area') {
+    if (widgetSettings?.dataset !== 'modis_burned_area') {
       return firesRanked;
     }
     return defaultConfig;

--- a/components/widgets/fires/burned-area-ranked/index.js
+++ b/components/widgets/fires/burned-area-ranked/index.js
@@ -163,12 +163,10 @@ export default {
   refetchKeys: ['dataset'],
   getWidget: (widgetSettings) => {
     // called when settings changes
-    if (!widgetSettings || !widgetSettings.dataset) {
-      return defaultConfig;
-    }
     if (widgetSettings?.dataset !== 'modis_burned_area') {
       return firesRanked;
     }
+
     return defaultConfig;
   },
 };

--- a/components/widgets/fires/burned-area/index.js
+++ b/components/widgets/fires/burned-area/index.js
@@ -86,7 +86,7 @@ export default {
     fires: 1,
   },
   settings: {
-    dataset: 'modis_burned_area',
+    dataset: 'viirs',
     firesThreshold: 0,
   },
   sentences: {

--- a/components/widgets/fires/fires-alerts-cumulative/index.js
+++ b/components/widgets/fires/fires-alerts-cumulative/index.js
@@ -2,6 +2,8 @@ import { all, spread } from 'axios';
 import uniq from 'lodash/uniq';
 import moment from 'moment';
 import { fetchVIIRSAlerts, fetchVIIRSLatest } from 'services/analysis-cached';
+import { FIRES_VIIRS_DATASET } from 'data/datasets';
+import { FIRES_ALERTS_VIIRS } from 'data/layers';
 
 import getWidgetProps from './selectors';
 
@@ -10,6 +12,12 @@ export default {
   title: 'Cumulative Fire Alerts in {location}',
   large: true,
   categories: ['summary', 'fires'],
+  datasets: [
+    {
+      dataset: FIRES_VIIRS_DATASET,
+      layers: [FIRES_ALERTS_VIIRS],
+    },
+  ],
   settingsConfig: [
     {
       key: 'forestType',

--- a/data/fires-datasets.json
+++ b/data/fires-datasets.json
@@ -12,11 +12,5 @@
     "unit": "alerts",
     "metaKey": null,
     "infoText": "MODIS alerts perform better in cloudy areas, but are coarser resolution than VIIRS alerts"
-  },{
-    "label": "MODIS Burned Area",
-    "value": "modis_burned_area",
-    "unit": "ha",
-    "metaKey": null,
-    "infoText": "MODIS burned area dataset gives an indication of the total area affected by fires"
   }
 ]


### PR DESCRIPTION
## Overview

Removing "MODIS Burned Areas" from the web application.

This release will require updating the RW API to unpublish the corresponding layer and dataset.

before:
<img width="300" alt="Screenshot 2023-10-18 at 3 42 56 p m" src="https://github.com/wri/gfw/assets/127868788/c4c90873-a09b-4296-a733-42edefe72bc7">

after:
<img width="282" alt="Screenshot 2023-10-18 at 3 48 35 p m" src="https://github.com/wri/gfw/assets/127868788/edece168-4fa5-4d20-aa2f-b0180dffb08b">



## Demo

If applicable: screenshots, gifs, etc.

## Notes

If applicable: ancilary topics, caveats, alternative strategies that didn't work out, etc.

## Testing

- Include any steps to verify the features this PR introduces.
- If this fixes a bug, include bug reproduction steps.

