### PR TITLE
[FLAG-982] Weekly Fire Alerts wrong date comparison

### DIFF
--- a/components/widgets/utils/data.js
+++ b/components/widgets/utils/data.js
@@ -188,7 +188,7 @@ export const getStatsData = (data, latest) => {
   const lastYear = data.filter(
     (item) =>
       item.year === latestWeek.year() ||
-      (item.week >= latestWeek.isoWeek() && item.year >= latestWeek.year() - 1) // 52 weeks ago, including latestWeek
+      (item.week >= latestWeek.isoWeek() && item.year >= latestWeek.year()) // 52 weeks ago, including latestWeek
   );
 
   const parsedData = lastYear.map((d, i) => {

--- a/components/widgets/utils/data.js
+++ b/components/widgets/utils/data.js
@@ -185,13 +185,13 @@ export const getStatsData = (data, latest) => {
 
   const latestWeek = moment(latest);
 
-  const lastYear = data.filter(
+  const pastTwelveMonths = data.filter(
     (item) =>
       item.year === latestWeek.year() ||
-      (item.week >= latestWeek.isoWeek() && item.year >= latestWeek.year()) // 52 weeks ago, including latestWeek
-  );
+      (item.week >= latestWeek.isoWeek() && item.year === latestWeek.year() - 1)
+  ); // 52 weeks ago, including latestWeek
 
-  const parsedData = lastYear.map((d, i) => {
+  const parsedData = pastTwelveMonths.map((d, i) => {
     const weekMean = (translatedMeans && translatedMeans[i]) || 0;
     const stdDev = (translatedStds && translatedStds[i]) || 0;
 


### PR DESCRIPTION
## Overview

When doing a year comparison for the[ weekly fire alerts widget](https://gfw.global/47ESukX), the selected year or the blue line shows a previous year. For example, 2022 was selected, but 2021 is shown instead. We must ensure that Dec 2022-Dec 2022 is displayed when 2022 is selected. I’m noticing the same pattern for all selected years. 

### Acceptance criteria:

- Check whether the data or just the label is incorrect
- Implement a fix so that the blue label shows a full year (in the example below, should be Dec 2021 - Dec 2022)

## Demo

![Screenshot 2023-12-28 at 15 32 39](https://github.com/wri/gfw/assets/23243868/a1f3bc02-6b85-410e-80b8-a1706a96e700)


## Testing

- Open the [widget](https://gfw-staging-pr-4735.herokuapp.com/dashboards/country/BRA/?category=fires)
- Select the year to compare
- Validate which year appears at year label

