### PR TITLE
fix(rw-api): remove x-api-key from RW API requests

### DIFF
--- a/pages/api/gfw/[...params].js
+++ b/pages/api/gfw/[...params].js
@@ -3,8 +3,6 @@ import httpProxyMiddleware from 'next-http-proxy-middleware';
 import { GFW_API } from 'utils/apis';
 import { PROXIES } from 'utils/proxies';
 
-const GFW_API_KEY = process.env.NEXT_PUBLIC_GFW_API_KEY;
-
 // We never use the `staging-api.resourcewatch.org`
 const GFW_API_URL = GFW_API;
 
@@ -27,9 +25,6 @@ export default (req, res) =>
         replaceStr: '/',
       },
     ],
-    headers: {
-      'x-api-key': GFW_API_KEY,
-    },
     followRedirects: true,
   }).catch(async (error) => {
     res.end(error.message);

--- a/utils/request.js
+++ b/utils/request.js
@@ -27,9 +27,7 @@ const RESOURCE_WATCH_API_URL = RESOURCE_WATCH_API;
 
 // At the moment, the API key is the same
 const GFW_API_KEY = process.env.NEXT_PUBLIC_GFW_API_KEY;
-const GFW_METADATA_API_KEY = GFW_API_KEY;
 const DATA_API_KEY = GFW_API_KEY;
-const RESOURCE_WATCH_API_KEY = GFW_API_KEY;
 
 const isServer = typeof window === 'undefined';
 
@@ -41,9 +39,6 @@ export const apiRequest = create({
   ...defaultRequestConfig,
   ...(isServer && {
     baseURL: GFW_API_URL,
-    headers: {
-      'x-api-key': GFW_API_KEY,
-    },
   }),
   ...(!isServer && {
     baseURL: PROXIES.GFW_API,
@@ -68,9 +63,6 @@ export const metadataRequest = create({
   ...defaultRequestConfig,
   ...(isServer && {
     baseURL: GFW_METADATA_API_URL,
-    headers: {
-      'x-api-key': GFW_METADATA_API_KEY,
-    },
   }),
   ...(!isServer && {
     baseURL: PROXIES.METADATA_API,
@@ -81,9 +73,6 @@ export const rwRequest = create({
   ...defaultRequestConfig,
   ...(isServer && {
     baseURL: RESOURCE_WATCH_API_URL,
-    headers: {
-      'x-api-key': RESOURCE_WATCH_API_KEY,
-    },
   }),
   ...(!isServer && {
     baseURL: PROXIES.RESOURCE_WATCH_API,
@@ -97,7 +86,6 @@ export const apiAuthRequest = create({
     baseURL: GFW_API,
     headers: {
       'content-type': 'application/json',
-      'x-api-key': GFW_API_KEY,
     },
   }),
   ...(!isServer && {


### PR DESCRIPTION
## Overview

RW API now validates Api Key. So for now, we are removing the x-api-key until we have the right value for that.

## Demo

![Screenshot 2024-01-09 at 12 30 52](https://github.com/wri/gfw/assets/23243868/fa6dcd67-9c5f-4e1d-8984-208abcbdf7ab)
![Screenshot 2024-01-09 at 12 31 01](https://github.com/wri/gfw/assets/23243868/15ee917e-8579-47f4-9215-1656315612d1)

