### PR TITLE
[FLAG-1094] Remove MVP items 

### DIFF
--- a/components/widgets/climate/carbon-flux/index.js
+++ b/components/widgets/climate/carbon-flux/index.js
@@ -35,14 +35,6 @@ export default {
   categories: ['climate'],
   types: ['geostore', 'global', 'country', 'aoi', 'use', 'wdpa'],
   admins: ['global', 'adm0', 'adm1', 'adm2'],
-  alerts: [
-    {
-      id: 'carbon-flux-1',
-      text: `2023 loss data is currently available only for specific analyses. Note that this widget does not reflect updated data. [Click here](https://gfw2-data.s3.amazonaws.com/country-pages/country_stats/download/gfw_2023_statistics_summary.xlsx) to access a file with country-level 2023 loss data.`,
-      icon: 'warning',
-      visible: ['global', 'country', 'geostore', 'aoi', 'wdpa', 'use'],
-    },
-  ],
   chartType: 'verticalComposedChart',
   settingsConfig: [
     {

--- a/components/widgets/climate/emissions-deforestation/index.js
+++ b/components/widgets/climate/emissions-deforestation/index.js
@@ -31,14 +31,6 @@ export default {
   categories: ['climate'],
   types: ['geostore', 'country', 'aoi', 'use', 'wdpa'],
   admins: ['adm0', 'adm1', 'adm2'],
-  alerts: [
-    {
-      id: 'emissions-deforestation-1',
-      text: `2023 loss data is currently available only for specific analyses. Note that this widget does not reflect updated data. [Click here](https://gfw2-data.s3.amazonaws.com/country-pages/country_stats/download/gfw_2023_statistics_summary.xlsx) to access a file with country-level 2023 loss data.`,
-      icon: 'warning',
-      visible: ['geostore', 'country', 'aoi', 'use', 'wdpa'],
-    },
-  ],
   chartType: 'composedChart',
   settingsConfig: [
     {

--- a/components/widgets/fires/tree-loss-fires-annual/index.js
+++ b/components/widgets/fires/tree-loss-fires-annual/index.js
@@ -34,14 +34,6 @@ export default {
   categories: ['summary', 'fires'],
   types: ['global', 'country', 'geostore', 'aoi', 'wdpa', 'use'],
   admins: ['global', 'adm0', 'adm1', 'adm2'],
-  alerts: [
-    {
-      id: 'tree-loss-fires-annual-1',
-      text: `2023 loss data is currently available only for specific analyses. Note that this widget does not reflect updated data. [Click here](https://gfw2-data.s3.amazonaws.com/country-pages/country_stats/download/gfw_2023_statistics_summary.xlsx) to access a file with country-level 2023 loss data.`,
-      icon: 'warning',
-      visible: ['global', 'country', 'geostore', 'aoi', 'wdpa', 'use'],
-    },
-  ],
   large: true,
   visible: ['dashboard', 'analysis'],
   chartType: 'composedChart',

--- a/components/widgets/fires/tree-loss-fires-annual/index.js
+++ b/components/widgets/fires/tree-loss-fires-annual/index.js
@@ -660,10 +660,8 @@ export default {
     return lossFetch.then((loss) => {
       let data = {};
       if (loss && loss.data) {
-        const filteredLoss = loss.data.data.filter((item) => item.year < 2023);
-
         data = {
-          loss: filteredLoss,
+          loss: loss.data.data,
         };
       }
 

--- a/components/widgets/fires/tree-loss-fires-annual/selectors.js
+++ b/components/widgets/fires/tree-loss-fires-annual/selectors.js
@@ -176,7 +176,7 @@ const parseSentence = createSelector(
       indicator: indicator && indicator.label,
       location: locationLabel,
       startYear,
-      endYear: endYear === 2023 ? endYear - 1 : endYear, // TODO: Remove this for TCL 2023 update full release!!
+      endYear,
       treeCoverLossFires: formatNumber({
         num: treeCoverLossFires,
         unit: 'ha',

--- a/components/widgets/fires/tree-loss-fires-proportion/index.js
+++ b/components/widgets/fires/tree-loss-fires-proportion/index.js
@@ -128,10 +128,8 @@ export default {
     return lossFetch.then((loss) => {
       let data = {};
       if (loss && loss.data) {
-        const filteredLoss = loss.data.data.filter((item) => item.year < 2023);
-
         data = {
-          loss: filteredLoss,
+          loss: loss.data.data,
         };
       }
 

--- a/components/widgets/fires/tree-loss-fires-proportion/index.js
+++ b/components/widgets/fires/tree-loss-fires-proportion/index.js
@@ -33,14 +33,6 @@ export default {
   categories: ['fires'],
   types: ['global', 'country', 'geostore', 'aoi', 'wdpa', 'use'],
   admins: ['global', 'adm0', 'adm1', 'adm2'],
-  alerts: [
-    {
-      id: 'tree-loss-fires-proportion-1',
-      text: `2023 loss data is currently available only for specific analyses. Note that this widget does not reflect updated data. [Click here](https://gfw2-data.s3.amazonaws.com/country-pages/country_stats/download/gfw_2023_statistics_summary.xlsx) to access a file with country-level 2023 loss data.`,
-      icon: 'warning',
-      visible: ['global', 'country', 'geostore', 'aoi', 'wdpa', 'use'],
-    },
-  ],
   large: false,
   visible: ['dashboard', 'analysis'],
   chartType: 'pieChart',

--- a/components/widgets/fires/tree-loss-fires-proportion/selectors.js
+++ b/components/widgets/fires/tree-loss-fires-proportion/selectors.js
@@ -94,7 +94,7 @@ const parseSentence = createSelector(
       indicator: indicator && indicator.label,
       location: locationLabel,
       startYear,
-      endYear: endYear === 2023 ? endYear - 1 : endYear, // TODO: Remove this for TCL 2023 update full release!!,
+      endYear,
       lossFiresPercentage: formatNumber({
         num: lossFiresPercentage,
         unit: '%',

--- a/components/widgets/fires/tree-loss-fires/index.js
+++ b/components/widgets/fires/tree-loss-fires/index.js
@@ -27,14 +27,6 @@ export default {
   categories: ['fires'],
   types: ['global', 'country'],
   admins: ['global', 'adm0', 'adm1'],
-  alerts: [
-    {
-      id: 'tree-loss-fires-1',
-      text: `2023 loss data is currently available only for specific analyses. Note that this widget does not reflect updated data. [Click here](https://gfw2-data.s3.amazonaws.com/country-pages/country_stats/download/gfw_2023_statistics_summary.xlsx) to access a file with country-level 2023 loss data.`,
-      icon: 'warning',
-      visible: ['global', 'country'],
-    },
-  ],
   settingsConfig: [
     {
       key: 'forestType',

--- a/components/widgets/forest-change/tree-loss-drivers/index.js
+++ b/components/widgets/forest-change/tree-loss-drivers/index.js
@@ -31,12 +31,6 @@ export default {
   alerts: {
     default: [
       {
-        id: 'tree-loss-drivers-alert-2',
-        text: `2023 loss data is currently available only for specific analyses. Note that this widget does not reflect updated data. [Click here](https://gfw2-data.s3.amazonaws.com/country-pages/country_stats/download/gfw_2023_statistics_summary.xlsx) to access a file with country-level 2023 loss data.`,
-        icon: 'warning',
-        visible: ['global', 'country', 'geostore', 'aoi', 'wdpa', 'use'],
-      },
-      {
         id: 'tree-loss-drivers-alert-1',
         text: `The methods behind this data have changed over time. Be cautious comparing old and new, data especially before/after 2015. [Read more here](https://www.globalforestwatch.org/blog/data-and-research/tree-cover-loss-satellite-data-trend-analysis/).`,
         icon: 'warning',

--- a/components/widgets/forest-change/tree-loss-drivers/index.js
+++ b/components/widgets/forest-change/tree-loss-drivers/index.js
@@ -149,7 +149,6 @@ export default {
       landCategory: 'tsc',
       lossTsc: true,
       download: true,
-      widgetId: 'treeLossTsc',
     }),
     getExtent({ ...params, download: true }),
   ],

--- a/components/widgets/forest-change/tree-loss-global/selectors.js
+++ b/components/widgets/forest-change/tree-loss-global/selectors.js
@@ -175,11 +175,7 @@ export const parseSentence = createSelector(
     const percentageLoss =
       (totalLoss && totalExtent && (totalLoss / totalExtent) * 100) || 0;
 
-    let sentence = indicator ? withInd : initial;
-
-    if (endYear === 2023) {
-      sentence = sentence.replace(' and {emissions} of CO₂ emissions', '');
-    }
+    const sentence = indicator ? withInd : initial;
 
     const params = {
       indicator: indicator && indicator.label,

--- a/components/widgets/forest-change/tree-loss-plantations/selectors.js
+++ b/components/widgets/forest-change/tree-loss-plantations/selectors.js
@@ -140,17 +140,8 @@ export const parseSentence = createSelector(
       percentage: formatNumber({ num: percentage, unit: '%' }),
     };
 
-    let finalSentence = sentence;
-
-    if (endYear === 2023) {
-      finalSentence = sentence.replace(
-        ' The total loss within natural forest was equivalent to {value} of CO\u2082e emissions.',
-        ''
-      );
-    }
-
     return {
-      sentence: finalSentence,
+      sentence,
       params,
     };
   }

--- a/components/widgets/forest-change/tree-loss/selectors.js
+++ b/components/widgets/forest-change/tree-loss/selectors.js
@@ -136,7 +136,7 @@ const parseSentence = createSelector(
     if (totalLoss === 0) {
       sentence = indicator ? noLossWithIndicator : noLoss;
     }
-    if (tropical && totalLoss > 0 && endYear !== 2023) {
+    if (tropical && totalLoss > 0) {
       sentence = `${sentence}, ${co2Emissions}`;
     }
     sentence = `${sentence}.`;

--- a/data/dashboard-summary-sentence.js
+++ b/data/dashboard-summary-sentence.js
@@ -1,11 +1,11 @@
 export default {
   global: {
     summary:
-      'Explore interactive charts and maps that summarize key statistics about global forests. Statistics and global rankings – including rates of forest change, forest extent and drivers of deforestation – can be customized, easily shared and downloaded for offline use. <a href="https://gfw2-data.s3.amazonaws.com/country-pages/country_stats/download/gfw_2023_statistics_summary.xlsx">Download global 2023 tree cover loss data by country here.</a>',
+      'Explore interactive charts and maps that summarize key statistics about global forests. Statistics and global rankings – including rates of forest change, forest extent and drivers of deforestation – can be customized, easily shared and downloaded for offline use.',
     'land-cover':
       'Explore interactive charts and maps that summarize global forest extent. Statistics – including rankings of countries with the most forest – can be customized, easily shared and downloaded for offline use.',
     'forest-change':
-      'Explore interactive charts and maps that summarize global rates of forest change. Statistics – including rankings of countries with the most forest loss and gain, and drivers of deforestation – can be customized, easily shared and downloaded for offline use. <a href="https://gfw2-data.s3.amazonaws.com/country-pages/country_stats/download/gfw_2023_statistics_summary.xlsx">Download global 2023 tree cover loss data by country here.</a>',
+      'Explore interactive charts and maps that summarize global rates of forest change. Statistics – including rankings of countries with the most forest loss and gain, and drivers of deforestation – can be customized, easily shared and downloaded for offline use.',
     fires:
       'Explore real-time fire alerts and identify countries with the most significant number of fires based on historical trends. The interactive chart can be customized, easily shared and downloaded for offline use.',
     climate:
@@ -13,11 +13,11 @@ export default {
   },
   country: {
     summary:
-      'Explore interactive charts and maps that summarize key statistics about forests in {location}. Statistics – including rates of forest change, forest extent, drivers of deforestation, and deforestation and fire alerts – can be customized, easily shared and downloaded for offline use. <a href="https://gfw2-data.s3.amazonaws.com/country-pages/country_stats/download/gfw_2023_statistics_summary.xlsx">Download global 2023 tree cover loss data by country here.</a>',
+      'Explore interactive charts and maps that summarize key statistics about forests in {location}. Statistics – including rates of forest change, forest extent, drivers of deforestation, and deforestation and fire alerts – can be customized, easily shared and downloaded for offline use.',
     'land-cover':
       'Explore interactive charts and maps that summarize forest extent in {location}. Statistics – including rankings of regions with the most forest – can be customized, easily shared and downloaded for offline use.',
     'forest-change':
-      'Explore interactive charts and maps that summarize rates of forest change in {location}. Statistics – including rankings of regions with the most forest loss and gain – can be customized, easily shared and downloaded for offline use. <a href="https://gfw2-data.s3.amazonaws.com/country-pages/country_stats/download/gfw_2023_statistics_summary.xlsx">Download global 2023 tree cover loss data by country here.</a>',
+      'Explore interactive charts and maps that summarize rates of forest change in {location}. Statistics – including rankings of regions with the most forest loss and gain – can be customized, easily shared and downloaded for offline use.',
     'land-use':
       'Explore interactive charts and maps that summarize the human use of land in {location}. Statistics – including export flows of agricultural commodities, the economic impact of forests and forestry employment – can be customized, easily shared and downloaded for offline use.',
     fires:
@@ -27,11 +27,11 @@ export default {
   },
   adm1: {
     summary:
-      'Explore interactive charts and maps that summarize key statistics about forests in {adm1}, {location}. Statistics – including rates of forest change and forest extent – can be customized, easily shared and downloaded for offline use. <a href="https://gfw2-data.s3.amazonaws.com/country-pages/country_stats/download/gfw_2023_statistics_summary.xlsx">Download global 2023 tree cover loss data by country here.</a>',
+      'Explore interactive charts and maps that summarize key statistics about forests in {adm1}, {location}. Statistics – including rates of forest change and forest extent – can be customized, easily shared and downloaded for offline use.',
     'land-cover':
       'Explore interactive charts and maps that summarize forest extent in {adm1}, {location}. Statistics – including rankings of regions with the most forest – can be customized, easily shared and downloaded for offline use.',
     'forest-change':
-      'Explore interactive charts and maps that summarize rates of forest change in {adm1}, {location}. Statistics – including rankings of regions with the most forest loss and gain – can be customized, easily shared and downloaded for offline use. <a href="https://gfw2-data.s3.amazonaws.com/country-pages/country_stats/download/gfw_2023_statistics_summary.xlsx">Download global 2023 tree cover loss data by country here.</a>',
+      'Explore interactive charts and maps that summarize rates of forest change in {adm1}, {location}. Statistics – including rankings of regions with the most forest loss and gain – can be customized, easily shared and downloaded for offline use.',
     fires:
       'Explore interactive charts and maps that summarize forest fires in {adm1}, {location}. Statistics – including regions with the most fire alerts and how current fires compare to historical trends – can be customized, easily shared and downloaded for offline use.',
     climate:
@@ -39,11 +39,11 @@ export default {
   },
   adm2: {
     summary:
-      'Explore interactive charts and maps that summarize key statistics about forests in {adm2}, {adm1}, {location}. Statistics – including rates of forest change and forest extent – can be customized, easily shared and downloaded for offline use. <a href="https://gfw2-data.s3.amazonaws.com/country-pages/country_stats/download/gfw_2023_statistics_summary.xlsx">Download global 2023 tree cover loss data by country here.</a>',
+      'Explore interactive charts and maps that summarize key statistics about forests in {adm2}, {adm1}, {location}. Statistics – including rates of forest change and forest extent – can be customized, easily shared and downloaded for offline use.',
     'land-cover':
       'Explore interactive charts and maps that summarize forest extent in {adm2}, {adm1}, {location}. Statistics – including types of forest cover – can be customized, easily shared and downloaded for offline use.',
     'forest-change':
-      'Explore interactive charts and maps that summarize rates of forest change in {adm2}, {adm1}, {location}. Forest cover change statistics – including rankings of regions with the most forest loss and gain – can be customized, easily shared and downloaded for offline use. <a href="https://gfw2-data.s3.amazonaws.com/country-pages/country_stats/download/gfw_2023_statistics_summary.xlsx">Download global 2023 tree cover loss data by country here.</a>',
+      'Explore interactive charts and maps that summarize rates of forest change in {adm2}, {adm1}, {location}. Forest cover change statistics – including rankings of regions with the most forest loss and gain – can be customized, easily shared and downloaded for offline use.',
     fires:
       'Explore interactive charts and maps that summarize forest fires in {adm2}, {adm1}, {location}. Fire statistics – including how current fires compare to historical trends – can be customized, easily shared and downloaded for offline use.',
     climate:

--- a/services/get-where-query.js
+++ b/services/get-where-query.js
@@ -8,7 +8,7 @@ const isNumber = (value) => !!(typeof value === 'number' || !isNaN(value));
 
 // build {where} statement for query
 export const getWHEREQuery = (params = {}) => {
-  const { type, dataset, widgetId } = params || {};
+  const { type, dataset } = params || {};
 
   const allFilterOptions = forestTypes.concat(landCategories);
   const allowedParams = ALLOWED_PARAMS[params.dataset || 'annual'];
@@ -95,12 +95,6 @@ export const getWHEREQuery = (params = {}) => {
       WHERE = `${WHERE}${paramKey}${comparisonString}${
         isNumericValue ? value : `'${value}'`
       }`;
-    }
-
-    // this is a temporary patch, it should be removed soon for the full TCL release!!
-    // see https://gfw.atlassian.net/browse/FLAG-1077
-    if (widgetId === 'treeLossTsc') {
-      WHERE = `${WHERE} AND umd_tree_cover_loss__year < 2023 `;
     }
 
     if (isLastParameter) {

--- a/services/sentences.js
+++ b/services/sentences.js
@@ -37,7 +37,7 @@ export const adminSentences = {
   countrySpecific: {
     IDN: 'In 2001, {location} had {primaryForest} of primary forest*, extending over {percentagePrimaryForest} of its land area. In {year}, it lost {primaryLoss} of primary forest*, equivalent to {emissionsPrimary} of CO₂ emissions.',
   },
-  co2Emissions: ', equivalent to {emissions} of CO\u2082 emissions.',
+  co2Emissions: ', equivalent to {emissionsTreeCover} of CO\u2082 emissions.',
   end: '.',
 };
 

--- a/services/sentences.js
+++ b/services/sentences.js
@@ -291,14 +291,6 @@ export const parseSentence = (
     sentence = countrySpecific[adm0];
   }
 
-  // 2023 TCL MVP
-  // removing last part of paragraph
-  // see: https://gfw.atlassian.net/browse/FLAG-1070
-  sentence = sentence.replace(
-    ', equivalent to {emissions} of CO₂ emissions',
-    ''
-  );
-
   return {
     sentence,
     params,


### PR DESCRIPTION
## Overview

While we work to complete final TCL items and prepare for the full launch, we’ll need to also prepare to remove the MVP-specific work that we did. Since we didn’t initially launch all the data we normally do (drivers, carbon, etc), we made a number of changes (all included below) that we will need to revert.

We need to remove the sentence that we added to the paragraphs at the top of the “summary” and “forest change” tabs: “Download global 2023 tree cover loss data by country here.”

in 1070, we hid parts of the sentence that related to carbon; we need to ensure they appear again with the updated data we’re doing in FLAG-1049: Update dashboard + map widgets with new TCL tables

We added a caveat to dashboards and layers explaining that data weren’t updated; we need to remove it with the full launch.

