### PR TITLE
FLAG-1111: fix widget embed for IDN

### DIFF
--- a/components/widgets/forest-change/tree-loss-primary/index.js
+++ b/components/widgets/forest-change/tree-loss-primary/index.js
@@ -209,6 +209,7 @@ export default {
     return (
       location.type === 'country' &&
       location.adm0 === 'IDN' &&
+      !location.pathname.includes('embed') &&
       (category === 'summary' || !category)
     );
   },


### PR DESCRIPTION
## Overview

adding a validation for widget embed for the specific case in Indonesia, to avoid displaying the hardcoded image when embedding a widget.

## Demo

If applicable: screenshots, gifs, etc.

## Notes

If applicable: ancilary topics, caveats, alternative strategies that didn't work out, etc.

## Testing

- Include any steps to verify the features this PR introduces.
- If this fixes a bug, include bug reproduction steps.

