### PR TITLE
[FLAG-1016] Priority 1: Update gain layer with 5-year baselines

### DIFF
--- a/components/map/components/legend/components/timeline/index.js
+++ b/components/map/components/legend/components/timeline/index.js
@@ -15,6 +15,8 @@ const mapStateToProps = (
     startDate,
     endDate,
     trimEndDate,
+    step,
+    matchLegend,
     dynamicTimeline,
     ...props
   }
@@ -28,7 +30,8 @@ const mapStateToProps = (
     dynamicTimeline,
   };
   return {
-    marks: getMarks({ dates, dynamicTimeline }),
+    marks: getMarks({ dates, step, matchLegend, dynamicTimeline }),
+    step,
     ...props,
   };
 };

--- a/components/map/components/legend/components/timeline/selectors.js
+++ b/components/map/components/legend/components/timeline/selectors.js
@@ -3,7 +3,15 @@ import moment from 'moment';
 import range from 'lodash/range';
 
 const getDates = (state) => state.dates;
-export const getMarks = createSelector(getDates, (dates) => {
+const getSliderStep = (state) => state.step;
+const getMatchLegend = (state) => state.matchLegend;
+
+const getTicksStep = (numOfYears, sliderStep, matchLegend) => {
+  if (matchLegend && numOfYears && sliderStep) return numOfYears / sliderStep;
+  return (numOfYears > 6 ? 6 : numOfYears);
+}
+
+export const getMarks = createSelector(getDates, getSliderStep, getMatchLegend, (dates, sliderStep, matchLegend) => {
   if (!dates) return null;
   const { minDate, maxDate, dynamicTimeline = false } = dates;
   const numOfYears = moment(maxDate).diff(minDate, 'years');
@@ -12,11 +20,12 @@ export const getMarks = createSelector(getDates, (dates) => {
   if (!numOfYears || maxDays <= 365) return null;
 
   const marks = {};
+  const ticksStep = getTicksStep(numOfYears, sliderStep, matchLegend);
 
   let ticks = range(
     0,
     maxDays + 1,
-    maxDays / (numOfYears > 6 ? 6 : numOfYears)
+    maxDays / ticksStep
   );
 
   if (dynamicTimeline) {

--- a/components/slider/index.js
+++ b/components/slider/index.js
@@ -51,11 +51,17 @@ export class Slider extends PureComponent {
     disableStartHandle: false,
     disableEndHandle: false,
     playing: false,
-    onChange: () => { },
+    onChange: () => {},
   };
 
   renderHandle = (props) => {
-    const { formatValue, showTooltip, playing, disableStartHandle, disableEndHandle } = this.props;
+    const {
+      formatValue,
+      showTooltip,
+      playing,
+      disableStartHandle,
+      disableEndHandle,
+    } = this.props;
     const { value, dragging, index, ...restProps } = props;
     const formattedValue = formatValue ? formatValue(value) : value;
     const tooltipVisible = showTooltip ? showTooltip(index) : false;
@@ -91,8 +97,13 @@ export class Slider extends PureComponent {
     );
   };
 
-  handleOnChange = (newValue) => {
-    const { value, disableStartHandle, disableEndHandle, onChange } = this.props;
+  handleOnChange = (newSliderPositions) => {
+    const {
+      value: sliderPositions,
+      disableStartHandle,
+      disableEndHandle,
+      onChange,
+    } = this.props;
 
     // Both handles are disabled, no possible changes can be made.
     if (disableStartHandle && disableEndHandle) {
@@ -101,23 +112,28 @@ export class Slider extends PureComponent {
 
     // Start handle disabled. We allow trim and end value, but keep the start value the same.
     if (disableStartHandle) {
-      onChange([value[0], newValue[1], newValue[2]])
+      onChange([
+        sliderPositions[0],
+        newSliderPositions[1],
+        newSliderPositions[2],
+      ]);
       return null;
     }
 
     // End handle disabled. We allow the start value, but keep the same trim and end value.
     if (disableEndHandle) {
-      onChange([newValue[0], value[1], value[2]])
+      onChange([newSliderPositions[0], sliderPositions[1], sliderPositions[2]]);
       return null;
     }
 
     // Full functionality, pass the new values along.
-    onChange(newValue);
+    onChange(newSliderPositions);
     return null;
-  }
+  };
 
   render() {
-    const { customClass, range, handleStyle, value, onChange, ...rest } = this.props;
+    const { customClass, range, handleStyle, value, onChange, ...rest } =
+      this.props;
 
     const Component = range ? Range : RCSlider;
     const handleNum = Array.isArray(value) ? value.length : 1;

--- a/components/timestep/index.js
+++ b/components/timestep/index.js
@@ -45,7 +45,7 @@ class Timestep extends PureComponent {
     customClass: null,
     range: true,
     pushable: 0,
-    canPlay: false,
+    canPlay: true,
 
     trim: null,
 

--- a/components/timestep/index.js
+++ b/components/timestep/index.js
@@ -39,6 +39,8 @@ class Timestep extends PureComponent {
     handleOnChange: PropTypes.func,
     handleOnAfterChange: PropTypes.func,
     handleOnPlay: PropTypes.func,
+    disableStartHandle: PropTypes.bool,
+    disableEndHandle: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -75,6 +77,8 @@ class Timestep extends PureComponent {
     handleOnChange: null,
     handleOnAfterChange: null,
     handleOnPlay: null,
+    disableStartHandle: false,
+    disableEndHandle: false,
   };
 
   constructor(props) {
@@ -462,6 +466,8 @@ class Timestep extends PureComponent {
       range,
       pushable,
       PlayButton,
+      disableStartHandle,
+      disableEndHandle,
     } = this.props;
 
     const { playing } = this.state;
@@ -488,6 +494,9 @@ class Timestep extends PureComponent {
             pushable={pushable}
             onChange={this.handleOnChange}
             onAfterChange={this.handleOnAfterChange}
+            disableStartHandle={disableStartHandle}
+            disableEndHandle={disableEndHandle}
+            playing={playing}
           />
         </div>
       </div>

--- a/providers/datasets-provider/actions.js
+++ b/providers/datasets-provider/actions.js
@@ -270,7 +270,6 @@ export const fetchDatasets = createThunkAction(
                               minDate: decodeParams.startDate,
                               maxDate: decodeParams.endDate,
                               trimEndDate: decodeParams.endDate,
-                              canPlay: true,
                             }),
                           },
                         }),

--- a/providers/datasets-provider/config.js
+++ b/providers/datasets-provider/config.js
@@ -55,6 +55,36 @@ const decodes = {
       alpha = 0.;
     }
   `,
+  treeCoverGain5y: `
+  // values for creating power scale, domain (input), and range (output)
+  float domainMin = 0.;
+  float domainMax = 255.;
+  float rangeMin = 0.;
+  float rangeMax = 255.;
+
+  float exponent = zoom < 13. ? 0.3 + (zoom - 3.) / 20. : 1.;
+  float intensity = color.r * 255.;
+
+  // get the min, max, and current values on the power scale
+  float minPow = pow(domainMin, exponent - domainMin);
+  float maxPow = pow(domainMax, exponent);
+  float currentPow = pow(intensity, exponent);
+
+  // get intensity value mapped to range
+  float scaleIntensity = ((currentPow - minPow) / (maxPow - minPow) * (rangeMax - rangeMin)) + rangeMin;
+  // a value between 0 and 255
+  alpha = zoom < 13. ? scaleIntensity / 255. : color.g;
+
+  float year = 1999.0 + ((color.b * 5.) * 255.);
+  // map to years
+  if (year >= startYear && year <= endYear && year >= 2001.) {
+    color.r = 109. / 255.;
+    color.g = (72. - zoom + 109. - 3. * scaleIntensity / zoom) / 255.;
+    color.b = (33. - zoom + 229. - intensity / zoom) / 255.;
+  } else {
+    alpha = 0.;
+  }
+`,
   treeCoverLossFire: `
   // values for creating power scale, domain (input), and range (output)
   float domainMin = 0.;
@@ -1051,6 +1081,7 @@ const decodes = {
 export default {
   treeCover: decodes.treeCover,
   treeCoverLoss: decodes.treeCoverLoss,
+  treeCoverGain5y: decodes.treeCoverGain5y,
   treeCoverLossFire: decodes.treeCoverLossFire,
   treeLossByDriver: decodes.treeLossByDriver,
   integratedAlerts8Bit: decodes.integratedAlerts8Bit,


### PR DESCRIPTION
## IMPORTANT   

This PR is focused on the code implementation (decoding functions, adding FE support for the desired behaviours) that enables this functionality. 

Enabling this functionality is done in the datasets configuration. 

At the moment this can be tested by enabling the _"Tree cover gain (TEST)"_ layer (it is currently defined as a separate one dataset side, `staging`). 

Text and metadata, likewise, is set in the dataset side and not currently up to date, I'm passing the original JIRA task to @AngelArcones. The FE code can be reviewed in advance though. 

## Overview

### Science

A new version Tree Cover Gain is in development, including year encoding with a similar decoding function to Tree Cover Loss. This PR aims to create a new decoding function `treeCoverGain5y` to correctly display this new layer data, adapting the dates (data is only for 5 year intervals) and the color produced.

### Frontend

- `Slider` support changes:  
  - Added options to disable start/end handles  
- `Timestep` component changes:  
  - Added the respective props to support disabling start/end handles in the `Slider` component
    _Timestep is the one we usually call in our map widgets_  
- `Legend`'s `Timeline` component changes:  
  - Added support for defining the `step` size when using the slider
    _this allows us to, when dragging the slider, define the "step size" (eg: years jumped between steps)_  
  - Added support for matching the years displayed in a legend to match the `step`, via `matchLegend` prop  
    _this allows us to match the legend to force the years displayed in the legend to match the slider's step sizes, instead of the default behaviour which may not match (and in this case would default to displaying every 3 years)_

&nbsp;

**FE notes:** 

All new options are defined in a dataset's `timeline_config` options. New options are (as per the description above): 
  - `disableEndHandle` to hide the end handle of a slider  
    _required by the acceptance criteria_
  - `disableStartHandle` to hide the start handle of a slider  
    _not required by the acceptance criteria, but it made sense to add it now, as the changes were a bit tricky due to the use of an old third party library for which is hard to find documentation, and updating it wasn't helping_
  - `step` to set the step size (in this case years) when dragging  the handle  
  - `matchLegend` to match the legend to the step size

&nbsp;
`canPlay` tweaks:  

This one was a bit odd and not part of the acceptance criteria, but I did notice some oddities. It may need to be revised, though the display seems to be correct with the current changes. What I've noticed:  

- `canPlay` seemed to be misplaced when fetching datasets, especially being inside `decodeParams`, and was overriding the prop in the `Timestep` component. 
- I've noticed that for all widgets we have with such a `Timestep` component, the dataset has `canPlay` specified to true. This seems to be the only time we actually do not the play behaviour, so it made sense to default it to `false`. 
  _This would allow the configuration on the dataset side to omit this setting for all widgets, except for this particular one where it is specifically set to `false`. That's why I defaulted it to `true` in the `Timestep component`._

&nbsp;  

Handles behaviors and oddities:  

In order to display a slider, we are using the `RCSlider` third party library, an old version at that. Because we want to hide certain handles (start handle in this case) I had a quick look at updating the library, but the changes looked to be a bit too extensive and risky. I don't think it'd give us the option to do this either way, although the documentation for this library is hard to track down (especially when looking at specific versions). 

I've opted to use the existing setup but "tweak it" in order to force it to fulfill the acceptance criteria. This came in two parts:  

Handles display:  
- In the `Slider` component, where we define the handles styles, we decide whether to render the handle or not. 
- Still in the `Slider` component, and because this seems to be the first widget of its type that does not have the "play" function, I've made a tweak to hide the "playing" vertical bar that displays on top of the slider  

Slider behaviour: 
Although we hid the handles, RCSlider's behaviour of the handles still extends to when the user click the track, whether the handles are being displayed or not. For this reason we're also using the `onChange` callback, to disable the behaviours of the clicking the track depending on which (if any, or both) handle is hidden.   

Note:  
Dragging handles _can_ display a little weird behaviour at times, but it's not due to this implementation. It seems to be just how the third party library works. We may want to address this in the future, though I don't think it'd be necessary unless we have had reports of users finding the sliders hard to use. 

## Relevant tickets  

[FLAG-1016](https://gfw.atlassian.net/browse/FLAG-1016)


[FLAG-1016]: https://gfw.atlassian.net/browse/FLAG-1016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ