### PR TITLE
FLAG-1038: remove api key from apiRequest function

### DIFF
--- a/utils/request.js
+++ b/utils/request.js
@@ -41,9 +41,6 @@ export const apiRequest = axios.create({
   ...defaultRequestConfig,
   ...(isServer && {
     baseURL: GFW_API_URL,
-    headers: {
-      'x-api-key': GFW_API_KEY,
-    },
   }),
   ...(!isServer && {
     baseURL: PROXIES.GFW_API,


### PR DESCRIPTION
removing api key form `apiRequest` function since it was breaking my gfw areas requests.