### PR TITLE
[FLAG-926]  FAO reforestation widget

### DIFF
--- a/components/widgets/forest-change/fao-reforest/index.js
+++ b/components/widgets/forest-change/fao-reforest/index.js
@@ -32,9 +32,9 @@ export default {
   colors: 'gain',
   sentences: {
     globalInitial:
-      'According to the FAO, the {location} rate of reforestation in {year} was {rate} per year.',
+      'According to the FAO, the {location} rate of reforestation in between {startYearRange} and {endYearRange} was {rate} per year.',
     initial:
-      'According to the FAO, the rate of reforestation in {location} was {rate} per year in {year}.',
+      'According to the FAO, the rate of reforestation in {location} was {rate} per year between {startYearRange} and {endYearRange}.',
     noReforest: 'No reforestation data in {location}.',
   },
   settings: {

--- a/components/widgets/forest-change/fao-reforest/index.js
+++ b/components/widgets/forest-change/fao-reforest/index.js
@@ -14,9 +14,11 @@ export default {
   admins: ['global', 'adm0'],
   settingsConfig: [
     {
-      key: 'period',
+      key: 'yearRange',
       label: 'period',
       type: 'select',
+      clearable: false,
+      border: true,
     },
   ],
   chartType: 'rankedList',
@@ -25,7 +27,7 @@ export default {
   sortOrder: {
     forestChange: 8,
   },
-  refetchKeys: ['period'],
+  refetchKeys: ['yearRange'],
   colors: 'gain',
   sentences: {
     globalInitial:
@@ -35,7 +37,7 @@ export default {
     noReforest: 'No reforestation data in {location}.',
   },
   settings: {
-    period: 2010,
+    yearRange: '2015-2020',
     unit: 'ha/year',
     pageSize: 5,
     page: 0,

--- a/components/widgets/forest-change/fao-reforest/index.js
+++ b/components/widgets/forest-change/fao-reforest/index.js
@@ -49,6 +49,8 @@ export default {
 
       return hasCountryData ? data : {};
     }),
-  getDataURL: (params) => [getFAOReforest({ ...params, download: true })],
+  getDataURL: async (params) => [
+    await getFAOReforest({ ...params, download: true }),
+  ],
   getWidgetProps,
 };

--- a/components/widgets/forest-change/fao-reforest/index.js
+++ b/components/widgets/forest-change/fao-reforest/index.js
@@ -1,4 +1,3 @@
-import { all, spread } from 'axios';
 import { getFAOReforest } from 'services/forest-data';
 
 import getWidgetProps from './selectors';
@@ -44,13 +43,12 @@ export default {
     page: 0,
   },
   getData: (params) =>
-    all([getFAOReforest(params)]).then(
-      spread((getFAOReforestResponse) => {
-        const fao = getFAOReforestResponse;
+    getFAOReforest({ ...params }).then((response) => {
+      const data = response.data.rows;
+      const hasCountryData = (data.length && data.find((d) => d.iso)) || null;
 
-        return { fao };
-      })
-    ),
+      return hasCountryData ? data : {};
+    }),
   getDataURL: (params) => [getFAOReforest({ ...params, download: true })],
   getWidgetProps,
 };

--- a/components/widgets/forest-change/fao-reforest/index.js
+++ b/components/widgets/forest-change/fao-reforest/index.js
@@ -1,3 +1,4 @@
+import { all, spread } from 'axios';
 import { getFAOReforest } from 'services/forest-data';
 
 import getWidgetProps from './selectors';
@@ -43,11 +44,13 @@ export default {
     page: 0,
   },
   getData: (params) =>
-    getFAOReforest({ ...params }).then((response) => {
-      const data = response.data.rows;
-      const hasCountryData = (data.length && data.find((d) => d.iso)) || null;
-      return hasCountryData ? data : {};
-    }),
+    all([getFAOReforest(params)]).then(
+      spread((getFAOReforestResponse) => {
+        const fao = getFAOReforestResponse;
+
+        return { fao };
+      })
+    ),
   getDataURL: (params) => [getFAOReforest({ ...params, download: true })],
   getWidgetProps,
 };

--- a/components/widgets/forest-change/fao-reforest/selectors.js
+++ b/components/widgets/forest-change/fao-reforest/selectors.js
@@ -26,9 +26,7 @@ export const getSortedData = createSelector([getData], (data) => {
 export const parseData = createSelector(
   [getData, getAdm0, getColors],
   (data, adm0, colors) => {
-    // if (!data || !data.length) return null;
-
-    console.log(data);
+    if (!data || !data.length) return null;
 
     let dataTrimmed = data;
 
@@ -50,11 +48,9 @@ export const parseData = createSelector(
       dataTrimmed = data?.slice(trimStart, trimEnd);
     }
 
-    console.log('data trimmed', dataTrimmed);
-
     return dataTrimmed?.map((d) => ({
       ...d,
-      label: d.name,
+      label: d.iso,
       color: colors.main,
       value: d.rate,
     }));

--- a/components/widgets/forest-change/fao-reforest/selectors.js
+++ b/components/widgets/forest-change/fao-reforest/selectors.js
@@ -24,10 +24,9 @@ export const getSortedData = createSelector([getData], (data) => {
 });
 
 export const parseData = createSelector(
-  [getData, getAdm0, getColors],
+  [getSortedData, getAdm0, getColors],
   (data, adm0, colors) => {
     if (!data || !data.length) return null;
-
     let dataTrimmed = data;
 
     if (adm0) {

--- a/components/widgets/forest-change/fao-reforest/selectors.js
+++ b/components/widgets/forest-change/fao-reforest/selectors.js
@@ -50,7 +50,7 @@ export const parseData = createSelector(
 
     return dataTrimmed?.map((d) => ({
       ...d,
-      label: d.iso,
+      label: d.name,
       color: colors.main,
       value: d.rate,
     }));

--- a/components/widgets/forest-change/fao-reforest/selectors.js
+++ b/components/widgets/forest-change/fao-reforest/selectors.js
@@ -4,16 +4,17 @@ import findIndex from 'lodash/findIndex';
 import sortBy from 'lodash/sortBy';
 import { formatNumber } from 'utils/format';
 
-const getData = (state) => state.data || null;
-const getAdm0 = (state) => state.adm0 || null;
+const getData = (state) => state.data;
+const getAdm0 = (state) => state.adm0;
 const getColors = (state) => state.colors || null;
 const getLocationName = (state) => state.locationLabel || null;
-const getPeriod = (state) => state.settings.period || null;
+const getSettings = (state) => state.settings;
 const getSentences = (state) => state.sentences;
 const getTitle = (state) => state.title;
 
 export const getSortedData = createSelector([getData], (data) => {
   if (!data || !data.length) return null;
+
   return sortBy(uniqBy(data, 'iso'), 'rate')
     .reverse()
     .map((d, i) => ({
@@ -23,26 +24,35 @@ export const getSortedData = createSelector([getData], (data) => {
 });
 
 export const parseData = createSelector(
-  [getSortedData, getAdm0, getColors],
+  [getData, getAdm0, getColors],
   (data, adm0, colors) => {
-    if (!data || !data.length) return null;
+    // if (!data || !data.length) return null;
+
+    console.log(data);
+
     let dataTrimmed = data;
+
     if (adm0) {
       const locationIndex = findIndex(data, (d) => d.iso === adm0);
       let trimStart = locationIndex - 2;
       let trimEnd = locationIndex + 3;
+
       if (locationIndex < 2) {
         trimStart = 0;
         trimEnd = 5;
       }
-      if (locationIndex > data.length - 3) {
-        trimStart = data.length - 5;
-        trimEnd = data.length;
+
+      if (locationIndex > data?.length - 3) {
+        trimStart = data?.length - 5;
+        trimEnd = data?.length;
       }
-      dataTrimmed = data.slice(trimStart, trimEnd);
+
+      dataTrimmed = data?.slice(trimStart, trimEnd);
     }
 
-    return dataTrimmed.map((d) => ({
+    console.log('data trimmed', dataTrimmed);
+
+    return dataTrimmed?.map((d) => ({
       ...d,
       label: d.name,
       color: colors.main,
@@ -52,28 +62,43 @@ export const parseData = createSelector(
 );
 
 export const parseSentence = createSelector(
-  [getSortedData, parseData, getPeriod, getSentences, getLocationName, getAdm0],
-  (sortedData, data, period, sentences, locationName, adm0) => {
+  [
+    getSortedData,
+    parseData,
+    getSettings,
+    getSentences,
+    getLocationName,
+    getAdm0,
+  ],
+  (sortedData, data, settings, sentences, locationName, adm0) => {
     if (!data || !data.length) return null;
     const { initial, noReforest, globalInitial } = sentences;
     const countryData = data.find((d) => adm0 === d.iso) || null;
 
+    const yearRangeSeparated = settings.yearRange.split('-');
+    const startYearRange = yearRangeSeparated[0];
+    const endYearRange = yearRangeSeparated[1];
+
     let globalRate = 0;
+
     Object.keys(sortedData).forEach((k) => {
       globalRate += sortedData[k].rate;
     });
-    const rate =
-      locationName === 'global' ? globalRate : countryData && countryData.value;
+
+    const rate = locationName === 'global' ? globalRate : countryData?.value;
+    const formatType = rate < 1 ? '.3r' : '.3s';
 
     let sentence = globalInitial;
+
     if (locationName !== 'global') {
       sentence = countryData && countryData.value > 0 ? initial : noReforest;
     }
-    const formatType = rate < 1 ? '.3r' : '.3s';
 
     const params = {
       location: locationName,
-      year: period,
+      year: settings.yearRange,
+      startYearRange,
+      endYearRange,
       rate: formatNumber({
         num: rate,
         unit: 'ha',

--- a/services/forest-data.js
+++ b/services/forest-data.js
@@ -9,7 +9,7 @@ const NEW_SQL_QUERIES = {
   faoExtent:
     'SELECT iso, country, "planted forest (ha)" AS planted_forest__ha, "primary (ha)" AS primary_forest__ha, "naturally regenerating forest (ha)" AS regenerated_forest__ha, "forest (ha)" AS fao_treecover__ha, "total land area (ha)" as area_ha FROM data WHERE {location} AND year = {year}',
   faoReforest:
-    'SELECT country AS iso, year, "reforestation (ha per year)" AS reforestation__rate, "forest expansion (ha per year)" AS fao_treecover_reforest__ha FROM table_1_forest_area_and_characteristics as fao WHERE fao.year = {yearRange} AND "reforestation (ha per year)" > 0 ORDER BY reforestation__rate DESC',
+    'SELECT iso, country AS name, year, "reforestation (ha per year)" AS reforestation__rate, "forest expansion (ha per year)" AS fao_treecover_reforest__ha FROM table_1_forest_area_and_characteristics as fao WHERE fao.year = {yearRange} AND "reforestation (ha per year)" > 0 ORDER BY reforestation__rate DESC',
   faoDeforest:
     'SELECT iso, country as name, "deforestation (ha per year)" as fao_treecover_deforest__ha, "reforestation (ha per year)" as fao_reforestation__ha, "forest expansion (ha per year)" as fao_expansion__ha, year FROM data where year = {yearRange}',
   faoDeforestRank:

--- a/services/forest-data.js
+++ b/services/forest-data.js
@@ -10,6 +10,8 @@ const NEW_SQL_QUERIES = {
     'SELECT iso, country, "planted forest (ha)" AS planted_forest__ha, "primary (ha)" AS primary_forest__ha, "naturally regenerating forest (ha)" AS regenerated_forest__ha, "forest (ha)" AS fao_treecover__ha, "total land area (ha)" as area_ha FROM data WHERE {location} AND year = {year}',
   faoReforest:
     'SELECT iso, country AS name, year, "reforestation (ha per year)" AS reforestation__rate, "forest expansion (ha per year)" AS fao_treecover_reforest__ha FROM table_1_forest_area_and_characteristics as fao WHERE fao.year = {yearRange} AND "reforestation (ha per year)" > 0 ORDER BY reforestation__rate DESC',
+  faoReforestDownload:
+    'SELECT iso, country AS name, year, "reforestation (ha per year)" AS reforestation__rate  FROM table_1_forest_area_and_characteristics as fao WHERE fao.year = {yearRange} AND "reforestation (ha per year)" > 0 ORDER BY reforestation__rate DESC',
   faoDeforest:
     'SELECT iso, country as name, "deforestation (ha per year)" as fao_treecover_deforest__ha, "reforestation (ha per year)" as fao_reforestation__ha, "forest expansion (ha per year)" as fao_expansion__ha, year FROM data where year = {yearRange}',
   faoDeforestRank:
@@ -88,11 +90,13 @@ export const getFAOExtent = async ({ adm0, faoYear = 2020, download }) => {
 
 export const getFAOReforest = async ({ yearRange = '2015-2020', download }) => {
   const target = download ? 'download/csv' : 'query/json';
-  const url =
-    `/dataset/fao_forest_change/v2020/${target}?sql=${NEW_SQL_QUERIES.faoReforest}`.replace(
-      /{yearRange}/g,
-      `'${yearRange}'`
-    );
+  const query = download
+    ? NEW_SQL_QUERIES.faoReforestDownload
+    : NEW_SQL_QUERIES.faoReforest;
+  const url = `/dataset/fao_forest_change/v2020/${target}?sql=${query}`.replace(
+    /{yearRange}/g,
+    `'${yearRange}'`
+  );
 
   if (download) {
     return {

--- a/services/forest-data.js
+++ b/services/forest-data.js
@@ -107,7 +107,7 @@ export const getFAOReforest = async ({ yearRange = '2015-2020', download }) => {
 
   const widgetData = {
     data: {
-      rows: response.data.rows.map((o) => {
+      rows: response.data.map((o) => {
         delete Object.assign(o, { rate: o.reforestation__rate })
           .reforestation__rate;
         delete Object.assign(o, { extent: o.fao_treecover_reforest__ha })


### PR DESCRIPTION
## Overview

Update the current widget (shown below) to the 2020 data and update the year selector.

Data sources: we previously stored the data for FAO widgets in Carto. The engineering team has opted to move this data to the Data API, using [these spreadsheets](https://onewri.sharepoint.com/sites/globalforest/Shared%20Documents/Forms/AllItems.aspx?id=%2Fsites%2Fglobalforest%2FShared%20Documents%2FPlatform%2FProjects%20and%20Tasks%2FFAO%202020%20updates%2Fdata&p=true&ga=1) as a source. They’re hoping that constructing queries will be relatively straightforward, but Justin and Maanas are available in case we need help. The data on the Data API is available here:

FAO Forest Change: https://data-api.globalforestwatch.org/dataset/fao_forest_change/v2020/query/

FAO Forestry Employment: https://data-api.globalforestwatch.org/dataset/fao_forestry_employment/v2020/query

FAO Forest Extent: [https://data-api.globalforestwatch.org/dataset/fao_forest_extent/v2020/query](https://data-api.globalforestwatch.org/dataset/fao_forest_extent/v2020/query/json?)

FAO Management Objectives: https://data-api.globalforestwatch.org/dataset/fao_management_objectives/v2020/query

## Demo
![Screenshot 2023-12-29 at 12 41 32](https://github.com/wri/gfw/assets/23243868/236cb108-bc63-4c42-b683-3eb7d6fb52fd)
![Screenshot 2023-12-29 at 12 43 17](https://github.com/wri/gfw/assets/23243868/56b39dde-685a-4180-b371-881d467ea9ba)


## Testing

- Open the [widget](https://gfw-staging-pr-4734.herokuapp.com/dashboards/global/?category=forest-change)
- Select the year range (default 2015-2020)
- Validate data

