### PR TITLE
FLAG-1003: remove nonexistent getPresentationAttributes function

### DIFF
--- a/components/charts/sankey-chart/component.jsx
+++ b/components/charts/sankey-chart/component.jsx
@@ -13,7 +13,6 @@ import { shallowEqual } from 'recharts/lib/util/ShallowEqual';
 import { getValueByDataKey } from 'recharts/lib/util/ChartUtils';
 import {
   PRESENTATION_ATTRIBUTES,
-  getPresentationAttributes,
   EVENT_ATTRIBUTES,
   filterSvgElements,
   validateWidthHeight,
@@ -534,7 +533,6 @@ class Sankey extends PureComponent {
       targetY,
       targetControlX,
       linkWidth,
-      ...others
     } = props;
 
     return (
@@ -548,7 +546,6 @@ class Sankey extends PureComponent {
         stroke="#333"
         strokeWidth={linkWidth}
         strokeOpacity="0.2"
-        {...getPresentationAttributes(others)}
       />
     );
   }
@@ -588,7 +585,6 @@ class Sankey extends PureComponent {
             linkWidth,
             index: i,
             payload: { ...link, source, target },
-            ...getPresentationAttributes(linkContent),
           };
           const events = {
             onMouseEnter: this.handleMouseEnter.bind(this, linkProps, 'link'),
@@ -634,7 +630,6 @@ class Sankey extends PureComponent {
         {nodes.map((node, i) => {
           const { x, y, dx, dy } = node;
           const nodeProps = {
-            ...getPresentationAttributes(nodeContent),
             x: x + left,
             y: y + top,
             width: dx,
@@ -691,7 +686,6 @@ class Sankey extends PureComponent {
 
     const { width, height, className, style, children, ...others } = this.props;
     const { links, nodes } = this.state;
-    const attrs = getPresentationAttributes(others);
 
     return (
       <div
@@ -704,7 +698,7 @@ class Sankey extends PureComponent {
           height,
         }}
       >
-        <Surface {...attrs} width={width} height={height}>
+        <Surface {...others} width={width} height={height}>
           {filterSvgElements(children)}
           {this.renderLinks(links, nodes)}
           {this.renderNodes(nodes)}


### PR DESCRIPTION
## Overview

The Sankey component was trying to use a `getPresentationAttributes` function which doesn't exist neither in gfw codebase nor in recharts library.

Removing those calls to that non-existing function fixed the widget component.

## Demo

- [ ] go to`/dashboards/country/USA/?category=land-cover&location=WyJjb3VudHJ5IiwiVVNBIl0%3D&map=eyJjYW5Cb3VuZCI6dHJ1ZX0%3D` and check that the last widget displays correctly.

<img width="789" alt="Screenshot 2024-04-24 at 9 58 54 p m" src="https://github.com/wri/gfw/assets/127868788/ec1d28da-df27-4be7-8f82-0b8568c6f40d">


## Notes

If applicable: ancilary topics, caveats, alternative strategies that didn't work out, etc.

## Testing

- Include any steps to verify the features this PR introduces.
- If this fixes a bug, include bug reproduction steps.

