### PR TITLE
Layer cloning and release templeate initial commit

### DIFF
--- a/docs/GFW_cloning_template.ipynb
+++ b/docs/GFW_cloning_template.ipynb
@@ -1,0 +1,199 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Dataset / Layer cloning template  \n",
+    "This notebook illustrates the steps needed to clone a dataset or a layer in GFW. The [Resource Watch API](https://api.resourcewatch.org/) (where the assets are stored) provides with a [cloning option](https://resource-watch.github.io/doc-api/reference.html#cloning-a-dataset) directly, but the downside is that it requires to clone each component (dataset, layers, metadata, vocabulary) independently, which makes the process cumbersone and much more error-prone.  \n",
+    "This notebook provides a template to clone a full dataset (with all its components) using the [**LMIpy library**](https://lmipy.readthedocs.io/en/latest/), which was built for operations with RW datasets and is therefore much more efficient and less error-prone."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Importing the necessary libraries\n",
+    "import os\n",
+    "import json\n",
+    "from IPython.display import display\n",
+    "import getpass\n",
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "LMI ver. 0.6.2 ready!\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Install LMIpy if needed\n",
+    "#!pip install LMIPy\n",
+    "#!python setup.py develop \n",
+    "\n",
+    "from IPython.display import clear_output\n",
+    "clear_output()\n",
+    "\n",
+    "import LMIPy as lmi\n",
+    "from LMIPy import utils, dataAPI\n",
+    "\n",
+    "print(f'LMI ver. {lmi.__version__} ready!')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Authentiction  \n",
+    "To modify Resource Watch API's assets, the user needs a RW API account ([see here on creation](https://resource-watch.github.io/doc-api/quickstart.html#2-create-an-account-with-the-rw-api)) with editor privileges, and use it to retrieve the API token key."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "email = getpass.getpass('Login email:')\n",
+    "password = getpass.getpass('Login password:')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "payload = {\n",
+    "    \"email\": f\"{email}\",\n",
+    "    \"password\": f\"{password}\"\n",
+    "}\n",
+    "\n",
+    "url = f'https://api.resourcewatch.org/auth/login'\n",
+    "\n",
+    "headers = {'Content-Type': 'application/json'}\n",
+    "\n",
+    "r = requests.post(url, data=json.dumps(payload), headers=headers)\n",
+    "\n",
+    "API_TOKEN = r.json().get('data').get('token')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Clone a dataset and release in production \n",
+    "On this step, the new datset is cloned and moved from staging to production, while the old dataset is unpublished."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1) load staging and (current) production datasets (if not already) via id  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = lmi.Dataset('')\n",
+    "ds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds_prod = lmi.Dataset('')\n",
+    "ds_prod"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2) Clone staging dataset to production  \n",
+    "Clone dataset using the `clone` method from LMIpy. Update dataset asset name.  \n",
+    "Change environment to `production` afterwards (it does not work during clonning)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_name = 'SET NAME (v202205)'\n",
+    "\n",
+    "\n",
+    "ds_clone = ds.clone(\n",
+    "    token=API_TOKEN,\n",
+    "    env='production',\n",
+    "    dataset_params={\n",
+    "        'name': dataset_name,\n",
+    "        'application': ['gfw']\n",
+    "    },\n",
+    "    clone_children=True\n",
+    ")\n",
+    "#Environment does not update with clone, needs to be updated after\n",
+    "ds_clone.update(update_params={'env':'production'}, token=API_TOKEN) "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3) Unpublish old production dataset  \n",
+    "Instead of deleting the old dataset, it is suggested to unpublish it. This way, the dataset is not lost and can be recovered as a back-up if necessary.  \n",
+    "Update name to indicate old dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds_prod.update(update_params={\n",
+    "    'name': 'SET NAME (DEPRECATED)',\n",
+    "    'published':False}, token=API_TOKEN)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "py_gfw",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/TCL_2022_release.ipynb
+++ b/docs/TCL_2022_release.ipynb
@@ -1,0 +1,1118 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "d5c2c2b8-a87a-4a08-851c-5aba2ada41af",
+   "metadata": {},
+   "source": [
+    "# Tree Cover Loss 2022 map layers release"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "83fb0a53-d352-4b95-a3d0-6f458301dbe1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import json\n",
+    "from IPython.display import display\n",
+    "import getpass\n",
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "49e5d0f3-1d2a-4563-ad24-bc09e2232211",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "LMI ver. 0.6.2 ready!\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Pip install LMIPy\n",
+    "#!pip install LMIPy\n",
+    "#!python setup.py develop \n",
+    "\n",
+    "from IPython.display import clear_output\n",
+    "clear_output()\n",
+    "\n",
+    "import LMIPy as lmi\n",
+    "from LMIPy import utils, dataAPI\n",
+    "\n",
+    "print(f'LMI ver. {lmi.__version__} ready!')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "9ff22d21-ffd6-4380-915a-03b43ef61c5d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "email = getpass.getpass('Login email:')\n",
+    "password = getpass.getpass('Login password:')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "5a845be2-d929-4313-a066-2f140ed354e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "payload = {\n",
+    "    \"email\": f\"{email}\",\n",
+    "    \"password\": f\"{password}\"\n",
+    "}\n",
+    "\n",
+    "url = f'https://api.resourcewatch.org/auth/login'\n",
+    "\n",
+    "headers = {'Content-Type': 'application/json'}\n",
+    "\n",
+    "r = requests.post(url, data=json.dumps(payload), headers=headers)\n",
+    "\n",
+    "API_TOKEN = r.json().get('data').get('token')"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "0767f4f5",
+   "metadata": {},
+   "source": [
+    "## 1) Tree Cover Loss"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "cd47885c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class='item_container' style='height: auto; overflow: hidden; border: 3px solid #2BA4A0;border-radius: 2px; background: #fff; line-height: 1.21429em; padding: 10px;''><div class='item_left' style='width: 210px; float: left;''><a href='https://resourcewatch.org/' target='_blank'><img class='itemThumbnail' src='https://resourcewatch.org/static/images/logo-embed.png'></a></div><div class='item_right' style='float: none; width: auto; hidden;padding-left: 10px; overflow: hidden;''><a href=https://api.resourcewatch.org/v1/dataset/30ec7d3d-1047-4e11-a765-785cead8375a?filterIncludesByEnv=true&includes=vocabulary,metadata,layer,widget&env=staging target='_blank'><b>Tree cover loss 2022 (LM v3) STAGING</b></a><br>Staging Dataset in GFW.<br> GEE asset: <a href='https://code.earthengine.google.com/asset='projects/wri-datalab/HansenComposite_17 target='_blank'>projects/wri-datalab/HansenComposite_17</a><br>Last Modified: 2023-03-30T07:55:31.616Z<br><a href='https://api.resourcewatch.org/v1/fields/30ec7d3d-1047-4e11-a765-785cead8375a' target='_blank'>Fields</a> Connector: gee | Published: True </div> </div>"
+      ],
+      "text/plain": [
+       "Dataset 30ec7d3d-1047-4e11-a765-785cead8375a Tree cover loss 2022 (LM v3) STAGING"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds_staging = lmi.Dataset('30ec7d3d-1047-4e11-a765-785cead8375a')\n",
+    "ds_staging"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "6034827d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class='item_container' style='height: auto; overflow: hidden; border: 3px solid #2BA4A0;border-radius: 2px; background: #fff; line-height: 1.21429em; padding: 10px;''><div class='item_left' style='width: 210px; float: left;''><a href='https://resourcewatch.org/' target='_blank'><img class='itemThumbnail' src='https://resourcewatch.org/static/images/logo-embed.png'></a></div><div class='item_right' style='float: none; width: auto; hidden;padding-left: 10px; overflow: hidden;''><a href=https://api.resourcewatch.org/v1/dataset/893d2c15-7f3c-4fbc-bc84-2bedfd863e84?filterIncludesByEnv=true&includes=vocabulary,metadata,layer,widget&env=production target='_blank'><b>Tree cover loss 2021 (LM v3)</b></a><br>Production Dataset in GFW.<br> GEE asset: <a href='https://code.earthengine.google.com/asset='projects/wri-datalab/HansenComposite_17 target='_blank'>projects/wri-datalab/HansenComposite_17</a><br>Last Modified: 2022-04-28T06:58:01.859Z<br><a href='https://api.resourcewatch.org/v1/fields/893d2c15-7f3c-4fbc-bc84-2bedfd863e84' target='_blank'>Fields</a> Connector: gee | Published: True </div> </div>"
+      ],
+      "text/plain": [
+       "Dataset 893d2c15-7f3c-4fbc-bc84-2bedfd863e84 Tree cover loss 2021 (LM v3)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds_prod = lmi.Dataset('893d2c15-7f3c-4fbc-bc84-2bedfd863e84')\n",
+    "ds_prod"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "edc7d5b6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating clone dataset: https://api.resourcewatch.org/v1/dataset\n",
+      "https://api.resourcewatch.org/dataset/789dd976-11af-4948-82c9-f4ac02d92658\n",
+      "Creating clone layer on target dataset\n",
+      "https://api.resourcewatch.org/v1/dataset/789dd976-11af-4948-82c9-f4ac02d92658/layer/a99fd6ad-60b3-4eab-806c-8d80b3b825ff\n",
+      "No child widgets to clone!\n",
+      "Vocabulary categoryTab created.\n",
+      "Vocabulary layer_manager_ver created.\n",
+      "Vocabulary gfw_env created.\n",
+      "Metadata created.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div class='item_container' style='height: auto; overflow: hidden; border: 3px solid #2BA4A0;border-radius: 2px; background: #fff; line-height: 1.21429em; padding: 10px;''><div class='item_left' style='width: 210px; float: left;''><a href='https://resourcewatch.org/' target='_blank'><img class='itemThumbnail' src='https://resourcewatch.org/static/images/logo-embed.png'></a></div><div class='item_right' style='float: none; width: auto; hidden;padding-left: 10px; overflow: hidden;''><a href=https://api.resourcewatch.org/v1/dataset/789dd976-11af-4948-82c9-f4ac02d92658?filterIncludesByEnv=true&includes=vocabulary,metadata,layer,widget&env=production target='_blank'><b>Tree cover loss 2022 (LM v3) (v202306)</b></a><br>Production Dataset in GFW.<br> GEE asset: <a href='https://code.earthengine.google.com/asset='projects/wri-datalab/HansenComposite_17 target='_blank'>projects/wri-datalab/HansenComposite_17</a><br>Last Modified: 2023-06-27T05:27:48.696Z<br><a href='https://api.resourcewatch.org/v1/fields/789dd976-11af-4948-82c9-f4ac02d92658' target='_blank'>Fields</a> Connector: gee | Published: True </div> </div>"
+      ],
+      "text/plain": [
+       "Dataset 789dd976-11af-4948-82c9-f4ac02d92658 Tree cover loss 2022 (LM v3) (v202306)"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dataset_name = 'Tree cover loss 2022 (LM v3) (v202306)'\n",
+    "\n",
+    "\n",
+    "ds_clone = ds_staging.clone(\n",
+    "    token=API_TOKEN,\n",
+    "    env='production',\n",
+    "    dataset_params={\n",
+    "        'name': dataset_name,\n",
+    "        'application': ['gfw']\n",
+    "    },\n",
+    "    clone_children=True\n",
+    ")\n",
+    "ds_clone.update(update_params={'env':'production'}, token=API_TOKEN)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ac42b8a3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class='item_container' style='height: auto; overflow: hidden; border: 3px solid #2BA4A0;border-radius: 2px; background: #fff; line-height: 1.21429em; padding: 10px;''><div class='item_left' style='width: 210px; float: left;''><a href='https://resourcewatch.org/' target='_blank'><img class='itemThumbnail' src='https://resourcewatch.org/static/images/logo-embed.png'></a></div><div class='item_right' style='float: none; width: auto; hidden;padding-left: 10px; overflow: hidden;''><a href=https://api.resourcewatch.org/v1/dataset/893d2c15-7f3c-4fbc-bc84-2bedfd863e84?filterIncludesByEnv=true&includes=vocabulary,metadata,layer,widget&env=production target='_blank'><b>Tree cover loss 2021 (LM v3) (DEPRECATED)</b></a><br>Production Dataset in GFW.<br> GEE asset: <a href='https://code.earthengine.google.com/asset='projects/wri-datalab/HansenComposite_17 target='_blank'>projects/wri-datalab/HansenComposite_17</a><br>Last Modified: 2023-06-27T05:28:18.455Z<br><a href='https://api.resourcewatch.org/v1/fields/893d2c15-7f3c-4fbc-bc84-2bedfd863e84' target='_blank'>Fields</a> Connector: gee | Published: False </div> </div>"
+      ],
+      "text/plain": [
+       "Dataset 893d2c15-7f3c-4fbc-bc84-2bedfd863e84 Tree cover loss 2021 (LM v3) (DEPRECATED)"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds_prod.update(update_params={\n",
+    "    'name': 'Tree cover loss 2021 (LM v3) (DEPRECATED)',\n",
+    "    'published':False}, token=API_TOKEN)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d3b2f7a8",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "295fdb1d",
+   "metadata": {},
+   "source": [
+    "## TCL Fires"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "0dda66f6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class='item_container' style='height: auto; overflow: hidden; border: 3px solid #2BA4A0;border-radius: 2px; background: #fff; line-height: 1.21429em; padding: 10px;''><div class='item_left' style='width: 210px; float: left;''><a href='https://resourcewatch.org/' target='_blank'><img class='itemThumbnail' src='https://resourcewatch.org/static/images/logo-embed.png'></a></div><div class='item_right' style='float: none; width: auto; hidden;padding-left: 10px; overflow: hidden;''><a href=https://api.resourcewatch.org/v1/dataset/e3df0fca-e230-40c1-9fac-d7ad40df2b31?filterIncludesByEnv=true&includes=vocabulary,metadata,layer,widget&env=staging target='_blank'><b>Tree cover loss due to fires (v202304) STAGING</b></a><br>Staging Dataset in GFW.<br> GEE asset: <a href='https://code.earthengine.google.com/asset='projects/wri-datalab/HansenComposite_17 target='_blank'>projects/wri-datalab/HansenComposite_17</a><br>Last Modified: 2023-03-30T10:08:22.851Z<br><a href='https://api.resourcewatch.org/v1/fields/e3df0fca-e230-40c1-9fac-d7ad40df2b31' target='_blank'>Fields</a> Connector: gee | Published: True </div> </div>"
+      ],
+      "text/plain": [
+       "Dataset e3df0fca-e230-40c1-9fac-d7ad40df2b31 Tree cover loss due to fires (v202304) STAGING"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds_staging = lmi.Dataset('e3df0fca-e230-40c1-9fac-d7ad40df2b31')\n",
+    "ds_staging"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "22cc7ab5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class='item_container' style='height: auto; overflow: hidden; border: 3px solid #2BA4A0;border-radius: 2px; background: #fff; line-height: 1.21429em; padding: 10px;''><div class='item_left' style='width: 210px; float: left;''><a href='https://resourcewatch.org/' target='_blank'><img class='itemThumbnail' src='https://resourcewatch.org/static/images/logo-embed.png'></a></div><div class='item_right' style='float: none; width: auto; hidden;padding-left: 10px; overflow: hidden;''><a href=https://api.resourcewatch.org/v1/dataset/bd66ee37-ad8d-4c6a-b6ab-0294ecd1759d?filterIncludesByEnv=true&includes=vocabulary,metadata,layer,widget&env=production target='_blank'><b>Tree cover loss due to fires (v202207)</b></a><br>Production Dataset in GFW.<br> GEE asset: <a href='https://code.earthengine.google.com/asset='projects/wri-datalab/HansenComposite_17 target='_blank'>projects/wri-datalab/HansenComposite_17</a><br>Last Modified: 2022-08-03T09:06:08.702Z<br><a href='https://api.resourcewatch.org/v1/fields/bd66ee37-ad8d-4c6a-b6ab-0294ecd1759d' target='_blank'>Fields</a> Connector: gee | Published: True </div> </div>"
+      ],
+      "text/plain": [
+       "Dataset bd66ee37-ad8d-4c6a-b6ab-0294ecd1759d Tree cover loss due to fires (v202207)"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds_prod = lmi.Dataset('bd66ee37-ad8d-4c6a-b6ab-0294ecd1759d')\n",
+    "ds_prod"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "7e3ee276",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating clone dataset: https://api.resourcewatch.org/v1/dataset\n",
+      "https://api.resourcewatch.org/dataset/15d4af69-3316-400a-8c50-e9306e93fe85\n",
+      "Creating clone layer on target dataset\n",
+      "https://api.resourcewatch.org/v1/dataset/15d4af69-3316-400a-8c50-e9306e93fe85/layer/c9d86bf9-4eef-43d9-b377-e9481df36168\n",
+      "No child widgets to clone!\n",
+      "Vocabulary layer_manager_ver created.\n",
+      "Vocabulary gfw_env created.\n",
+      "Vocabulary categoryTab created.\n",
+      "Metadata created.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div class='item_container' style='height: auto; overflow: hidden; border: 3px solid #2BA4A0;border-radius: 2px; background: #fff; line-height: 1.21429em; padding: 10px;''><div class='item_left' style='width: 210px; float: left;''><a href='https://resourcewatch.org/' target='_blank'><img class='itemThumbnail' src='https://resourcewatch.org/static/images/logo-embed.png'></a></div><div class='item_right' style='float: none; width: auto; hidden;padding-left: 10px; overflow: hidden;''><a href=https://api.resourcewatch.org/v1/dataset/15d4af69-3316-400a-8c50-e9306e93fe85?filterIncludesByEnv=true&includes=vocabulary,metadata,layer,widget&env=production target='_blank'><b>Tree cover loss due to fires (LM v3) (v202306)</b></a><br>Production Dataset in GFW.<br> GEE asset: <a href='https://code.earthengine.google.com/asset='projects/wri-datalab/HansenComposite_17 target='_blank'>projects/wri-datalab/HansenComposite_17</a><br>Last Modified: 2023-06-27T05:32:11.738Z<br><a href='https://api.resourcewatch.org/v1/fields/15d4af69-3316-400a-8c50-e9306e93fe85' target='_blank'>Fields</a> Connector: gee | Published: True </div> </div>"
+      ],
+      "text/plain": [
+       "Dataset 15d4af69-3316-400a-8c50-e9306e93fe85 Tree cover loss due to fires (LM v3) (v202306)"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dataset_name = 'Tree cover loss due to fires (LM v3) (v202306)'\n",
+    "\n",
+    "\n",
+    "ds_clone = ds_staging.clone(\n",
+    "    token=API_TOKEN,\n",
+    "    env='production',\n",
+    "    dataset_params={\n",
+    "        'name': dataset_name,\n",
+    "        'application': ['gfw']\n",
+    "    },\n",
+    "    clone_children=True\n",
+    ")\n",
+    "ds_clone.update(update_params={'env':'production'}, token=API_TOKEN)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class='item_container' style='height: auto; overflow: hidden; border: 3px solid #2BA4A0;border-radius: 2px; background: #fff; line-height: 1.21429em; padding: 10px;''><div class='item_left' style='width: 210px; float: left;''><a href='https://resourcewatch.org/' target='_blank'><img class='itemThumbnail' src='https://resourcewatch.org/static/images/logo-embed.png'></a></div><div class='item_right' style='float: none; width: auto; hidden;padding-left: 10px; overflow: hidden;''><a href=https://api.resourcewatch.org/v1/dataset/bd66ee37-ad8d-4c6a-b6ab-0294ecd1759d?filterIncludesByEnv=true&includes=vocabulary,metadata,layer,widget&env=production target='_blank'><b>Tree cover loss due to fires (LM v3) (DEPRECATED)</b></a><br>Production Dataset in GFW.<br> GEE asset: <a href='https://code.earthengine.google.com/asset='projects/wri-datalab/HansenComposite_17 target='_blank'>projects/wri-datalab/HansenComposite_17</a><br>Last Modified: 2023-06-27T05:32:20.175Z<br><a href='https://api.resourcewatch.org/v1/fields/bd66ee37-ad8d-4c6a-b6ab-0294ecd1759d' target='_blank'>Fields</a> Connector: gee | Published: False </div> </div>"
+      ],
+      "text/plain": [
+       "Dataset bd66ee37-ad8d-4c6a-b6ab-0294ecd1759d Tree cover loss due to fires (LM v3) (DEPRECATED)"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds_prod.update(update_params={\n",
+    "    'name': 'Tree cover loss due to fires (LM v3) (DEPRECATED)',\n",
+    "    'published':False}, token=API_TOKEN)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9200e68e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "aa045abe",
+   "metadata": {},
+   "source": [
+    "## 3) TCL by Driver"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "d621d9fd",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class='item_container' style='height: auto; overflow: hidden; border: 3px solid #2BA4A0;border-radius: 2px; background: #fff; line-height: 1.21429em; padding: 10px;''><div class='item_left' style='width: 210px; float: left;''><a href='https://resourcewatch.org/' target='_blank'><img class='itemThumbnail' src='https://resourcewatch.org/static/images/logo-embed.png'></a></div><div class='item_right' style='float: none; width: auto; hidden;padding-left: 10px; overflow: hidden;''><a href=https://api.resourcewatch.org/v1/dataset/5ee44ec5-1d02-4521-b16d-693f75710bbb?filterIncludesByEnv=true&includes=vocabulary,metadata,layer,widget&env=staging target='_blank'><b>Tree cover loss by dominant driver (LM v3) STAGING</b></a><br>Staging Dataset in GFW.<br> GEE asset: <a href='https://code.earthengine.google.com/asset='projects/wri-datalab/HansenComposite_17 target='_blank'>projects/wri-datalab/HansenComposite_17</a><br>Last Modified: 2022-09-19T14:25:39.312Z<br><a href='https://api.resourcewatch.org/v1/fields/5ee44ec5-1d02-4521-b16d-693f75710bbb' target='_blank'>Fields</a> Connector: gee | Published: True </div> </div>"
+      ],
+      "text/plain": [
+       "Dataset 5ee44ec5-1d02-4521-b16d-693f75710bbb Tree cover loss by dominant driver (LM v3) STAGING"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds_staging = lmi.Dataset('5ee44ec5-1d02-4521-b16d-693f75710bbb')\n",
+    "ds_staging"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "1af804fc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class='item_container' style='height: auto; overflow: hidden; border: 3px solid #2BA4A0;border-radius: 2px; background: #fff; line-height: 1.21429em; padding: 10px;''><div class='item_left' style='width: 210px; float: left;''><a href='https://resourcewatch.org/' target='_blank'><img class='itemThumbnail' src='https://resourcewatch.org/static/images/logo-embed.png'></a></div><div class='item_right' style='float: none; width: auto; hidden;padding-left: 10px; overflow: hidden;''><a href=https://api.resourcewatch.org/v1/dataset/f23a1803-ba17-4fe3-a1ad-39abfbfb56c6?filterIncludesByEnv=true&includes=vocabulary,metadata,layer,widget&env=production target='_blank'><b>Tree cover loss by dominant driver (LM v3)</b></a><br>Production Dataset in GFW.<br> GEE asset: <a href='https://code.earthengine.google.com/asset='projects/wri-datalab/HansenComposite_17 target='_blank'>projects/wri-datalab/HansenComposite_17</a><br>Last Modified: 2020-03-31T08:31:35.755Z<br><a href='https://api.resourcewatch.org/v1/fields/f23a1803-ba17-4fe3-a1ad-39abfbfb56c6' target='_blank'>Fields</a> Connector: gee | Published: True </div> </div>"
+      ],
+      "text/plain": [
+       "Dataset f23a1803-ba17-4fe3-a1ad-39abfbfb56c6 Tree cover loss by dominant driver (LM v3)"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds_prod = lmi.Dataset('f23a1803-ba17-4fe3-a1ad-39abfbfb56c6')\n",
+    "ds_prod"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "4e9cf438",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating clone dataset: https://api.resourcewatch.org/v1/dataset\n",
+      "https://api.resourcewatch.org/dataset/a78cf392-8952-4beb-8303-e10f38ca9069\n",
+      "Creating clone layer on target dataset\n",
+      "https://api.resourcewatch.org/v1/dataset/a78cf392-8952-4beb-8303-e10f38ca9069/layer/1ef66df5-623e-4953-a11b-5469b030c9b8\n",
+      "No child widgets to clone!\n",
+      "Vocabulary categoryTab created.\n",
+      "Vocabulary layer_manager_ver created.\n",
+      "Vocabulary gfw_env created.\n",
+      "Metadata created.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div class='item_container' style='height: auto; overflow: hidden; border: 3px solid #2BA4A0;border-radius: 2px; background: #fff; line-height: 1.21429em; padding: 10px;''><div class='item_left' style='width: 210px; float: left;''><a href='https://resourcewatch.org/' target='_blank'><img class='itemThumbnail' src='https://resourcewatch.org/static/images/logo-embed.png'></a></div><div class='item_right' style='float: none; width: auto; hidden;padding-left: 10px; overflow: hidden;''><a href=https://api.resourcewatch.org/v1/dataset/a78cf392-8952-4beb-8303-e10f38ca9069?filterIncludesByEnv=true&includes=vocabulary,metadata,layer,widget&env=production target='_blank'><b>Tree cover loss by dominant driver (LM v3) (v202306)</b></a><br>Production Dataset in GFW.<br> GEE asset: <a href='https://code.earthengine.google.com/asset='projects/wri-datalab/HansenComposite_17 target='_blank'>projects/wri-datalab/HansenComposite_17</a><br>Last Modified: 2023-06-27T05:33:47.426Z<br><a href='https://api.resourcewatch.org/v1/fields/a78cf392-8952-4beb-8303-e10f38ca9069' target='_blank'>Fields</a> Connector: gee | Published: True </div> </div>"
+      ],
+      "text/plain": [
+       "Dataset a78cf392-8952-4beb-8303-e10f38ca9069 Tree cover loss by dominant driver (LM v3) (v202306)"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dataset_name = 'Tree cover loss by dominant driver (LM v3) (v202306)'\n",
+    "\n",
+    "\n",
+    "ds_clone = ds_staging.clone(\n",
+    "    token=API_TOKEN,\n",
+    "    env='production',\n",
+    "    dataset_params={\n",
+    "        'name': dataset_name,\n",
+    "        'application': ['gfw']\n",
+    "    },\n",
+    "    clone_children=True\n",
+    ")\n",
+    "ds_clone.update(update_params={'env':'production'}, token=API_TOKEN)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "5c1b4990",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class='item_container' style='height: auto; overflow: hidden; border: 3px solid #2BA4A0;border-radius: 2px; background: #fff; line-height: 1.21429em; padding: 10px;''><div class='item_left' style='width: 210px; float: left;''><a href='https://resourcewatch.org/' target='_blank'><img class='itemThumbnail' src='https://resourcewatch.org/static/images/logo-embed.png'></a></div><div class='item_right' style='float: none; width: auto; hidden;padding-left: 10px; overflow: hidden;''><a href=https://api.resourcewatch.org/v1/dataset/f23a1803-ba17-4fe3-a1ad-39abfbfb56c6?filterIncludesByEnv=true&includes=vocabulary,metadata,layer,widget&env=production target='_blank'><b>Tree cover loss by dominant driver (LM v3) (DEPRECATED)</b></a><br>Production Dataset in GFW.<br> GEE asset: <a href='https://code.earthengine.google.com/asset='projects/wri-datalab/HansenComposite_17 target='_blank'>projects/wri-datalab/HansenComposite_17</a><br>Last Modified: 2023-06-27T05:33:55.346Z<br><a href='https://api.resourcewatch.org/v1/fields/f23a1803-ba17-4fe3-a1ad-39abfbfb56c6' target='_blank'>Fields</a> Connector: gee | Published: False </div> </div>"
+      ],
+      "text/plain": [
+       "Dataset f23a1803-ba17-4fe3-a1ad-39abfbfb56c6 Tree cover loss by dominant driver (LM v3) (DEPRECATED)"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds_prod.update(update_params={\n",
+    "    'name': 'Tree cover loss by dominant driver (LM v3) (DEPRECATED)',\n",
+    "    'published':False}, token=API_TOKEN)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df2d5f27",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "6c1a6e59",
+   "metadata": {},
+   "source": [
+    "## 4) Emerging hotspots"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "a2ccb108",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class='item_container' style='height: auto; overflow: hidden; border: 3px solid #2BA4A0;border-radius: 2px; background: #fff; line-height: 1.21429em; padding: 10px;''><div class='item_left' style='width: 210px; float: left;''><a href='https://resourcewatch.org/' target='_blank'><img class='itemThumbnail' src='https://resourcewatch.org/static/images/logo-embed.png'></a></div><div class='item_right' style='float: none; width: auto; hidden;padding-left: 10px; overflow: hidden;''><a href=https://api.resourcewatch.org/v1/dataset/ba358b27-0d86-41cf-a141-260357ed25f3?filterIncludesByEnv=true&includes=vocabulary,metadata,layer,widget&env=staging target='_blank'><b>Emerging hot spots 2002-2022 (LM v3) STAGING</b></a><br>Staging Dataset in GFW.<br> Carto table: <a href=https://wri-01.carto.com/tables/ehs_2019_final target='_blank'>ehs_2019_final</a><br>Last Modified: 2023-04-17T09:07:21.140Z<br><a href='https://api.resourcewatch.org/v1/fields/ba358b27-0d86-41cf-a141-260357ed25f3' target='_blank'>Fields</a> Connector: cartodb | Published: True </div> </div>"
+      ],
+      "text/plain": [
+       "Dataset ba358b27-0d86-41cf-a141-260357ed25f3 Emerging hot spots 2002-2022 (LM v3) STAGING"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds_staging = lmi.Dataset('ba358b27-0d86-41cf-a141-260357ed25f3')\n",
+    "ds_staging"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "3fa84eaf",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class='item_container' style='height: auto; overflow: hidden; border: 3px solid #2BA4A0;border-radius: 2px; background: #fff; line-height: 1.21429em; padding: 10px;''><div class='item_left' style='width: 210px; float: left;''><a href='https://resourcewatch.org/' target='_blank'><img class='itemThumbnail' src='https://resourcewatch.org/static/images/logo-embed.png'></a></div><div class='item_right' style='float: none; width: auto; hidden;padding-left: 10px; overflow: hidden;''><a href=https://api.resourcewatch.org/v1/dataset/05922e44-94fb-4798-b50e-e26adf41e2ce?filterIncludesByEnv=true&includes=vocabulary,metadata,layer,widget&env=production target='_blank'><b>Emerging hot spots 2002-2021 (LM v3)</b></a><br>Production Dataset in GFW.<br> Carto table: <a href=https://wri-01.carto.com/tables/ehs_2019_final target='_blank'>ehs_2019_final</a><br>Last Modified: 2022-04-28T07:28:08.750Z<br><a href='https://api.resourcewatch.org/v1/fields/05922e44-94fb-4798-b50e-e26adf41e2ce' target='_blank'>Fields</a> Connector: cartodb | Published: True </div> </div>"
+      ],
+      "text/plain": [
+       "Dataset 05922e44-94fb-4798-b50e-e26adf41e2ce Emerging hot spots 2002-2021 (LM v3)"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds_prod = lmi.Dataset('05922e44-94fb-4798-b50e-e26adf41e2ce')\n",
+    "ds_prod"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "8546dc3a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating clone dataset: https://api.resourcewatch.org/v1/dataset\n",
+      "https://api.resourcewatch.org/dataset/d37bb7cf-f97f-432f-b23c-519fa8abec13\n",
+      "Creating clone layer on target dataset\n",
+      "https://api.resourcewatch.org/v1/dataset/d37bb7cf-f97f-432f-b23c-519fa8abec13/layer/5f960d84-3b19-40f4-933c-dd5a04f3af9a\n",
+      "No child widgets to clone!\n",
+      "Vocabulary categoryTab created.\n",
+      "Vocabulary layer_manager_ver created.\n",
+      "Vocabulary gfw_env created.\n",
+      "Metadata created.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div class='item_container' style='height: auto; overflow: hidden; border: 3px solid #2BA4A0;border-radius: 2px; background: #fff; line-height: 1.21429em; padding: 10px;''><div class='item_left' style='width: 210px; float: left;''><a href='https://resourcewatch.org/' target='_blank'><img class='itemThumbnail' src='https://resourcewatch.org/static/images/logo-embed.png'></a></div><div class='item_right' style='float: none; width: auto; hidden;padding-left: 10px; overflow: hidden;''><a href=https://api.resourcewatch.org/v1/dataset/d37bb7cf-f97f-432f-b23c-519fa8abec13?filterIncludesByEnv=true&includes=vocabulary,metadata,layer,widget&env=production target='_blank'><b>Emerging hot spots 2002-2022 (LM v3) (v202306)</b></a><br>Production Dataset in GFW.<br> Carto table: <a href=https://wri-01.carto.com/tables/ehs_2019_final target='_blank'>ehs_2019_final</a><br>Last Modified: 2023-06-27T05:36:37.130Z<br><a href='https://api.resourcewatch.org/v1/fields/d37bb7cf-f97f-432f-b23c-519fa8abec13' target='_blank'>Fields</a> Connector: cartodb | Published: True </div> </div>"
+      ],
+      "text/plain": [
+       "Dataset d37bb7cf-f97f-432f-b23c-519fa8abec13 Emerging hot spots 2002-2022 (LM v3) (v202306)"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dataset_name = 'Emerging hot spots 2002-2022 (LM v3) (v202306)'\n",
+    "\n",
+    "\n",
+    "ds_clone = ds_staging.clone(\n",
+    "    token=API_TOKEN,\n",
+    "    env='production',\n",
+    "    dataset_params={\n",
+    "        'name': dataset_name,\n",
+    "        'application': ['gfw']\n",
+    "    },\n",
+    "    clone_children=True\n",
+    ")\n",
+    "ds_clone.update(update_params={'env':'production'}, token=API_TOKEN)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "3dc0d25c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class='item_container' style='height: auto; overflow: hidden; border: 3px solid #2BA4A0;border-radius: 2px; background: #fff; line-height: 1.21429em; padding: 10px;''><div class='item_left' style='width: 210px; float: left;''><a href='https://resourcewatch.org/' target='_blank'><img class='itemThumbnail' src='https://resourcewatch.org/static/images/logo-embed.png'></a></div><div class='item_right' style='float: none; width: auto; hidden;padding-left: 10px; overflow: hidden;''><a href=https://api.resourcewatch.org/v1/dataset/05922e44-94fb-4798-b50e-e26adf41e2ce?filterIncludesByEnv=true&includes=vocabulary,metadata,layer,widget&env=production target='_blank'><b>Emerging hot spots 2002-2021 (LM v3) (DEPRECATED)</b></a><br>Production Dataset in GFW.<br> Carto table: <a href=https://wri-01.carto.com/tables/ehs_2019_final target='_blank'>ehs_2019_final</a><br>Last Modified: 2023-06-27T05:38:42.300Z<br><a href='https://api.resourcewatch.org/v1/fields/05922e44-94fb-4798-b50e-e26adf41e2ce' target='_blank'>Fields</a> Connector: cartodb | Published: False </div> </div>"
+      ],
+      "text/plain": [
+       "Dataset 05922e44-94fb-4798-b50e-e26adf41e2ce Emerging hot spots 2002-2021 (LM v3) (DEPRECATED)"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds_prod.update(update_params={\n",
+    "    'name': 'Emerging hot spots 2002-2021 (LM v3) (DEPRECATED)',\n",
+    "    'published':False}, token=API_TOKEN)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8af6e014",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "dcaf9619",
+   "metadata": {},
+   "source": [
+    "## 5) Carbon emissions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "49770ea1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class='item_container' style='height: auto; overflow: hidden; border: 3px solid #2BA4A0;border-radius: 2px; background: #fff; line-height: 1.21429em; padding: 10px;''><div class='item_left' style='width: 210px; float: left;''><a href='https://resourcewatch.org/' target='_blank'><img class='itemThumbnail' src='https://resourcewatch.org/static/images/logo-embed.png'></a></div><div class='item_right' style='float: none; width: auto; hidden;padding-left: 10px; overflow: hidden;''><a href=https://api.resourcewatch.org/v1/dataset/472eb070-20b2-4e3e-89a9-3a27df39344a?filterIncludesByEnv=true&includes=vocabulary,metadata,layer,widget&env=staging target='_blank'><b>Gross Carbon Emissions (LM v3) v202305 STAGING</b></a><br>Staging Dataset in GFW.<br> Data source wms<br>Last Modified: 2023-05-15T15:16:01.849Z<br><a href='https://api.resourcewatch.org/v1/fields/472eb070-20b2-4e3e-89a9-3a27df39344a' target='_blank'>Fields</a> Connector: wms | Published: True </div> </div>"
+      ],
+      "text/plain": [
+       "Dataset 472eb070-20b2-4e3e-89a9-3a27df39344a Gross Carbon Emissions (LM v3) v202305 STAGING"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds_staging = lmi.Dataset('472eb070-20b2-4e3e-89a9-3a27df39344a')\n",
+    "ds_staging"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "479056e3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class='item_container' style='height: auto; overflow: hidden; border: 3px solid #2BA4A0;border-radius: 2px; background: #fff; line-height: 1.21429em; padding: 10px;''><div class='item_left' style='width: 210px; float: left;''><a href='https://resourcewatch.org/' target='_blank'><img class='itemThumbnail' src='https://resourcewatch.org/static/images/logo-embed.png'></a></div><div class='item_right' style='float: none; width: auto; hidden;padding-left: 10px; overflow: hidden;''><a href=https://api.resourcewatch.org/v1/dataset/617ac59e-ca09-4b7c-9598-d67838937c7b?filterIncludesByEnv=true&includes=vocabulary,metadata,layer,widget&env=production target='_blank'><b>Gross Carbon Emissions (LM v3) v202204</b></a><br>Production Dataset in GFW.<br> Data source wms<br>Last Modified: 2022-04-28T07:22:22.115Z<br><a href='https://api.resourcewatch.org/v1/fields/617ac59e-ca09-4b7c-9598-d67838937c7b' target='_blank'>Fields</a> Connector: wms | Published: True </div> </div>"
+      ],
+      "text/plain": [
+       "Dataset 617ac59e-ca09-4b7c-9598-d67838937c7b Gross Carbon Emissions (LM v3) v202204"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds_prod = lmi.Dataset('617ac59e-ca09-4b7c-9598-d67838937c7b')\n",
+    "ds_prod"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "b5d239f6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating clone dataset: https://api.resourcewatch.org/v1/dataset\n",
+      "https://api.resourcewatch.org/dataset/de961ce7-6f25-4474-a27a-bc5abbd87336\n",
+      "Creating clone layer on target dataset\n",
+      "https://api.resourcewatch.org/v1/dataset/de961ce7-6f25-4474-a27a-bc5abbd87336/layer/53b216a9-17c8-4f6b-8585-af5f68eabdef\n",
+      "No child widgets to clone!\n",
+      "Vocabulary categoryTab created.\n",
+      "Vocabulary layer_manager_ver created.\n",
+      "Vocabulary gfw_env created.\n",
+      "Metadata created.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div class='item_container' style='height: auto; overflow: hidden; border: 3px solid #2BA4A0;border-radius: 2px; background: #fff; line-height: 1.21429em; padding: 10px;''><div class='item_left' style='width: 210px; float: left;''><a href='https://resourcewatch.org/' target='_blank'><img class='itemThumbnail' src='https://resourcewatch.org/static/images/logo-embed.png'></a></div><div class='item_right' style='float: none; width: auto; hidden;padding-left: 10px; overflow: hidden;''><a href=https://api.resourcewatch.org/v1/dataset/de961ce7-6f25-4474-a27a-bc5abbd87336?filterIncludesByEnv=true&includes=vocabulary,metadata,layer,widget&env=production target='_blank'><b>Gross Carbon Emissions (LM v3) (v202306)</b></a><br>Production Dataset in GFW.<br> Data source wms<br>Last Modified: 2023-06-27T05:40:02.072Z<br><a href='https://api.resourcewatch.org/v1/fields/de961ce7-6f25-4474-a27a-bc5abbd87336' target='_blank'>Fields</a> Connector: wms | Published: True </div> </div>"
+      ],
+      "text/plain": [
+       "Dataset de961ce7-6f25-4474-a27a-bc5abbd87336 Gross Carbon Emissions (LM v3) (v202306)"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dataset_name = 'Gross Carbon Emissions (LM v3) (v202306)'\n",
+    "\n",
+    "\n",
+    "ds_clone = ds_staging.clone(\n",
+    "    token=API_TOKEN,\n",
+    "    env='production',\n",
+    "    dataset_params={\n",
+    "        'name': dataset_name,\n",
+    "        'application': ['gfw']\n",
+    "    },\n",
+    "    clone_children=True\n",
+    ")\n",
+    "ds_clone.update(update_params={'env':'production'}, token=API_TOKEN)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "5d73297c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class='item_container' style='height: auto; overflow: hidden; border: 3px solid #2BA4A0;border-radius: 2px; background: #fff; line-height: 1.21429em; padding: 10px;''><div class='item_left' style='width: 210px; float: left;''><a href='https://resourcewatch.org/' target='_blank'><img class='itemThumbnail' src='https://resourcewatch.org/static/images/logo-embed.png'></a></div><div class='item_right' style='float: none; width: auto; hidden;padding-left: 10px; overflow: hidden;''><a href=https://api.resourcewatch.org/v1/dataset/617ac59e-ca09-4b7c-9598-d67838937c7b?filterIncludesByEnv=true&includes=vocabulary,metadata,layer,widget&env=production target='_blank'><b>Gross Carbon Emissions (LM v3) (DEPRECATED)</b></a><br>Production Dataset in GFW.<br> Data source wms<br>Last Modified: 2023-06-27T05:40:04.221Z<br><a href='https://api.resourcewatch.org/v1/fields/617ac59e-ca09-4b7c-9598-d67838937c7b' target='_blank'>Fields</a> Connector: wms | Published: False </div> </div>"
+      ],
+      "text/plain": [
+       "Dataset 617ac59e-ca09-4b7c-9598-d67838937c7b Gross Carbon Emissions (LM v3) (DEPRECATED)"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds_prod.update(update_params={\n",
+    "    'name': 'Gross Carbon Emissions (LM v3) (DEPRECATED)',\n",
+    "    'published':False}, token=API_TOKEN)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46430c2f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "bb30ccae",
+   "metadata": {},
+   "source": [
+    "## 6) Carbon removals"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "169e5687",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class='item_container' style='height: auto; overflow: hidden; border: 3px solid #2BA4A0;border-radius: 2px; background: #fff; line-height: 1.21429em; padding: 10px;''><div class='item_left' style='width: 210px; float: left;''><a href='https://resourcewatch.org/' target='_blank'><img class='itemThumbnail' src='https://resourcewatch.org/static/images/logo-embed.png'></a></div><div class='item_right' style='float: none; width: auto; hidden;padding-left: 10px; overflow: hidden;''><a href=https://api.resourcewatch.org/v1/dataset/388e758f-d5be-45f7-9283-8885502a3699?filterIncludesByEnv=true&includes=vocabulary,metadata,layer,widget&env=staging target='_blank'><b>Gross Carbon Removals (LM v3) v202305 STAGING</b></a><br>Staging Dataset in GFW.<br> Data source wms<br>Last Modified: 2023-05-15T15:28:21.226Z<br><a href='https://api.resourcewatch.org/v1/fields/388e758f-d5be-45f7-9283-8885502a3699' target='_blank'>Fields</a> Connector: wms | Published: True </div> </div>"
+      ],
+      "text/plain": [
+       "Dataset 388e758f-d5be-45f7-9283-8885502a3699 Gross Carbon Removals (LM v3) v202305 STAGING"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds_staging = lmi.Dataset('388e758f-d5be-45f7-9283-8885502a3699')\n",
+    "ds_staging"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "93307bbc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class='item_container' style='height: auto; overflow: hidden; border: 3px solid #2BA4A0;border-radius: 2px; background: #fff; line-height: 1.21429em; padding: 10px;''><div class='item_left' style='width: 210px; float: left;''><a href='https://resourcewatch.org/' target='_blank'><img class='itemThumbnail' src='https://resourcewatch.org/static/images/logo-embed.png'></a></div><div class='item_right' style='float: none; width: auto; hidden;padding-left: 10px; overflow: hidden;''><a href=https://api.resourcewatch.org/v1/dataset/8cad8847-40c1-4163-9299-01bb0ccd2477?filterIncludesByEnv=true&includes=vocabulary,metadata,layer,widget&env=production target='_blank'><b>Gross Carbon Removals (LM v3) v202204</b></a><br>Production Dataset in GFW.<br> Data source wms<br>Last Modified: 2022-04-28T07:24:17.296Z<br><a href='https://api.resourcewatch.org/v1/fields/8cad8847-40c1-4163-9299-01bb0ccd2477' target='_blank'>Fields</a> Connector: wms | Published: True </div> </div>"
+      ],
+      "text/plain": [
+       "Dataset 8cad8847-40c1-4163-9299-01bb0ccd2477 Gross Carbon Removals (LM v3) v202204"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds_prod = lmi.Dataset('8cad8847-40c1-4163-9299-01bb0ccd2477')\n",
+    "ds_prod"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "a79e13f0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating clone dataset: https://api.resourcewatch.org/v1/dataset\n",
+      "https://api.resourcewatch.org/dataset/d98dffe9-7ea3-46ca-b378-e89a4cd26bce\n",
+      "Creating clone layer on target dataset\n",
+      "https://api.resourcewatch.org/v1/dataset/d98dffe9-7ea3-46ca-b378-e89a4cd26bce/layer/73297b00-6c45-4652-8688-c29b46837fa1\n",
+      "No child widgets to clone!\n",
+      "Vocabulary categoryTab created.\n",
+      "Vocabulary layer_manager_ver created.\n",
+      "Vocabulary gfw_env created.\n",
+      "Metadata created.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div class='item_container' style='height: auto; overflow: hidden; border: 3px solid #2BA4A0;border-radius: 2px; background: #fff; line-height: 1.21429em; padding: 10px;''><div class='item_left' style='width: 210px; float: left;''><a href='https://resourcewatch.org/' target='_blank'><img class='itemThumbnail' src='https://resourcewatch.org/static/images/logo-embed.png'></a></div><div class='item_right' style='float: none; width: auto; hidden;padding-left: 10px; overflow: hidden;''><a href=https://api.resourcewatch.org/v1/dataset/d98dffe9-7ea3-46ca-b378-e89a4cd26bce?filterIncludesByEnv=true&includes=vocabulary,metadata,layer,widget&env=production target='_blank'><b>Gross Carbon Removals (LM v3) (v202306)</b></a><br>Production Dataset in GFW.<br> Data source wms<br>Last Modified: 2023-06-27T05:40:56.348Z<br><a href='https://api.resourcewatch.org/v1/fields/d98dffe9-7ea3-46ca-b378-e89a4cd26bce' target='_blank'>Fields</a> Connector: wms | Published: True </div> </div>"
+      ],
+      "text/plain": [
+       "Dataset d98dffe9-7ea3-46ca-b378-e89a4cd26bce Gross Carbon Removals (LM v3) (v202306)"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dataset_name = 'Gross Carbon Removals (LM v3) (v202306)'\n",
+    "\n",
+    "\n",
+    "ds_clone = ds_staging.clone(\n",
+    "    token=API_TOKEN,\n",
+    "    env='production',\n",
+    "    dataset_params={\n",
+    "        'name': dataset_name,\n",
+    "        'application': ['gfw']\n",
+    "    },\n",
+    "    clone_children=True\n",
+    ")\n",
+    "ds_clone.update(update_params={'env':'production'}, token=API_TOKEN)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "f04e11dd",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class='item_container' style='height: auto; overflow: hidden; border: 3px solid #2BA4A0;border-radius: 2px; background: #fff; line-height: 1.21429em; padding: 10px;''><div class='item_left' style='width: 210px; float: left;''><a href='https://resourcewatch.org/' target='_blank'><img class='itemThumbnail' src='https://resourcewatch.org/static/images/logo-embed.png'></a></div><div class='item_right' style='float: none; width: auto; hidden;padding-left: 10px; overflow: hidden;''><a href=https://api.resourcewatch.org/v1/dataset/8cad8847-40c1-4163-9299-01bb0ccd2477?filterIncludesByEnv=true&includes=vocabulary,metadata,layer,widget&env=production target='_blank'><b>Gross Carbon Removals (LM v3) (DEPRECATED)</b></a><br>Production Dataset in GFW.<br> Data source wms<br>Last Modified: 2023-06-27T05:41:06.509Z<br><a href='https://api.resourcewatch.org/v1/fields/8cad8847-40c1-4163-9299-01bb0ccd2477' target='_blank'>Fields</a> Connector: wms | Published: False </div> </div>"
+      ],
+      "text/plain": [
+       "Dataset 8cad8847-40c1-4163-9299-01bb0ccd2477 Gross Carbon Removals (LM v3) (DEPRECATED)"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds_prod.update(update_params={\n",
+    "    'name': 'Gross Carbon Removals (LM v3) (DEPRECATED)',\n",
+    "    'published':False}, token=API_TOKEN)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eaa94c68",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "7f9d99c6",
+   "metadata": {},
+   "source": [
+    "## 7) Carbon Net Flux"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "b2c8ef15",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class='item_container' style='height: auto; overflow: hidden; border: 3px solid #2BA4A0;border-radius: 2px; background: #fff; line-height: 1.21429em; padding: 10px;''><div class='item_left' style='width: 210px; float: left;''><a href='https://resourcewatch.org/' target='_blank'><img class='itemThumbnail' src='https://resourcewatch.org/static/images/logo-embed.png'></a></div><div class='item_right' style='float: none; width: auto; hidden;padding-left: 10px; overflow: hidden;''><a href=https://api.resourcewatch.org/v1/dataset/2b7c7671-4dbd-4175-9d77-8fcb44979060?filterIncludesByEnv=true&includes=vocabulary,metadata,layer,widget&env=staging target='_blank'><b>Net Greenhouse Gas Flux (LM v3) v202305 STAGING</b></a><br>Staging Dataset in GFW.<br> Data source wms<br>Last Modified: 2023-05-15T15:54:13.464Z<br><a href='https://api.resourcewatch.org/v1/fields/2b7c7671-4dbd-4175-9d77-8fcb44979060' target='_blank'>Fields</a> Connector: wms | Published: True </div> </div>"
+      ],
+      "text/plain": [
+       "Dataset 2b7c7671-4dbd-4175-9d77-8fcb44979060 Net Greenhouse Gas Flux (LM v3) v202305 STAGING"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds_staging = lmi.Dataset('2b7c7671-4dbd-4175-9d77-8fcb44979060')\n",
+    "ds_staging"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "0eb8f4e9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class='item_container' style='height: auto; overflow: hidden; border: 3px solid #2BA4A0;border-radius: 2px; background: #fff; line-height: 1.21429em; padding: 10px;''><div class='item_left' style='width: 210px; float: left;''><a href='https://resourcewatch.org/' target='_blank'><img class='itemThumbnail' src='https://resourcewatch.org/static/images/logo-embed.png'></a></div><div class='item_right' style='float: none; width: auto; hidden;padding-left: 10px; overflow: hidden;''><a href=https://api.resourcewatch.org/v1/dataset/e8bf518b-b926-43e3-bf5b-c4a8ac9a2fe2?filterIncludesByEnv=true&includes=vocabulary,metadata,layer,widget&env=production target='_blank'><b>Net Greenhouse Gas Flux (LM v3) v202204</b></a><br>Production Dataset in GFW.<br> Data source wms<br>Last Modified: 2022-04-28T07:17:28.240Z<br><a href='https://api.resourcewatch.org/v1/fields/e8bf518b-b926-43e3-bf5b-c4a8ac9a2fe2' target='_blank'>Fields</a> Connector: wms | Published: True </div> </div>"
+      ],
+      "text/plain": [
+       "Dataset e8bf518b-b926-43e3-bf5b-c4a8ac9a2fe2 Net Greenhouse Gas Flux (LM v3) v202204"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds_prod = lmi.Dataset('e8bf518b-b926-43e3-bf5b-c4a8ac9a2fe2')\n",
+    "ds_prod"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "05a63436",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating clone dataset: https://api.resourcewatch.org/v1/dataset\n",
+      "https://api.resourcewatch.org/dataset/1d51d813-f944-4cfe-b6fa-b2ef3a6d7cce\n",
+      "Creating clone layer on target dataset\n",
+      "https://api.resourcewatch.org/v1/dataset/1d51d813-f944-4cfe-b6fa-b2ef3a6d7cce/layer/f401eb8c-b49f-44a1-adf2-b110bd92d53f\n",
+      "No child widgets to clone!\n",
+      "Vocabulary layer_manager_ver created.\n",
+      "Vocabulary categoryTab created.\n",
+      "Vocabulary gfw_env created.\n",
+      "Metadata created.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div class='item_container' style='height: auto; overflow: hidden; border: 3px solid #2BA4A0;border-radius: 2px; background: #fff; line-height: 1.21429em; padding: 10px;''><div class='item_left' style='width: 210px; float: left;''><a href='https://resourcewatch.org/' target='_blank'><img class='itemThumbnail' src='https://resourcewatch.org/static/images/logo-embed.png'></a></div><div class='item_right' style='float: none; width: auto; hidden;padding-left: 10px; overflow: hidden;''><a href=https://api.resourcewatch.org/v1/dataset/1d51d813-f944-4cfe-b6fa-b2ef3a6d7cce?filterIncludesByEnv=true&includes=vocabulary,metadata,layer,widget&env=production target='_blank'><b>Net Greenhouse Gas Flux (LM v3) (v202306)</b></a><br>Production Dataset in GFW.<br> Data source wms<br>Last Modified: 2023-06-27T05:43:17.811Z<br><a href='https://api.resourcewatch.org/v1/fields/1d51d813-f944-4cfe-b6fa-b2ef3a6d7cce' target='_blank'>Fields</a> Connector: wms | Published: True </div> </div>"
+      ],
+      "text/plain": [
+       "Dataset 1d51d813-f944-4cfe-b6fa-b2ef3a6d7cce Net Greenhouse Gas Flux (LM v3) (v202306)"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dataset_name = 'Net Greenhouse Gas Flux (LM v3) (v202306)'\n",
+    "\n",
+    "\n",
+    "ds_clone = ds_staging.clone(\n",
+    "    token=API_TOKEN,\n",
+    "    env='production',\n",
+    "    dataset_params={\n",
+    "        'name': dataset_name,\n",
+    "        'application': ['gfw']\n",
+    "    },\n",
+    "    clone_children=True\n",
+    ")\n",
+    "ds_clone.update(update_params={'env':'production'}, token=API_TOKEN)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "92e258dd",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class='item_container' style='height: auto; overflow: hidden; border: 3px solid #2BA4A0;border-radius: 2px; background: #fff; line-height: 1.21429em; padding: 10px;''><div class='item_left' style='width: 210px; float: left;''><a href='https://resourcewatch.org/' target='_blank'><img class='itemThumbnail' src='https://resourcewatch.org/static/images/logo-embed.png'></a></div><div class='item_right' style='float: none; width: auto; hidden;padding-left: 10px; overflow: hidden;''><a href=https://api.resourcewatch.org/v1/dataset/e8bf518b-b926-43e3-bf5b-c4a8ac9a2fe2?filterIncludesByEnv=true&includes=vocabulary,metadata,layer,widget&env=production target='_blank'><b>Net Greenhouse Gas Flux (LM v3) (DEPRECATED)</b></a><br>Production Dataset in GFW.<br> Data source wms<br>Last Modified: 2023-06-27T05:43:23.385Z<br><a href='https://api.resourcewatch.org/v1/fields/e8bf518b-b926-43e3-bf5b-c4a8ac9a2fe2' target='_blank'>Fields</a> Connector: wms | Published: False </div> </div>"
+      ],
+      "text/plain": [
+       "Dataset e8bf518b-b926-43e3-bf5b-c4a8ac9a2fe2 Net Greenhouse Gas Flux (LM v3) (DEPRECATED)"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds_prod.update(update_params={\n",
+    "    'name': 'Net Greenhouse Gas Flux (LM v3) (DEPRECATED)',\n",
+    "    'published':False}, token=API_TOKEN)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a729697d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "2a9ac8d5dd6905b6db348871184a65dd2dfdf9210270a3ede0635c6e864e6650"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.9.7 ('gfw')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Overview

Notebook demonstrating of the use of LMIpy to clone datasets in GFW for production release, and another notebook with an example of the Tree Cover Loss release process from previous year.


