### PR TITLE
FLAG-1014: Change main subscribe form and PTW to use Ortto instead of Pardot

### DIFF
--- a/components/forms/components/field-wrapper/styles.scss
+++ b/components/forms/components/field-wrapper/styles.scss
@@ -41,6 +41,10 @@
 
   .input-field {
     width: 100%;
+
+    .input-field-description {
+      font-style: italic;
+    }
   }
 
   &.hidden {

--- a/components/forms/components/select/component.jsx
+++ b/components/forms/components/select/component.jsx
@@ -74,7 +74,7 @@ class Select extends PureComponent {
               </p>
             )}
             {description && (
-              <p>{description}</p>
+              <p className="input-field-description">{description}</p>
             )}
             <select
               className={cx('c-form-select', { multiple })}

--- a/components/forms/components/select/component.jsx
+++ b/components/forms/components/select/component.jsx
@@ -22,6 +22,7 @@ class Select extends PureComponent {
     required: PropTypes.bool,
     multiple: PropTypes.bool,
     selectInput: PropTypes.bool,
+    description: PropTypes.string,
   };
 
   render() {
@@ -35,6 +36,7 @@ class Select extends PureComponent {
       required,
       multiple,
       selectInput,
+      description,
     } = this.props;
 
     const parsedOptions =
@@ -70,6 +72,9 @@ class Select extends PureComponent {
                 Select all that apply; select multiple by holding
                 shift/selecting other options.
               </p>
+            )}
+            {description && (
+              <p>{description}</p>
             )}
             <select
               className={cx('c-form-select', { multiple })}

--- a/components/forms/newsletter/component.jsx
+++ b/components/forms/newsletter/component.jsx
@@ -151,10 +151,11 @@ class NewsletterForm extends PureComponent {
                     placeholder="Select a sector"
                     required
                   />
-                  <Checkbox
+                  <Select
                     name="interest"
                     label="I'm interested in (check all that apply)"
                     options={interestsOptions}
+                    multiple
                   />
                   <Error
                     valid={valid}

--- a/components/forms/newsletter/component.jsx
+++ b/components/forms/newsletter/component.jsx
@@ -15,6 +15,20 @@ import Error from 'components/forms/components/error';
 
 import { email as validateEmail } from 'components/forms/validations';
 
+const sectors = [
+  "Government",
+  "Donor Institution/Agency",
+  "Local NGO (National or Subnational)",
+  "International NGO",
+  "UN or International Organization",
+  "Academic/Research Organization",
+  "Journalist/Media Organization",
+  "Indigenous or Community-Based Organization",
+  "Private Sector",
+  "No Affiliation",
+  "Other"
+];
+
 const subscriptions = [
   { label: 'Innovations in Monitoring', value: 'monitoring' },
   { label: 'Fires', value: 'fires' },
@@ -39,6 +53,7 @@ class NewsletterForm extends PureComponent {
       organization,
       city,
       country,
+      sector,
       comments,
       gfwInterests,
     } = values;
@@ -51,6 +66,7 @@ class NewsletterForm extends PureComponent {
       company: organization,
       city,
       country,
+      sector,
       gfw_interests: gfwInterests,
       pardot_extra_field: comments,
     };
@@ -72,6 +88,7 @@ class NewsletterForm extends PureComponent {
     const { countries, initialValues } = this.props;
 
     const countriesOptions = countries.map(({ label }) => ({ label, value: label }));
+    const sectorsOptions = sectors.map((sector) => ({ label: sector, value: sector }));
 
     return (
       <Fragment>
@@ -117,6 +134,13 @@ class NewsletterForm extends PureComponent {
                     label="country"
                     options={countriesOptions}
                     placeholder="Select a country"
+                    required
+                  />
+                  <Select
+                    name="sector"
+                    label="sector"
+                    options={sectorsOptions}
+                    placeholder="Select a sector"
                     required
                   />
                   <Checkbox

--- a/components/forms/newsletter/component.jsx
+++ b/components/forms/newsletter/component.jsx
@@ -8,7 +8,6 @@ import { submitNewsletterSubscription } from 'services/forms';
 import CountryDataProvider from 'providers/country-data-provider';
 import Input from 'components/forms/components/input';
 import Select from 'components/forms/components/select';
-import Checkbox from 'components/forms/components/checkbox';
 import Submit from 'components/forms/components/submit';
 import SuccessMessage from 'components/success-message';
 import Error from 'components/forms/components/error';

--- a/components/forms/newsletter/component.jsx
+++ b/components/forms/newsletter/component.jsx
@@ -114,7 +114,7 @@ class NewsletterForm extends PureComponent {
                   <Input name="lastName" label="last name" required />
                   <Input name="jobTitle" label="job title" />
                   <Input name="organization" label="organization" required />
-                  <Input name="city" label="city" required />
+                  <Input name="city" label="city" />
                   <Select
                     name="country"
                     label="country"

--- a/components/forms/newsletter/component.jsx
+++ b/components/forms/newsletter/component.jsx
@@ -131,8 +131,8 @@ class NewsletterForm extends PureComponent {
             <form className="c-newsletter-form" onSubmit={handleSubmit}>
               {submitSucceeded ? (
                 <SuccessMessage
-                  title="Thank you for subscribing to Global Forest Watch newsletters and updates!"
-                  description="You may wish to read our <a href='/privacy-policy' target='_blank'>privacy policy</a>, which provides further information about how we use personal data."
+                  title="Thank you!<br />You aren't done yet."
+                  description="<p>Please check your inbox for an email<br /> and click the button to confirm your subscription.</p><p>You may wish to read our <a href='/privacy-policy' target='_blank'>privacy policy</a>, which provides further information about how we use personal data.</p>"
                 />
               ) : (
                 <Fragment>

--- a/components/forms/newsletter/component.jsx
+++ b/components/forms/newsletter/component.jsx
@@ -171,12 +171,12 @@ class NewsletterForm extends PureComponent {
                   <Select
                     name="interest"
                     label="Preferred Language"
+                    description="Please note that most communications will be sent in English."
                     options={preferredLanguageOptions}
                   />
                   <Select
                     name="interest"
                     label="I'm interested in"
-                    description="Please note that most communications will be sent in English."
                     options={interestsOptions}
                     multiple
                   />

--- a/components/forms/newsletter/component.jsx
+++ b/components/forms/newsletter/component.jsx
@@ -13,6 +13,7 @@ import SuccessMessage from 'components/success-message';
 import Error from 'components/forms/components/error';
 
 import { email as validateEmail } from 'components/forms/validations';
+import Checkbox from '../components/checkbox/component';
 
 const sectors = [
   'Government',
@@ -180,11 +181,10 @@ class NewsletterForm extends PureComponent {
                     placeholder="Select a preferred language"
                     options={preferredLanguageOptions}
                   />
-                  <Select
+                  <Checkbox
                     name="interest"
                     label="I'm interested in"
                     options={interestsOptions}
-                    multiple
                   />
                   <Error
                     valid={valid}

--- a/components/forms/newsletter/component.jsx
+++ b/components/forms/newsletter/component.jsx
@@ -180,6 +180,7 @@ class NewsletterForm extends PureComponent {
                     name="language"
                     label="Preferred Language"
                     description="Please note that most communications will be sent in English."
+                    placeholder="Select a preferred language"
                     options={preferredLanguageOptions}
                   />
                   <Select

--- a/components/forms/newsletter/component.jsx
+++ b/components/forms/newsletter/component.jsx
@@ -171,6 +171,7 @@ class NewsletterForm extends PureComponent {
                   <Select
                     name="interest"
                     label="I'm interested in"
+                    description="Please note that most communications will be sent in English."
                     options={interestsOptions}
                     multiple
                   />

--- a/components/forms/newsletter/component.jsx
+++ b/components/forms/newsletter/component.jsx
@@ -113,7 +113,7 @@ class NewsletterForm extends PureComponent {
                   <Input name="firstName" label="first name" required />
                   <Input name="lastName" label="last name" required />
                   <Input name="jobTitle" label="job title" />
-                  <Input name="organization" label="organization" />
+                  <Input name="organization" label="organization" required />
                   <Input name="city" label="city" required />
                   <Select
                     name="country"

--- a/components/forms/newsletter/component.jsx
+++ b/components/forms/newsletter/component.jsx
@@ -69,6 +69,7 @@ class NewsletterForm extends PureComponent {
       city,
       country,
       sector,
+      language,
       interest,
     } = values;
 
@@ -81,6 +82,7 @@ class NewsletterForm extends PureComponent {
       city,
       country,
       sector,
+      language,
       interest,
       person_source_details: 'https://www.globalforestwatch.org',
       ip_address: ipAddress,
@@ -175,7 +177,7 @@ class NewsletterForm extends PureComponent {
                     required
                   />
                   <Select
-                    name="interest"
+                    name="language"
                     label="Preferred Language"
                     description="Please note that most communications will be sent in English."
                     options={preferredLanguageOptions}

--- a/components/forms/newsletter/component.jsx
+++ b/components/forms/newsletter/component.jsx
@@ -73,11 +73,11 @@ class NewsletterForm extends PureComponent {
       first_name: firstName,
       last_name: lastName,
       job_title: jobTitle,
-      company: organization,
+      organization,
       city,
       country,
-      sectors: sector,
-      interests: interest,
+      sector,
+      interest,
     };
 
     return submitNewsletterSubscription(postData)

--- a/components/forms/newsletter/component.jsx
+++ b/components/forms/newsletter/component.jsx
@@ -32,9 +32,9 @@ class NewsletterForm extends PureComponent {
 
   saveNewsletterSubscription = (values) => {
     const {
+      email,
       firstName,
       lastName,
-      email,
       organization,
       city,
       country,
@@ -43,9 +43,9 @@ class NewsletterForm extends PureComponent {
     } = values;
 
     const postData = {
+      email,
       first_name: firstName,
       last_name: lastName,
-      email,
       company: organization,
       city,
       country,
@@ -100,8 +100,6 @@ class NewsletterForm extends PureComponent {
                     Subscribe to monthly GFW newsletters and updates based on
                     your interests.
                   </h3>
-                  <Input name="firstName" label="first name" required />
-                  <Input name="lastName" label="last name" required />
                   <Input
                     name="email"
                     type="email"
@@ -110,6 +108,8 @@ class NewsletterForm extends PureComponent {
                     validate={[validateEmail]}
                     required
                   />
+                  <Input name="firstName" label="first name" required />
+                  <Input name="lastName" label="last name" required />
                   <Input name="organization" label="organization" />
                   <Input name="city" label="city" required />
                   <Select

--- a/components/forms/newsletter/component.jsx
+++ b/components/forms/newsletter/component.jsx
@@ -29,6 +29,14 @@ const sectors = [
   "Other"
 ];
 
+const preferredLanguages = [
+  "English",
+  "Français",
+  "Español",
+  "Português",
+  "Bahasa Indonesia"
+];
+
 const interests = [
   "Innovations in Monitoring",
   "Fires",
@@ -97,6 +105,10 @@ class NewsletterForm extends PureComponent {
       label: interest,
       value: interest,
     }));
+    const preferredLanguageOptions = preferredLanguages.map((preferredLanguage) => ({
+      label: preferredLanguage,
+      value: preferredLanguage,
+    }));
 
     return (
       <Fragment>
@@ -153,7 +165,12 @@ class NewsletterForm extends PureComponent {
                   />
                   <Select
                     name="interest"
-                    label="I'm interested in (check all that apply)"
+                    label="Preferred Language"
+                    options={preferredLanguageOptions}
+                  />
+                  <Select
+                    name="interest"
+                    label="I'm interested in"
                     options={interestsOptions}
                     multiple
                   />

--- a/components/forms/newsletter/component.jsx
+++ b/components/forms/newsletter/component.jsx
@@ -82,7 +82,7 @@ class NewsletterForm extends PureComponent {
       city,
       country,
       sector,
-      language,
+      preferred_language: language,
       interest,
       person_source_details: 'https://www.globalforestwatch.org',
       ip_address: ipAddress,

--- a/components/forms/newsletter/component.jsx
+++ b/components/forms/newsletter/component.jsx
@@ -51,12 +51,7 @@ class NewsletterForm extends PureComponent {
       company: organization,
       city,
       country,
-      gfw_interests: gfwInterests
-        ? Object.entries(gfwInterests)
-            .filter(([, val]) => val)
-            .map(([key]) => key)
-            .join(', ')
-        : '',
+      gfw_interests: gfwInterests,
       pardot_extra_field: comments,
     };
 

--- a/components/forms/newsletter/component.jsx
+++ b/components/forms/newsletter/component.jsx
@@ -29,11 +29,11 @@ const sectors = [
 ];
 
 const preferredLanguages = [
-  'English',
-  'Français',
-  'Español',
-  'Português',
-  'Bahasa Indonesia',
+  { label: 'English', value :'EN' },
+  { label: 'Français', value: 'FE' },
+  { label: 'Español', value: 'es' },
+  { label: 'Português', value: 'PT' },
+  { label: 'Bahasa Indonesia', value: 'ID' },
 ];
 
 const interests = [
@@ -117,10 +117,7 @@ class NewsletterForm extends PureComponent {
       value: interest,
     }));
     const preferredLanguageOptions = preferredLanguages.map(
-      (preferredLanguage) => ({
-        label: preferredLanguage,
-        value: preferredLanguage,
-      })
+      ({ label, value }) => ({ label, value })
     );
 
     return (

--- a/components/forms/newsletter/component.jsx
+++ b/components/forms/newsletter/component.jsx
@@ -29,13 +29,17 @@ const sectors = [
   "Other"
 ];
 
-const subscriptions = [
-  { label: 'Innovations in Monitoring', value: 'monitoring' },
-  { label: 'Fires', value: 'fires' },
-  { label: 'Forest Watcher Mobile App', value: 'fwapp' },
-  { label: 'Climate and Biodiversity', value: 'climate' },
-  { label: 'Agricultural Supply Chains', value: 'supplychains' },
-  { label: 'Small Grants Fund and Tech Fellowship', value: 'sgf' },
+const interests = [
+  "Innovations in Monitoring",
+  "Fires",
+  "Forest Watcher Mobile App",
+  "Climate and Carbon",
+  "Biodiversity",
+  "Agricultural Supply Chains",
+  "Small Grants Fund and Tech Fellowship",
+  "Landscape Restoration",
+  "GFW Users in Action",
+  "Places to Watch alerts",
 ];
 
 class NewsletterForm extends PureComponent {
@@ -55,7 +59,7 @@ class NewsletterForm extends PureComponent {
       country,
       sector,
       comments,
-      gfwInterests,
+      interest,
     } = values;
 
     const postData = {
@@ -66,8 +70,8 @@ class NewsletterForm extends PureComponent {
       company: organization,
       city,
       country,
-      sector,
-      gfw_interests: gfwInterests,
+      sectors: sector,
+      interests: interest,
       pardot_extra_field: comments,
     };
 
@@ -89,6 +93,10 @@ class NewsletterForm extends PureComponent {
 
     const countriesOptions = countries.map(({ label }) => ({ label, value: label }));
     const sectorsOptions = sectors.map((sector) => ({ label: sector, value: sector }));
+    const interestsOptions = interests.map((interest) => ({
+      label: interest,
+      value: interest,
+    }));
 
     return (
       <Fragment>
@@ -144,9 +152,9 @@ class NewsletterForm extends PureComponent {
                     required
                   />
                   <Checkbox
-                    name="gfwInterests"
+                    name="interest"
                     label="I'm interested in (check all that apply)"
-                    options={subscriptions}
+                    options={interestsOptions}
                   />
                   <Error
                     valid={valid}

--- a/components/forms/newsletter/component.jsx
+++ b/components/forms/newsletter/component.jsx
@@ -35,6 +35,7 @@ class NewsletterForm extends PureComponent {
       email,
       firstName,
       lastName,
+      jobTitle,
       organization,
       city,
       country,
@@ -46,6 +47,7 @@ class NewsletterForm extends PureComponent {
       email,
       first_name: firstName,
       last_name: lastName,
+      job_title: jobTitle,
       company: organization,
       city,
       country,
@@ -110,6 +112,7 @@ class NewsletterForm extends PureComponent {
                   />
                   <Input name="firstName" label="first name" required />
                   <Input name="lastName" label="last name" required />
+                  <Input name="jobTitle" label="job title" />
                   <Input name="organization" label="organization" />
                   <Input name="city" label="city" required />
                   <Select

--- a/components/forms/newsletter/component.jsx
+++ b/components/forms/newsletter/component.jsx
@@ -78,6 +78,7 @@ class NewsletterForm extends PureComponent {
       country,
       sector,
       interest,
+      person_source_details: 'https://www.globalforestwatch.org',
     };
 
     return submitNewsletterSubscription(postData)

--- a/components/forms/newsletter/component.jsx
+++ b/components/forms/newsletter/component.jsx
@@ -55,7 +55,11 @@ class NewsletterForm extends PureComponent {
     initialValues: PropTypes.object,
   };
 
-  saveNewsletterSubscription = (values) => {
+  saveNewsletterSubscription = async (values) => {
+    const ipAddress = await fetch('https://api.ipify.org/?format=json')
+      .then((response) => response.json())
+      .then((data) => data?.ip);
+
     const {
       email,
       firstName,
@@ -79,6 +83,7 @@ class NewsletterForm extends PureComponent {
       sector,
       interest,
       person_source_details: 'https://www.globalforestwatch.org',
+      ip_address: ipAddress,
     };
 
     return submitNewsletterSubscription(postData)

--- a/components/forms/newsletter/component.jsx
+++ b/components/forms/newsletter/component.jsx
@@ -15,38 +15,38 @@ import Error from 'components/forms/components/error';
 import { email as validateEmail } from 'components/forms/validations';
 
 const sectors = [
-  "Government",
-  "Donor Institution/Agency",
-  "Local NGO (National or Subnational)",
-  "International NGO",
-  "UN or International Organization",
-  "Academic/Research Organization",
-  "Journalist/Media Organization",
-  "Indigenous or Community-Based Organization",
-  "Private Sector",
-  "No Affiliation",
-  "Other"
+  'Government',
+  'Donor Institution/Agency',
+  'Local NGO (National or Subnational)',
+  'International NGO',
+  'UN or International Organization',
+  'Academic/Research Organization',
+  'Journalist/Media Organization',
+  'Indigenous or Community-Based Organization',
+  'Private Sector',
+  'No Affiliation',
+  'Other',
 ];
 
 const preferredLanguages = [
-  "English",
-  "Français",
-  "Español",
-  "Português",
-  "Bahasa Indonesia"
+  'English',
+  'Français',
+  'Español',
+  'Português',
+  'Bahasa Indonesia',
 ];
 
 const interests = [
-  "Innovations in Monitoring",
-  "Fires",
-  "Forest Watcher Mobile App",
-  "Climate and Carbon",
-  "Biodiversity",
-  "Agricultural Supply Chains",
-  "Small Grants Fund and Tech Fellowship",
-  "Landscape Restoration",
-  "GFW Users in Action",
-  "Places to Watch alerts",
+  'Innovations in Monitoring',
+  'Fires',
+  'Forest Watcher Mobile App',
+  'Climate and Carbon',
+  'Biodiversity',
+  'Agricultural Supply Chains',
+  'Small Grants Fund and Tech Fellowship',
+  'Landscape Restoration',
+  'GFW Users in Action',
+  'Places to Watch alerts',
 ];
 
 class NewsletterForm extends PureComponent {
@@ -65,7 +65,6 @@ class NewsletterForm extends PureComponent {
       city,
       country,
       sector,
-      comments,
       interest,
     } = values;
 
@@ -79,7 +78,6 @@ class NewsletterForm extends PureComponent {
       country,
       sectors: sector,
       interests: interest,
-      pardot_extra_field: comments,
     };
 
     return submitNewsletterSubscription(postData)
@@ -98,16 +96,24 @@ class NewsletterForm extends PureComponent {
   render() {
     const { countries, initialValues } = this.props;
 
-    const countriesOptions = countries.map(({ label }) => ({ label, value: label }));
-    const sectorsOptions = sectors.map((sector) => ({ label: sector, value: sector }));
+    const countriesOptions = countries.map(({ label }) => ({
+      label,
+      value: label,
+    }));
+    const sectorsOptions = sectors.map((sector) => ({
+      label: sector,
+      value: sector,
+    }));
     const interestsOptions = interests.map((interest) => ({
       label: interest,
       value: interest,
     }));
-    const preferredLanguageOptions = preferredLanguages.map((preferredLanguage) => ({
-      label: preferredLanguage,
-      value: preferredLanguage,
-    }));
+    const preferredLanguageOptions = preferredLanguages.map(
+      (preferredLanguage) => ({
+        label: preferredLanguage,
+        value: preferredLanguage,
+      })
+    );
 
     return (
       <Fragment>

--- a/components/forms/newsletter/component.jsx
+++ b/components/forms/newsletter/component.jsx
@@ -71,6 +71,8 @@ class NewsletterForm extends PureComponent {
   render() {
     const { countries, initialValues } = this.props;
 
+    const countriesOptions = countries.map(({ label }) => ({ label, value: label }));
+
     return (
       <Fragment>
         <Form
@@ -113,7 +115,7 @@ class NewsletterForm extends PureComponent {
                   <Select
                     name="country"
                     label="country"
-                    options={countries}
+                    options={countriesOptions}
                     placeholder="Select a country"
                     required
                   />

--- a/components/forms/newsletter/component.jsx
+++ b/components/forms/newsletter/component.jsx
@@ -30,11 +30,11 @@ const sectors = [
 ];
 
 const preferredLanguages = [
-  { label: 'English', value :'EN' },
-  { label: 'Français', value: 'FE' },
+  { label: 'English', value: 'en' },
+  { label: 'Français', value: 'fr' },
   { label: 'Español', value: 'es' },
-  { label: 'Português', value: 'PT' },
-  { label: 'Bahasa Indonesia', value: 'ID' },
+  { label: 'Português', value: 'pt' },
+  { label: 'Bahasa Indonesia', value: 'id' },
 ];
 
 const interests = [

--- a/components/map-menu/components/sections/explore/sections.js
+++ b/components/map-menu/components/sections/explore/sections.js
@@ -44,7 +44,7 @@ import {
 export const descriptions = {
   topics: 'Explore data related to the drivers and impacts of forest change.',
   placesToWatch:
-    'Explore areas of recent forest loss that pose the biggest threat to the world’s remaining forests. Updated monthly. Sign up <a href="https://connect.wri.org/l/120942/2017-12-07/3mtt5w" target="_blank" rel="noopener nofollower">here</a> to receive an email when new Places to Watch are identified.',
+    'Explore areas of recent forest loss that pose the biggest threat to the world’s remaining forests. Updated monthly. <a href="https://www.globalforestwatch.org/subscribe" target="_blank" rel="noopener nofollower">Sign up here</a> to receive an email when new Places to Watch are identified.',
 };
 
 export const stories = {

--- a/components/success-message/component.jsx
+++ b/components/success-message/component.jsx
@@ -16,10 +16,10 @@ class Thankyou extends PureComponent {
     return (
       <div className="c-success-message">
         <img src={treeImage} alt="success-tree" />
-        <h1>{title}</h1>
+        <h1>{ReactHtmlParser(title)}</h1>
         {description && (
           <>
-            {description.includes('<p>') ? (
+            {description.includes("<p>") ? (
               ReactHtmlParser(description)
             ) : (
               <p>{ReactHtmlParser(description)}</p>

--- a/services/forms.js
+++ b/services/forms.js
@@ -9,5 +9,5 @@ export const submitNewsletterSubscription = (data) =>
     method: 'POST',
     data: qs.stringify(data),
     headers: { 'content-type': 'application/x-www-form-urlencoded' },
-    url: 'https://connect.wri.org/l/120942/2019-07-18/4d6vw2',
+    url: 'https://ortto.wri.org/custom-forms/gfw/',
   });


### PR DESCRIPTION
## Overview

**In this PR:**  
- Add/change/reorder fields in the `/subscribe` form  
- `interests` is now sent as an array of interests, instead of a string with comma separated positions  
- Updated the form handler link to the new one  
- Updated message displayed after the user successfully submits the form  
- Added the possibility to add descriptions to the select input  
- Removed an unused pardot extra field  
- The _"Places to Watch"_ link now points to this subscribe form  

## Feature relevant tickets

[FLAG-1014](https://gfw.atlassian.net/browse/FLAG-1014)