### PR TITLE
[FLAG-940] Remove alert message from integrated alerts widgets

### DIFF
--- a/components/widgets/forest-change/integrated-alerts-ranked/index.js
+++ b/components/widgets/forest-change/integrated-alerts-ranked/index.js
@@ -30,12 +30,6 @@ export default {
   categories: ['forest-change'],
   subcategories: ['forest-loss'],
   types: ['country'],
-  alerts: [
-    {
-      text: `We are collecting user feedback for how we can improve the integrated deforestation alerts. Please provide your feedback through this [survey](https://survey.alchemer.com/s3/7460286/give-feedback-on-GFW-integrated-deforestation-alerts) or email us at [gfw@wri.org](mailto:gfw@wri.org)!`,
-      visible: ['country', 'geostore', 'aoi', 'wdpa', 'use'],
-    },
-  ],
   admins: ['adm0', 'adm1'],
   settingsConfig: [
     {

--- a/components/widgets/forest-change/integrated-deforestation-alerts/index.js
+++ b/components/widgets/forest-change/integrated-deforestation-alerts/index.js
@@ -91,12 +91,6 @@ export default {
   categories: ['summary', 'forest-change'],
   subcategories: ['forest-loss'],
   types: ['country', 'geostore', 'wdpa', 'aoi', 'use'],
-  alerts: [
-    {
-      text: `We are collecting user feedback for how we can improve the integrated deforestation alerts. Please provide your feedback through this [survey](https://survey.alchemer.com/s3/7460286/give-feedback-on-GFW-integrated-deforestation-alerts) or email us at [gfw@wri.org](mailto:gfw@wri.org)!`,
-      visible: ['country', 'geostore', 'aoi', 'wdpa', 'use'],
-    },
-  ],
   admins: ['adm0', 'adm1', 'adm2'],
   datasets: [
     {


### PR DESCRIPTION
## Overview

This PR removes the integrated alerts widgets' alerts/survey link added in [#4673](https://github.com/wri/gfw/pull/4673). 

## Tracking  

[FLAG-940](https://gfw.atlassian.net/browse/FLAG-940)
