### PR TITLE
[FLAG-973] Private saved areas are not accessible in a user's own My GFW account

### DIFF
--- a/components/modals/meta/actions.js
+++ b/components/modals/meta/actions.js
@@ -17,10 +17,11 @@ export const getModalMetaData = createThunkAction(
 
         getMetadata(metakey, metaType)
           .then((response) => {
+            console.log('XPTO', response);
             if (metaType === 'widget') {
               dispatch(setModalMetaData(response.data));
             } else {
-              dispatch(setModalMetaData(response.data));
+              dispatch(setModalMetaData(response.data.metadata));
             }
           })
           .catch(() => {

--- a/components/modals/meta/actions.js
+++ b/components/modals/meta/actions.js
@@ -8,23 +8,24 @@ export const setModalMetaSettings = createThunkAction('setModalMetaSettings');
 
 export const getModalMetaData = createThunkAction(
   'getModalMetaData',
-  ({metakey, metaType}) => (dispatch, getState) => {
-    const { modalMeta } = getState();
-    if (modalMeta && !modalMeta.loading) {
-      dispatch(setModalMetaLoading({ loading: true, error: false }));
-      getMetadata(metakey, metaType)
-        .then((response) => {
-          if (metaType === 'widget') {
-            dispatch(setModalMetaData(response.data[0].info))
-          } else {
-            dispatch(setModalMetaData(response.data));
-          }
-        })
-        .catch(() => {
-          dispatch(setModalMetaLoading({ loading: false, error: true }));
-        });
+  ({ metakey, metaType }) =>
+    (dispatch, getState) => {
+      const { modalMeta } = getState();
+      if (modalMeta && !modalMeta.loading) {
+        dispatch(setModalMetaLoading({ loading: true, error: false }));
+        getMetadata(metakey, metaType)
+          .then((response) => {
+            if (metaType === 'widget') {
+              dispatch(setModalMetaData(response.data));
+            } else {
+              dispatch(setModalMetaData(response.data));
+            }
+          })
+          .catch(() => {
+            dispatch(setModalMetaLoading({ loading: false, error: true }));
+          });
+      }
     }
-  }
 );
 
 export const setModalMetaClosed = createThunkAction(

--- a/components/modals/meta/actions.js
+++ b/components/modals/meta/actions.js
@@ -17,7 +17,6 @@ export const getModalMetaData = createThunkAction(
 
         getMetadata(metakey, metaType)
           .then((response) => {
-            console.log('XPTO', response);
             if (metaType === 'widget') {
               dispatch(setModalMetaData(response.data));
             } else {

--- a/components/modals/meta/actions.js
+++ b/components/modals/meta/actions.js
@@ -8,13 +8,17 @@ export const setModalMetaSettings = createThunkAction('setModalMetaSettings');
 
 export const getModalMetaData = createThunkAction(
   'getModalMetaData',
-  (metaKey) => (dispatch, getState) => {
+  ({metakey, metaType}) => (dispatch, getState) => {
     const { modalMeta } = getState();
     if (modalMeta && !modalMeta.loading) {
       dispatch(setModalMetaLoading({ loading: true, error: false }));
-      getMetadata(metaKey)
+      getMetadata(metakey, metaType)
         .then((response) => {
-          dispatch(setModalMetaData(response.data));
+          if (metaType === 'widget') {
+            dispatch(setModalMetaData(response.data[0].info))
+          } else {
+            dispatch(setModalMetaData(response.data));
+          }
         })
         .catch(() => {
           dispatch(setModalMetaLoading({ loading: false, error: true }));

--- a/components/modals/meta/actions.js
+++ b/components/modals/meta/actions.js
@@ -11,8 +11,10 @@ export const getModalMetaData = createThunkAction(
   ({ metakey, metaType }) =>
     (dispatch, getState) => {
       const { modalMeta } = getState();
+
       if (modalMeta && !modalMeta.loading) {
         dispatch(setModalMetaLoading({ loading: true, error: false }));
+
         getMetadata(metakey, metaType)
           .then((response) => {
             if (metaType === 'widget') {

--- a/components/modals/meta/component.jsx
+++ b/components/modals/meta/component.jsx
@@ -31,7 +31,6 @@ class ModalMeta extends PureComponent {
   }
 
   componentDidUpdate(prevProps) {
-    console.log('componentDidUpdate', this.props);
     const { getModalMetaData, metakey, metaData, metaType } = this.props;
     if (metakey && metakey !== prevProps.metakey) {
       getModalMetaData({ metakey, metaType });

--- a/components/modals/meta/component.jsx
+++ b/components/modals/meta/component.jsx
@@ -31,6 +31,7 @@ class ModalMeta extends PureComponent {
   }
 
   componentDidUpdate(prevProps) {
+    console.log('componentDidUpdate', this.props);
     const { getModalMetaData, metakey, metaData, metaType } = this.props;
     if (metakey && metakey !== prevProps.metakey) {
       getModalMetaData({ metakey, metaType });

--- a/components/modals/meta/component.jsx
+++ b/components/modals/meta/component.jsx
@@ -15,6 +15,7 @@ class ModalMeta extends PureComponent {
     setModalMetaClosed: PropTypes.func,
     metaData: PropTypes.object,
     getModalMetaData: PropTypes.func,
+    metaType: PropTypes.string,
     metakey: PropTypes.string,
     tableData: PropTypes.object,
     loading: PropTypes.bool,
@@ -23,16 +24,16 @@ class ModalMeta extends PureComponent {
   };
 
   componentDidMount() {
-    const { getModalMetaData, metakey } = this.props;
+    const { getModalMetaData, metakey, metaType } = this.props;
     if (metakey) {
-      getModalMetaData(metakey);
+      getModalMetaData({metakey, metaType});
     }
   }
 
   componentDidUpdate(prevProps) {
-    const { getModalMetaData, metakey, metaData } = this.props;
+    const { getModalMetaData, metakey, metaData, metaType } = this.props;
     if (metakey && metakey !== prevProps.metakey) {
-      getModalMetaData(metakey);
+      getModalMetaData({metakey, metaType});
     }
 
     if (

--- a/components/modals/meta/component.jsx
+++ b/components/modals/meta/component.jsx
@@ -26,14 +26,14 @@ class ModalMeta extends PureComponent {
   componentDidMount() {
     const { getModalMetaData, metakey, metaType } = this.props;
     if (metakey) {
-      getModalMetaData({metakey, metaType});
+      getModalMetaData({ metakey, metaType });
     }
   }
 
   componentDidUpdate(prevProps) {
     const { getModalMetaData, metakey, metaData, metaType } = this.props;
     if (metakey && metakey !== prevProps.metakey) {
-      getModalMetaData({metakey, metaType});
+      getModalMetaData({ metakey, metaType });
     }
 
     if (
@@ -51,15 +51,8 @@ class ModalMeta extends PureComponent {
 
   getContent() {
     const { metaData, tableData, loading, error, locationName } = this.props;
-    const {
-      subtitle,
-      overview,
-      citation,
-      map_service,
-      learn_more,
-      download_data,
-      amazon_link,
-    } = metaData || {};
+    const { subtitle, overview, citation, learn_more, download_data } =
+      metaData || {};
 
     const parsedCitation =
       citation &&
@@ -109,7 +102,7 @@ class ModalMeta extends PureComponent {
                 <div className="body">{this.parseContent(parsedCitation)}</div>
               </div>
             )}
-            {(learn_more || download_data || map_service || amazon_link) && (
+            {(learn_more || download_data) && (
               <div className="ext-actions">
                 {learn_more && (
                   <a
@@ -127,15 +120,6 @@ class ModalMeta extends PureComponent {
                     rel="noopener noreferrer"
                   >
                     <Button size="medium">DOWNLOAD DATA</Button>
-                  </a>
-                )}
-                {(map_service || amazon_link) && (
-                  <a
-                    href={map_service || amazon_link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <Button size="medium">OPEN IN ARCGIS</Button>
                   </a>
                 )}
               </div>

--- a/components/modals/meta/component.jsx
+++ b/components/modals/meta/component.jsx
@@ -84,7 +84,7 @@ class ModalMeta extends PureComponent {
                         dangerouslySetInnerHTML={{ __html: lowerCase(key) }} // eslint-disable-line
                       />
                       <div className="description-column">
-                        {this.parseContent(tableData[key])}
+                        <p>{this.parseMarkdownURLToHTML(tableData[key])}</p>
                       </div>
                     </div>
                   ) : null
@@ -93,13 +93,17 @@ class ModalMeta extends PureComponent {
             {overview && (
               <div className="overview">
                 <h4>Overview</h4>
-                <div className="body">{this.parseContent(overview)}</div>
+                <div className="body">
+                  <p>{this.parseMarkdownURLToHTML(overview)}</p>
+                </div>
               </div>
             )}
             {parsedCitation && (
               <div className="citation">
                 <h5>Citation</h5>
-                <div className="body">{this.parseContent(parsedCitation)}</div>
+                <div className="body">
+                  <p>{this.parseMarkdownURLToHTML(parsedCitation)}</p>
+                </div>
               </div>
             )}
             {(learn_more || download_data) && (
@@ -130,26 +134,15 @@ class ModalMeta extends PureComponent {
     );
   }
 
-  parseContent = (html) => {
-    return (
-      <div>
-        {ReactHtmlParser(html, {
-          transform: (node) =>
-            node.name === 'a' ? (
-              <a
-                key={node.attribs.href}
-                href={node.attribs.href}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {node.children[0].data}
-              </a>
-            ) : (
-              ''
-            ),
-        })}
-      </div>
+  parseMarkdownURLToHTML = (markdown) => {
+    const markdownRegex = /\[([^\]]+)\]\(([^)]+)\)/g;
+
+    const htmlAnchor = markdown.replace(
+      markdownRegex,
+      '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>'
     );
+
+    return <>{ReactHtmlParser(htmlAnchor)}</>;
   };
 
   render() {

--- a/components/modals/meta/selectors.js
+++ b/components/modals/meta/selectors.js
@@ -10,8 +10,6 @@ const META_FIELDS = [
   'overview',
   'learn_more',
   'download_data',
-  'map_service',
-  'amazon_link',
 ];
 const TABLE_FIELDS = [
   'function',

--- a/components/modals/meta/selectors.js
+++ b/components/modals/meta/selectors.js
@@ -16,8 +16,8 @@ const TABLE_FIELDS = [
   'resolution',
   'geographic_coverage',
   'source',
-  'frequency_of_updates',
-  'date_of_content',
+  'content_date',
+  'update_frequency',
   'cautions',
   'license',
 ];

--- a/components/widgets/forest-change/tree-loss-primary/index.js
+++ b/components/widgets/forest-change/tree-loss-primary/index.js
@@ -75,7 +75,7 @@ export default {
   pendingKeys: ['threshold', 'years'],
   refetchKeys: ['landCategory', 'threshold'],
   dataType: 'lossPrimary',
-  metaKey: '641b158b-f5be-40ae-9b13-8c5c35925b59',
+  metaKey: 'widget_primary_forest_loss',
   datasets: [
     {
       dataset: POLITICAL_BOUNDARIES_DATASET,

--- a/components/widgets/forest-change/tree-loss-primary/index.js
+++ b/components/widgets/forest-change/tree-loss-primary/index.js
@@ -75,7 +75,7 @@ export default {
   pendingKeys: ['threshold', 'years'],
   refetchKeys: ['landCategory', 'threshold'],
   dataType: 'lossPrimary',
-  metaKey: 'widget_primary_forest_loss',
+  metaKey: '641b158b-f5be-40ae-9b13-8c5c35925b59',
   datasets: [
     {
       dataset: POLITICAL_BOUNDARIES_DATASET,

--- a/layouts/dashboards/component.jsx
+++ b/layouts/dashboards/component.jsx
@@ -216,7 +216,7 @@ class DashboardsPage extends PureComponent {
           <MapControls className="map-controls" />
         </Desktop>
         <Share />
-        <ModalMeta />
+        <ModalMeta metaType="widget" />
         {widgetAnchor && (
           <ScrollTo target={widgetAnchor} afterScroll={clearScrollTo} />
         )}

--- a/layouts/embed/widget/component.jsx
+++ b/layouts/embed/widget/component.jsx
@@ -16,7 +16,7 @@ const WidgetEmbedPage = ({ widget, trase }) => (
   <div className={cx('l-embed-widget-page', { '-trase': trase })}>
     <Widgets className="embed-widget" embed widget={widget} />
     <Share />
-    <ModalMeta />
+    <ModalMeta metaType="widget" />
     <CountryDataProvider />
     <WhitelistsProvider />
     <GeodescriberProvider embed />

--- a/layouts/map/component.jsx
+++ b/layouts/map/component.jsx
@@ -16,7 +16,7 @@ import MyGFWProvider from 'providers/mygfw-provider';
 import MetaProvider from 'providers/meta-provider';
 
 import ModalWelcome from 'components/modals/welcome';
-import MetaModal from 'components/modals/meta';
+import ModalMeta from 'components/modals/meta';
 import ShareModal from 'components/modals/share';
 import AreaOfInterestModal from 'components/modals/area-of-interest';
 import ClimateModal from 'components/modals/climate';
@@ -96,7 +96,7 @@ class MainMapComponent extends PureComponent {
         )}
         <RecentImagery active={recentActive} />
         <ShareModal />
-        <MetaModal metaType="layer" />
+        <ModalMeta metaType="layer" />
         <AreaOfInterestModal viewAfterSave clearAfterDelete canDelete />
         <ClimateModal />
         <FiresModal />

--- a/layouts/map/component.jsx
+++ b/layouts/map/component.jsx
@@ -96,7 +96,7 @@ class MainMapComponent extends PureComponent {
         )}
         <RecentImagery active={recentActive} />
         <ShareModal />
-        <MetaModal />
+        <MetaModal metaType="layer" />
         <AreaOfInterestModal viewAfterSave clearAfterDelete canDelete />
         <ClimateModal />
         <FiresModal />

--- a/pages/api/metadata/[...params].js
+++ b/pages/api/metadata/[...params].js
@@ -12,7 +12,7 @@ export default async (req, res) => {
 
     const response = await axios.get(url);
 
-    return res.status(200).json(response.data);
+    return res.status(200).json(response.data.data);
   } catch (error) {
     return res.status(400).end(error.message);
   }

--- a/pages/api/metadata/[...params].js
+++ b/pages/api/metadata/[...params].js
@@ -7,13 +7,29 @@ const GFW_METADATA_API_URL =
 
 export default async (req, res) => {
   try {
-    const path = req.query.params.join('/');
-    const url = `${GFW_METADATA_API_URL}/${path}/`;
+    // const path = req.query.params.join('/');
+    // const url = `${GFW_METADATA_API_URL}/${path}`; // ${path}
+    const url = `${GFW_METADATA_API_URL}/dataset/birdlife_endemic_bird_areas`;
+    const datasetMetadata = await axios.get(url);
+    // const datasetVersionMetadata = await axios.get(`${url}/latest/metadata`);
+    const datasetVersionMetadata = await axios.get(
+      `${GFW_METADATA_API_URL}/dataset/gfw_integrated_alerts/v20240605/metadata`
+    );
 
-    const response = await axios.get(url);
+    const response = {
+      ...datasetMetadata.data.data,
+      metadata: {
+        ...datasetMetadata.data.data.metadata,
+        ...datasetVersionMetadata.data.data,
+      },
+    };
 
-    return res.status(200).json(response.data.data);
+    return res.status(200).json(response);
   } catch (error) {
+    if (error.response) {
+      return res.status(400).end(error.response.data.message);
+    }
+
     return res.status(400).end(error.message);
   }
 };

--- a/pages/api/metadata/[...params].js
+++ b/pages/api/metadata/[...params].js
@@ -16,13 +16,24 @@ export default async (req, res) => {
       `${GFW_METADATA_API_URL}/dataset/gfw_integrated_alerts/v20240605/metadata`
     );
 
+    const dataVersionMetadataObject = datasetVersionMetadata.data.data;
+
     const response = {
       ...datasetMetadata.data.data,
       metadata: {
         ...datasetMetadata.data.data.metadata,
-        ...datasetVersionMetadata.data.data,
       },
     };
+
+    /*
+     * Merging the metadata from the second request
+     * avoiding overwrite the object properties with null value
+     */
+    Object.keys(dataVersionMetadataObject).forEach((key) => {
+      if (dataVersionMetadataObject[key] !== null) {
+        response.metadata[key] = dataVersionMetadataObject[key];
+      }
+    });
 
     return res.status(200).json(response);
   } catch (error) {

--- a/pages/api/set-cookie.js
+++ b/pages/api/set-cookie.js
@@ -10,7 +10,7 @@ export default async function cookieHandler(req, res) {
         serialize('gfw-token', body.token, {
           path: '/',
           httpOnly: true,
-          maxAge: 2592000,
+          maxAge: 31536000, // expires in 1 year
         })
       );
       res.status(200).end('ok');

--- a/pages/api/widget-metadata/[...params].js
+++ b/pages/api/widget-metadata/[...params].js
@@ -1,15 +1,14 @@
-import { GFW_DATA_API, GFW_STAGING_DATA_API } from 'utils/apis';
+import { GFW_METADATA_API, GFW_STAGING_METADATA_API } from 'utils/apis';
 import axios from 'axios';
 
 const ENVIRONMENT = process.env.NEXT_PUBLIC_FEATURE_ENV;
 const GFW_METADATA_API_URL =
-  ENVIRONMENT === 'staging' ? GFW_STAGING_DATA_API : GFW_DATA_API;
+  ENVIRONMENT === 'staging' ? GFW_STAGING_METADATA_API : GFW_METADATA_API;
 
 export default async (req, res) => {
   try {
     const path = req.query.params.join('/');
     const url = `${GFW_METADATA_API_URL}/${path}/`;
-
     const response = await axios.get(url);
 
     return res.status(200).json(response.data);

--- a/pages/my-gfw.js
+++ b/pages/my-gfw.js
@@ -2,6 +2,7 @@ import PageLayout from 'wrappers/page';
 import MyGfw from 'layouts/my-gfw';
 
 import PropTypes from 'prop-types';
+import { parse } from 'cookie';
 
 import { getPublishedNotifications } from 'services/notifications';
 
@@ -16,14 +17,17 @@ const MyGfwPage = (props) => (
   </PageLayout>
 );
 
-export const getStaticProps = async () => {
+export const getServerSideProps = async (context) => {
   const notifications = await getPublishedNotifications();
+
+  const cookies = context.req.headers.cookie || null;
+
+  console.log('cookies', (cookies && parse(cookies)['gfw-token']) || 'empty');
 
   return {
     props: {
       notifications: notifications || [],
     },
-    revalidate: 10,
   };
 };
 

--- a/providers/mygfw-provider/actions.js
+++ b/providers/mygfw-provider/actions.js
@@ -11,7 +11,7 @@ export const setMyGFW = createAction('setMyGFW');
 export const getUserProfile = createThunkAction(
   'getUserProfile',
   (urlToken) => (dispatch) => {
-    const token = !isServer && (urlToken || localStorage.getItem('userToken'));
+    const token = !isServer && urlToken;
     if (token) {
       dispatch(setMyGFWLoading({ loading: true, error: false }));
       checkLoggedIn(token)

--- a/services/metadata.js
+++ b/services/metadata.js
@@ -1,16 +1,12 @@
-import { metadataRequest, rwRequest } from 'utils/request';
+import { metadataRequest } from 'utils/request';
 
 export const getMetadata = (slug, metaType) => {
   if (metaType === 'widget') {
-    return rwRequest.get(`widget/${slug}`)
-    .then((resp) => {
-      const dataset = resp.data?.dataset;
-      return rwRequest.get(`dataset/${dataset}/widget/${slug}/metadata`)
-    })
+    return metadataRequest.get(slug);
   }
-  
+
   return metadataRequest.get(slug);
-}
+};
 
 export default {
   getMetadata,

--- a/services/metadata.js
+++ b/services/metadata.js
@@ -1,11 +1,11 @@
-import { metadataRequest } from 'utils/request';
+import { metadataRequest, metadataWidgetRequest } from 'utils/request';
 
 export const getMetadata = (slug, metaType) => {
   if (metaType === 'widget') {
-    return metadataRequest.get(slug);
+    return metadataWidgetRequest.get(slug);
   }
 
-  return metadataRequest.get(slug);
+  return metadataRequest.get(`dataset/${slug}`);
 };
 
 export default {

--- a/services/metadata.js
+++ b/services/metadata.js
@@ -1,6 +1,16 @@
-import { metadataRequest } from 'utils/request';
+import { metadataRequest, rwRequest } from 'utils/request';
 
-export const getMetadata = (slug) => metadataRequest.get(slug);
+export const getMetadata = (slug, metaType) => {
+  if (metaType === 'widget') {
+    return rwRequest.get(`widget/${slug}`)
+    .then((resp) => {
+      const dataset = resp.data?.dataset;
+      return rwRequest.get(`dataset/${dataset}/widget/${slug}/metadata`)
+    })
+  }
+  
+  return metadataRequest.get(slug);
+}
 
 export default {
   getMetadata,

--- a/utils/proxies.js
+++ b/utils/proxies.js
@@ -2,6 +2,7 @@ export const PROXIES = {
   GFW_API: '/api/gfw',
   DATA_API: '/api/data',
   METADATA_API: '/api/metadata',
+  WIDGET_METADATA_API: '/api/widget-metadata',
   RESOURCE_WATCH_API: '/api/gfw/v1',
   PLANET_API: '/api/planet-mosaics',
   PLANET_TILES: '/api/planet-tiles',

--- a/utils/request.js
+++ b/utils/request.js
@@ -17,7 +17,7 @@ const ENVIRONMENT = process.env.NEXT_PUBLIC_FEATURE_ENV;
 
 // We never use the staging api
 const GFW_API_URL = GFW_API;
-const GFW_METADATA_API_URL =
+const GFW_WIDGET_METADATA_API_URL =
   ENVIRONMENT === 'staging' ? GFW_STAGING_METADATA_API : GFW_METADATA_API;
 const DATA_API_URL =
   ENVIRONMENT === 'staging' ? GFW_STAGING_DATA_API : GFW_DATA_API;
@@ -62,10 +62,20 @@ export const dataRequest = axios.create({
 export const metadataRequest = axios.create({
   ...defaultRequestConfig,
   ...(isServer && {
-    baseURL: GFW_METADATA_API_URL,
+    baseURL: DATA_API_URL,
   }),
   ...(!isServer && {
     baseURL: PROXIES.METADATA_API,
+  }),
+});
+
+export const metadataWidgetRequest = axios.create({
+  ...defaultRequestConfig,
+  ...(isServer && {
+    baseURL: GFW_WIDGET_METADATA_API_URL,
+  }),
+  ...(!isServer && {
+    baseURL: PROXIES.WIDGET_METADATA_API,
   }),
 });
 


### PR DESCRIPTION
## Overview

A user shared their area with me: http://www.globalforestwatch.org/dashboards/aoi/6557f6b9695f90001af381ea (currently it’s set to public), but when a user chooses to change it to private, it’s no longer accessible: https://www.globalforestwatch.org/dashboards/aoi/6557f6b9695f90001af381ea/?lang=en in their own My GFW account.


## Notes

The issue was related to an specific cookie (gfw-token) that once expired, the user remained logged in because the same cookie is found in the localStorage. The token must be validated by cookies instead of local Storage, so I removed this validation to ensure that every time the cookie expires, a new login is required. 

Cookie was set to expires in 1 year.

