### PR TITLE
[FLAG-942] Update MongabayStories map/explore link to the new external link

### DIFF
--- a/components/map-menu/components/sections/explore/sections.js
+++ b/components/map-menu/components/sections/explore/sections.js
@@ -58,7 +58,7 @@ export const stories = {
       {
         text: 'READ MORE',
         theme: 'theme-button-light theme-button-small',
-        link: '/stories',
+        extLink: 'https://news.mongabay.com/series/forest-trackers/',
       },
       {
         text: 'VIEW ON MAP',


### PR DESCRIPTION
## Overview

This PR changes the map/explore mongabay stores _Read more_ link to the new version. 

Although it implements [FLAG-942](https://gfw.atlassian.net/browse/FLAG-942), all the changes, including bugfix were implemented Science side; FE only debugged it. 

We're leveraging an existing mechanism to link to an external page. 

## Tracking 

[FLAG-942](https://gfw.atlassian.net/browse/FLAG-942)

