### PR TITLE
[FLAG-1012] Update privacy policy language

### DIFF
--- a/layouts/privacy-policy/component.jsx
+++ b/layouts/privacy-policy/component.jsx
@@ -8,9 +8,9 @@ const PrivacyPolicyPage = () => (
       <Column width={[1, 1 / 12]} />
       <Column width={[1, 5 / 6]}>
         <div className="privacy-container">
-          <h1>World Resources Institute - Privacy Policy</h1>
           <div>
-            <i>Effective date: March 1, 2022</i>
+            <h1>World Resources Institute - Privacy Policy</h1>
+            <i>Last revised: October 30, 2023</i>
             <p>
               We are World Resources Institute, a global research nonprofit
               headquartered at 10 G Street NE Suite 800, Washington, D.C. 20002,
@@ -20,9 +20,8 @@ const PrivacyPolicyPage = () => (
             <p>
               Our organization and network of affiliates spans more than 50
               countries. You may interact with WRI online through various
-              websites, applications (including the TerraMatch and Forest
-              Watcher apps), emails, social media pages and other online
-              services (collectively, “Services”).
+              websites, applications, emails, social media pages and other
+              online services (collectively, “Services”).
             </p>
             <p>
               For each of these Services, this Privacy Policy tells you what to
@@ -41,79 +40,60 @@ const PrivacyPolicyPage = () => (
             <p>
               <b>
                 Donor privacy: WRI and its affiliates do not sell, share, or
-                trade donors&apos; names or personal information with other
-                entities or send mailingson behalf of other organizations.
-              </b>{' '}
+                trade donors&apos; names or identifying personal information
+                with other entities or send mailings on behalf of other
+                organizations.
+              </b>{" "}
               With your permission, on occasion, we may share information with
               related organizations in connection with a particular project or
               campaign you are interested in. For example, if we are co-hosting
               an event with a partner organization and you sign up to attend
               that event, we may ask your permission to share your contact
-              details with our partner.{' '}
+              details with our partner.{" "}
               <a
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 href="https://www.wri.org/donate/donor-privacy-policy"
               >
                 See our Donor Privacy Policy.
               </a>
             </p>
           </div>
+
           <div>
-            <h2>Personal information we collect</h2>
+            <h2>Personal Information We Collect</h2>
             <p>
               We collect different kinds of information from you, depending on
               how you interact with us.
             </p>
-
             <p>
-              Online collection: We collect personal information from you when
-              you register to receive email communications, make donations,
+              <b>Online collection:</b> We collect personal information from you
+              when you register to receive email communications, make donations,
               apply for jobs, send email inquiries, register for events, or
               participate in other parts of our Services.
             </p>
-
             <p>
               Depending on the Services you interact with, the information
               collected may vary and may include, for example:
             </p>
-
             <ul>
               <li>
-                Identifiers and contact details you choose to provide, such as
-                your name and email address;
-              </li>
-              <li>
-                Emails, messages, posts, and other communications and
-                information you choose to share via email or over social media;
-              </li>
-              <li>Payment information;</li>
-              <li>
-                Location information: WRI rarely collects location information
-                about you. In some cases, we may ask for information about your
-                location for limited purposes. For example, users of the
-                TerraMatch application may enable collection of geolocation
-                information on their mobile devices in order to map the
-                boundaries of a proposed tree planting project. The Forest
-                Watcher application geotags user field reports and users may
-                also enable GPS tracking to record their traveled route. This
-                location data collected on TerraMatch and Forest Watcher is not
-                used for any other purpose or shared with or sold to third
-                parties;
-              </li>
-              <li>
-                Educational and employment information (such as your resume or
-                C.V.) that you may provide if you apply for a job at WRI;
-              </li>
-              <li>
                 Automatically collected information: We and our third-party
-                service providers may collect information about your interaction
-                with our Services using cookies and similar automatic
-                data-collection technology. We use this information to improve
-                and maintain our Services, collect aggregate site usage reports
-                that do not identify you individually, and to optimize site
-                users&apos; experience on the Services. The information we
-                collect includes:
+                service providers may collect information about you and/or your
+                interaction with our Services using cookies and similar
+                automatic data-collection technology. For example, if you browse
+                our website, click on links, or enter search terms, we may use
+                that information. We use this type of information and share it
+                with service providers to improve and maintain our Services,
+                collect aggregate site usage reports that do not identify you
+                individually, optimize site users’ experience on the Services,
+                and for marketing purposes.{" "}
+                <b>
+                  Please use the “Manage Cookie Preferences” link and the List
+                  of Cookies below if you wish to learn more and control which
+                  cookies and third-party technology are in use on the site.
+                </b>{" "}
+                The information we collect includes:
                 <ul>
                   <li>
                     Identifiers like IP address and device and browser
@@ -121,27 +101,63 @@ const PrivacyPolicyPage = () => (
                   </li>
                   <li>
                     Website and application activity information like clicks,
-                    content and page views, internet service provider, browser
-                    version, domain type.
+                    content and page views, search terms, internet service
+                    provider, browser version, domain type.
                   </li>
                 </ul>
               </li>
               <li>
                 Anonymous or aggregated information: We may use aggregate or
-                deidentified data that doesn&apos;t identify you for any lawful
+                deidentified data that doesn’t identify you for any lawful
                 business purpose.
+              </li>
+              <li>
+                Identifiers and contact details you choose to provide, such as
+                your name, organization, email address, and country of
+                residence.
+              </li>
+              <li>
+                Emails, messages, posts, and other communications and
+                information you choose to share via email or over social media;
+              </li>
+              <li>Payment information;</li>
+              <li>
+                Location information:{" "}
+                <b>
+                  WRI rarely collects specific location information about you.
+                </b>{" "}
+                In some cases, we may ask for information about your location
+                for limited purposes. For example,{" "}
+                <b>users of the TerraMatch application</b> may enable collection
+                of geolocation information on their mobile devices in order to
+                map the boundaries of a proposed tree planting project. This
+                location data collected on TerraMatch is not used for any other
+                purpose or shared with or sold to third parties;
+              </li>
+              <li>
+                Educational and employment information (such as your resume or
+                C.V.) that you may provide if you apply for a job at WRI;
               </li>
             </ul>
             <p>
+              <a href="#" onClick={(e) => e.preventDefault()}>
+                Manage Cookie Preferences
+              </a>{" "}
+              (some privacy tools or ad blockers might prevent this tool from
+              running).
+            </p>
+            <p>
               Offline collection: We also collect personal information from you
-              when you provide us with it at conferences or similar events. Such
-              personal information will typically consist of your organizational
-              or personal contact details, donation information, or other
-              information you choose to give us.
+              when you provide us with it at conferences or similar events or
+              otherwise interact with us offline. Such personal information will
+              typically consist of your organizational or personal contact
+              details, donation information, or other information you choose to
+              give us.
             </p>
           </div>
+
           <div>
-            <h2>Our use of your information</h2>
+            <h2>Our Use of Your Information</h2>
             <p>
               We use the personal information we collect about you for any of
               the following purposes:
@@ -164,6 +180,10 @@ const PrivacyPolicyPage = () => (
               </li>
               <li>responding to your inquiries and requests;</li>
               <li>
+                personalizing your website experience and delivering related ads
+                on third-party sites;
+              </li>
+              <li>
                 generating anonymous reports about use of our Services and their
                 features;
               </li>
@@ -182,6 +202,7 @@ const PrivacyPolicyPage = () => (
               </li>
             </ul>
           </div>
+
           <div>
             <h2>Outreach and Communications</h2>
             <p>
@@ -194,22 +215,32 @@ const PrivacyPolicyPage = () => (
             <ul>
               <li>email;</li>
               <li>phone;</li>
-              <li>social media messages;</li>
+              <li>short message service (SMS);</li>
+              <li>social media messages; and</li>
               <li>
-                and any other medium which becomes relevant from time to time.
+                any other medium which becomes relevant from time to time.
               </li>
             </ul>
             <p>
               You can opt-out of receiving communications from WRI at any time
-              by writing to us at privacy@wri.org or by following the
-              unsubscribe instructions in our communications. However, we may
-              still need to contact you for important administrative reasons,
-              such as in the event of a material change to our Services, related
-              policies, or accounts you create with us.
+              by writing to us at{" "}
+              <a
+                href="mailto:privacy@wri.org"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                privacy@wri.org
+              </a>{" "}
+              or by following the unsubscribe instructions in our
+              communications. However, we may still need to contact you for
+              important administrative reasons, such as in the event of a
+              material change to our Services, related policies, or accounts you
+              create with us.
             </p>
           </div>
+
           <div>
-            <h2>Disclosure of information</h2>
+            <h2>Disclosure of Information</h2>
             <p>Personal information is disclosed to the following parties:</p>
             <ul>
               <li>
@@ -245,23 +276,16 @@ const PrivacyPolicyPage = () => (
               </li>
             </ul>
             <p>
-              We also disclose non-private, aggregate or otherwise non-personal
-              information to third parties, including social media companies
-              like Facebook and Twitter for outreach purposes.
-            </p>
-            <p>
-              We take reasonable steps to ensure that any personal information
-              about you that we pass to a service provider or other third party
-              will be held securely by that party and only be used for the
-              purposes for which it was provided to them. Except as noted above,
-              information we collect from WRI website visitors will not be
-              shared with individuals or other companies unrelated to WRI, or
-              that do not perform a business, professional or technical function
-              for WRI.
+              We also may disclose online information about you to third
+              parties, including social media companies like Facebook, Google,
+              LinkedIn (Microsoft) and X for outreach and marketing purposes.{" "}
+              See the <b>“Manage Cookie Preferences”</b> link above to adjust
+              your relevant settings.
             </p>
           </div>
+
           <div>
-            <h2>Security and quality</h2>
+            <h2>Security and Quality</h2>
             <p>
               WRI takes reasonable steps to protect the personal information
               that you provide. We use a variety of security technologies and
@@ -289,13 +313,14 @@ const PrivacyPolicyPage = () => (
               risk.
             </p>
           </div>
+
           <div>
             <h2>Transfers</h2>
             <p>
               Where necessary, we may need to transfer your personal information
               to another country. These transfers can take place within the WRI
               group but also may be made to selected third parties (as explained
-              in the <b>Disclosure of information</b> section of this Privacy
+              in the ‘<u>Disclosure of information</u>‘ section of this Privacy
               Policy). Such transfers take place to enable us to provide you
               with our services and/or to communicate with you. Countries that
               we transfer your personal information to may not have the same
@@ -303,8 +328,9 @@ const PrivacyPolicyPage = () => (
               in.
             </p>
           </div>
+
           <div>
-            <h2>Links to external websites</h2>
+            <h2>Links to External Websites</h2>
             <p>
               WRI&apos;s Services may contain links to other websites belonging
               to third parties. These websites are not covered by this Privacy
@@ -314,8 +340,9 @@ const PrivacyPolicyPage = () => (
               read the privacy statements of other websites.
             </p>
           </div>
+
           <div>
-            <h2>Personal information access and deletion</h2>
+            <h2>Personal information Access and Deletion</h2>
             <p>
               You may request a copy of the personal information we hold about
               you and to have any inaccuracies corrected. You may also request
@@ -324,11 +351,17 @@ const PrivacyPolicyPage = () => (
             </p>
             WRI Communications
             <address>
-              <a href="mailto:privacy@wri.org">privacy@wri.org</a>
+              <a
+                href="mailto:privacy@wri.org"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                privacy@wri.org
+              </a>
             </address>
             <p>Or by post to:</p>
             <address>
-              World Resources Institute
+              <b>World Resources Institute</b>
               <br />
               10 G Street NE, Suite 800 <br />
               Washington, DC 20002
@@ -337,15 +370,16 @@ const PrivacyPolicyPage = () => (
             </address>
             <p>
               If you are resident in the European Economic Area, please also
-              read the{' '}
-              <b>
+              read the ‘
+              <u>
                 Information for Individuals Located in the European Economic
                 Area
-              </b>{' '}
-              section of this Privacy Policy. You may have additional rights in
-              relation to your personal information.
+              </u>
+              ’ section of this Privacy Policy. You may have additional rights
+              in relation to your personal information.
             </p>
           </div>
+
           <div>
             <h2>
               Information for individuals located in the European Economic Area
@@ -353,8 +387,8 @@ const PrivacyPolicyPage = () => (
             <p>
               European Economic Area (“EEA”) data protection laws offer
               additional rights and protections for individuals located in the
-              EEA. Further to the information set out at the{' '}
-              <b>Personal information access and deletion</b> section of this
+              EEA. Further to the information set out at the ‘
+              <u>Personal information access and deletion</u>’ section of this
               Privacy Policy, the following additional information applies to
               you if you are located in the EEA:
             </p>
@@ -378,9 +412,9 @@ const PrivacyPolicyPage = () => (
               </li>
               <li>
                 <b>Personal information rights:</b> In addition to your right to
-                access personal information we hold about you (as set out at the{' '}
-                <b>Personal information access and deletion</b> section of this
-                Privacy Policy), you have the right to have your personal
+                access personal information we hold about you (as set out at the
+                ‘<u>Personal information access and deletion</u>‘ section of
+                this Privacy Policy), you have the right to have your personal
                 information rectified or erased, to object to its processing or
                 to restrict access to it. You also have the right to lodge a
                 complaint with your local data protection authority if you are
@@ -391,6 +425,7 @@ const PrivacyPolicyPage = () => (
               </li>
             </ul>
           </div>
+
           <div>
             <h2>Donation processing partner</h2>
             <p>
@@ -403,26 +438,34 @@ const PrivacyPolicyPage = () => (
               provided to iATS Payments is not used for any other purposes.
             </p>
             <p>
-              We encourage you to read
-              https://home.iatspayments.com/privacy-policy/ for information
-              about how they process your personal information. You will be
-              given an opportunity to review their privacy policy before you
-              make a WRI donation online.
+              We encourage you to read the{" "}
+              <a
+                href="https://home.iatspayments.com/privacy-policy/"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Deluxe Privacy Center policy
+              </a>{" "}
+              for information about how they process your personal information.
+              You will be given an opportunity to review their privacy policy
+              before you make a WRI donation online.
             </p>
             <p>
-              WRI takes its donors&apos; privacy seriously. For more
-              information, please see our{' '}
+              WRI takes its donors’ privacy seriously. For more information,
+              please see our{" "}
               <a
-                target="_blank"
-                rel="noreferrer"
                 href="https://www.wri.org/donate/donor-privacy-policy"
+                rel="noopener noreferrer"
+                target="_blank"
               >
-                WRI Donor Privacy Policy.
+                Donor Privacy Policy
               </a>
+              .
             </p>
           </div>
+
           <div>
-            <h2>Changes, oversight and questions</h2>
+            <h2>Changes, Oversight and Questions</h2>
             <p>
               WRI welcomes comments and questions on this Privacy Policy. We are
               dedicated to protecting your privacy and will make every
@@ -437,26 +480,37 @@ const PrivacyPolicyPage = () => (
               provided us with your personal information.
             </p>
           </div>
+
           <div>
-            <h2>Contact information</h2>
+            <h2>Contact Us</h2>
             <p>
               If you have any questions about this Privacy Policy or our privacy
               practices, please contact us at:
             </p>
-
             <address>
-              <a href="mailto:privacy@wri.org">privacy@wri.org</a>
-              <br />
-              World Resources Institute
+              <b>World Resources Institute</b>
               <br />
               10 G Street NE, Suite 800 <br />
               Washington, DC 20002
               <br />
+              <a
+                href="mailto:privacy@wri.org"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                privacy@wri.org
+              </a>
             </address>
-
             <p>
               Comments and questions regarding this Privacy Policy should be
-              directed to the Legal Department.
+              directed to the{" "}
+              <a
+                href="mailto:legal@wri.org"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Legal Department
+              </a>
             </p>
           </div>
         </div>

--- a/layouts/privacy-policy/component.jsx
+++ b/layouts/privacy-policy/component.jsx
@@ -88,11 +88,11 @@ const PrivacyPolicyPage = () => (
                 collect aggregate site usage reports that do not identify you
                 individually, optimize site users’ experience on the Services,
                 and for marketing purposes.{" "}
-                <b>
+                {/* <b>
                   Please use the “Manage Cookie Preferences” link and the List
                   of Cookies below if you wish to learn more and control which
                   cookies and third-party technology are in use on the site.
-                </b>{" "}
+                </b>{" "} */}
                 The information we collect includes:
                 <ul>
                   <li>
@@ -139,13 +139,13 @@ const PrivacyPolicyPage = () => (
                 C.V.) that you may provide if you apply for a job at WRI;
               </li>
             </ul>
-            <p>
+            {/* <p>
               <a href="#" onClick={(e) => e.preventDefault()}>
                 Manage Cookie Preferences
               </a>{" "}
               (some privacy tools or ad blockers might prevent this tool from
               running).
-            </p>
+            </p> */}
             <p>
               Offline collection: We also collect personal information from you
               when you provide us with it at conferences or similar events or
@@ -278,9 +278,9 @@ const PrivacyPolicyPage = () => (
             <p>
               We also may disclose online information about you to third
               parties, including social media companies like Facebook, Google,
-              LinkedIn (Microsoft) and X for outreach and marketing purposes.{" "}
-              See the <b>“Manage Cookie Preferences”</b> link above to adjust
-              your relevant settings.
+              LinkedIn (Microsoft) and X for outreach and marketing purposes.
+              {/* See the <b>“Manage Cookie Preferences”</b> link above to adjust
+              your relevant settings. */}
             </p>
           </div>
 

--- a/layouts/privacy-policy/component.jsx
+++ b/layouts/privacy-policy/component.jsx
@@ -8,7 +8,7 @@ const PrivacyPolicyPage = () => (
       <Column width={[1, 1 / 12]} />
       <Column width={[1, 5 / 6]}>
         <div className="privacy-container">
-          <div>
+          <div id="intro">
             <h1>World Resources Institute - Privacy Policy</h1>
             <i>Last revised: October 30, 2023</i>
             <p>
@@ -60,7 +60,7 @@ const PrivacyPolicyPage = () => (
             </p>
           </div>
 
-          <div>
+          <div id="personal-information">
             <h2>Personal Information We Collect</h2>
             <p>
               We collect different kinds of information from you, depending on
@@ -156,7 +156,7 @@ const PrivacyPolicyPage = () => (
             </p>
           </div>
 
-          <div>
+          <div id="information-use">
             <h2>Our Use of Your Information</h2>
             <p>
               We use the personal information we collect about you for any of
@@ -203,7 +203,7 @@ const PrivacyPolicyPage = () => (
             </ul>
           </div>
 
-          <div>
+          <div id="outreach-communications">
             <h2>Outreach and Communications</h2>
             <p>
               Where you consent, we use your personal information to provide you
@@ -239,7 +239,7 @@ const PrivacyPolicyPage = () => (
             </p>
           </div>
 
-          <div>
+          <div id="information-disclosure">
             <h2>Disclosure of Information</h2>
             <p>Personal information is disclosed to the following parties:</p>
             <ul>
@@ -284,7 +284,7 @@ const PrivacyPolicyPage = () => (
             </p>
           </div>
 
-          <div>
+          <div id="security-quality">
             <h2>Security and Quality</h2>
             <p>
               WRI takes reasonable steps to protect the personal information
@@ -314,13 +314,13 @@ const PrivacyPolicyPage = () => (
             </p>
           </div>
 
-          <div>
+          <div id="transfers">
             <h2>Transfers</h2>
             <p>
               Where necessary, we may need to transfer your personal information
               to another country. These transfers can take place within the WRI
               group but also may be made to selected third parties (as explained
-              in the ‘<u>Disclosure of information</u>‘ section of this Privacy
+              in the ‘<a href="#information-disclosure">Disclosure of information</a>‘ section of this Privacy
               Policy). Such transfers take place to enable us to provide you
               with our services and/or to communicate with you. Countries that
               we transfer your personal information to may not have the same
@@ -329,7 +329,7 @@ const PrivacyPolicyPage = () => (
             </p>
           </div>
 
-          <div>
+          <div id="external-links">
             <h2>Links to External Websites</h2>
             <p>
               WRI&apos;s Services may contain links to other websites belonging
@@ -341,7 +341,7 @@ const PrivacyPolicyPage = () => (
             </p>
           </div>
 
-          <div>
+          <div id="information-access-deletion">
             <h2>Personal information Access and Deletion</h2>
             <p>
               You may request a copy of the personal information we hold about
@@ -371,16 +371,16 @@ const PrivacyPolicyPage = () => (
             <p>
               If you are resident in the European Economic Area, please also
               read the ‘
-              <u>
+              <a href="#info-individuals-eea">
                 Information for Individuals Located in the European Economic
                 Area
-              </u>
+              </a>
               ’ section of this Privacy Policy. You may have additional rights
               in relation to your personal information.
             </p>
           </div>
 
-          <div>
+          <div id="info-individuals-eea">
             <h2>
               Information for individuals located in the European Economic Area
             </h2>
@@ -388,7 +388,7 @@ const PrivacyPolicyPage = () => (
               European Economic Area (“EEA”) data protection laws offer
               additional rights and protections for individuals located in the
               EEA. Further to the information set out at the ‘
-              <u>Personal information access and deletion</u>’ section of this
+              <a href="#information-access-deletion">Personal information access and deletion</a>’ section of this
               Privacy Policy, the following additional information applies to
               you if you are located in the EEA:
             </p>
@@ -413,7 +413,8 @@ const PrivacyPolicyPage = () => (
               <li>
                 <b>Personal information rights:</b> In addition to your right to
                 access personal information we hold about you (as set out at the
-                ‘<u>Personal information access and deletion</u>‘ section of
+                ‘<a href="#information-access-deletion">Personal information access and deletion</a>‘{" "}
+                section of
                 this Privacy Policy), you have the right to have your personal
                 information rectified or erased, to object to its processing or
                 to restrict access to it. You also have the right to lodge a
@@ -426,7 +427,7 @@ const PrivacyPolicyPage = () => (
             </ul>
           </div>
 
-          <div>
+          <div id="donation-processing">
             <h2>Donation processing partner</h2>
             <p>
               WRI has partnered with a third-party service provider, iATS
@@ -464,7 +465,7 @@ const PrivacyPolicyPage = () => (
             </p>
           </div>
 
-          <div>
+          <div id="changes-oversight-questions">
             <h2>Changes, Oversight and Questions</h2>
             <p>
               WRI welcomes comments and questions on this Privacy Policy. We are
@@ -481,7 +482,7 @@ const PrivacyPolicyPage = () => (
             </p>
           </div>
 
-          <div>
+          <div id="contact-us">
             <h2>Contact Us</h2>
             <p>
               If you have any questions about this Privacy Policy or our privacy

--- a/layouts/privacy-policy/component.jsx
+++ b/layouts/privacy-policy/component.jsx
@@ -10,7 +10,7 @@ const PrivacyPolicyPage = () => (
         <div className="privacy-container">
           <div id="intro">
             <h1>World Resources Institute - Privacy Policy</h1>
-            <i>Last revised: October 30, 2023</i>
+            <i className="last-revised">Last revised: October 30, 2023</i>
             <p>
               We are World Resources Institute, a global research nonprofit
               headquartered at 10 G Street NE Suite 800, Washington, D.C. 20002,

--- a/layouts/privacy-policy/styles.scss
+++ b/layouts/privacy-policy/styles.scss
@@ -4,24 +4,51 @@
   padding: rem(50px) 0;
 
   .privacy-container {
-    // overflow: hidden;
-    // height: 100vh;
     position: relative;
+
+    b {
+      font-weight: 500;
+    }
 
     p {
       font-size: 1rem;
       margin: 1rem 0;
+
+      & + ul {
+        margin-top: -0.5rem;
+      }
     }
 
     ul {
       margin: 1rem 0;
     }
 
+    h2 {
+      font-size: 2rem;
+      margin-top: 4rem;
+    }
+
+    a {
+      text-decoration: underline;
+    }
+
     li {
       display: list-item;
       list-style: disc;
       font-size: 1rem;
+      margin-left: 2.4rem;
+      margin-top: 0.2rem;
+    }
+
+    address {
+      font-size: 1rem;
       margin-left: 1rem;
+    }
+
+    .last-revised {
+      display: block;
+      font-size: 1.2rem;
+      padding-bottom: 2rem;
     }
   }
 }


### PR DESCRIPTION
## Overview

This PR updates the Privacy Policy text in order to match the updated copy/version in the main WRI website, as per task's description. 

**Notes:**  
I made a couple quick changes, unrequested, under review by the QA team:  
- I've noticed WRI's Privacy Policy often mentions other sections, which are linked to the respective section via hash tags. This was not working nor implemented at all in the GFW website; I took the liberty of implementing it (no animations, just making them work. If necessary, we can animate the scroll later on)    
- Verified that all links have `rel="noopener noreferrer"`  
  Some were missing it. `noopener` ends up being redundant in this context, but as standard practice I've added both anyways. 
- While going through the Privacy Policy, I noticed it was both pretty much unstyled but also extremely difficult to read. I took the liberty of adding a couple styling tweaks, very basic just to improve spacing and readability, mostly focused on: 
  - Sized of the headers  
  - Spacing of the sections  
  - Spacing of the lists  
  This doesn't match the ToS, which are also majorly unstyled, waiting from input on the QA team as to whether:
    - Keep the changes  
    - Possibly improve ToS spacing as well  
    - Revert it (takes a couple minutes)  
- There are references to the cookie policy, including a link to open the settings, which works on the main WRI website but doesn't apply here. Waiting on input from the QA team on whether to: 
  - Remove the references  
  - Reword them to match the GFW cookie system. 

## Relevant tickets  

[FLAG-1012](https://gfw.atlassian.net/browse/FLAG-1012)
