### PR TITLE
[FLAG-973] Private saved areas are not accessible in a user's own My GFW account

### DIFF
--- a/pages/api/set-cookie.js
+++ b/pages/api/set-cookie.js
@@ -10,7 +10,7 @@ export default async function cookieHandler(req, res) {
         serialize('gfw-token', body.token, {
           path: '/',
           httpOnly: true,
-          maxAge: 2592000,
+          maxAge: 31536000, // expires in 1 year
         })
       );
       res.status(200).end('ok');

--- a/pages/my-gfw.js
+++ b/pages/my-gfw.js
@@ -2,7 +2,6 @@ import PageLayout from 'wrappers/page';
 import MyGfw from 'layouts/my-gfw';
 
 import PropTypes from 'prop-types';
-import { parse } from 'cookie';
 
 import { getPublishedNotifications } from 'services/notifications';
 
@@ -17,17 +16,14 @@ const MyGfwPage = (props) => (
   </PageLayout>
 );
 
-export const getServerSideProps = async (context) => {
+export const getStaticProps = async () => {
   const notifications = await getPublishedNotifications();
-
-  const cookies = context.req.headers.cookie || null;
-
-  console.log('cookies', (cookies && parse(cookies)['gfw-token']) || 'empty');
 
   return {
     props: {
       notifications: notifications || [],
     },
+    revalidate: 10,
   };
 };
 

--- a/pages/my-gfw.js
+++ b/pages/my-gfw.js
@@ -2,6 +2,7 @@ import PageLayout from 'wrappers/page';
 import MyGfw from 'layouts/my-gfw';
 
 import PropTypes from 'prop-types';
+import { parse } from 'cookie';
 
 import { getPublishedNotifications } from 'services/notifications';
 
@@ -16,14 +17,17 @@ const MyGfwPage = (props) => (
   </PageLayout>
 );
 
-export const getStaticProps = async () => {
+export const getServerSideProps = async (context) => {
   const notifications = await getPublishedNotifications();
+
+  const cookies = context.req.headers.cookie || null;
+
+  console.log('cookies', (cookies && parse(cookies)['gfw-token']) || 'empty');
 
   return {
     props: {
       notifications: notifications || [],
     },
-    revalidate: 10,
   };
 };
 

--- a/providers/mygfw-provider/actions.js
+++ b/providers/mygfw-provider/actions.js
@@ -11,7 +11,7 @@ export const setMyGFW = createAction('setMyGFW');
 export const getUserProfile = createThunkAction(
   'getUserProfile',
   (urlToken) => (dispatch) => {
-    const token = !isServer && (urlToken || localStorage.getItem('userToken'));
+    const token = !isServer && urlToken;
     if (token) {
       dispatch(setMyGFWLoading({ loading: true, error: false }));
       checkLoggedIn(token)

--- a/providers/mygfw-provider/actions.js
+++ b/providers/mygfw-provider/actions.js
@@ -11,8 +11,15 @@ export const setMyGFW = createAction('setMyGFW');
 export const getUserProfile = createThunkAction(
   'getUserProfile',
   (urlToken) => (dispatch) => {
-    const token = !isServer && urlToken;
-    if (token) {
+    let isTokenExpired = false;
+    const tokenExpiration = localStorage.getItem('userTokenExpirationDate');
+    const token = !isServer && (urlToken || localStorage.getItem('userToken'));
+
+    if (!tokenExpiration || new Date(tokenExpiration) <= new Date()) {
+      isTokenExpired = true;
+    }
+
+    if (token && !isTokenExpired) {
       dispatch(setMyGFWLoading({ loading: true, error: false }));
       checkLoggedIn(token)
         .then((authResponse) => {

--- a/services/user.js
+++ b/services/user.js
@@ -19,7 +19,16 @@ export const setUserToken = (token) => {
     if (token?.endsWith('#')) {
       serializedToken = token.replace(/#$/, '');
     }
+
+    const expirationDate = new Date();
+    expirationDate.setUTCFullYear(expirationDate.getFullYear() + 1);
+
     localStorage.setItem('userToken', serializedToken);
+    localStorage.setItem(
+      'userTokenExpirationDate',
+      expirationDate.toISOString()
+    ); // 1 year
+
     apiAuthRequest.defaults.headers.Authorization = `Bearer ${serializedToken}`;
   }
 };
@@ -78,6 +87,7 @@ export const logout = () =>
   apiAuthRequest.get('/auth/logout').then((response) => {
     if (response.status < 400 && !isServer) {
       localStorage.removeItem('userToken');
+      localStorage.removeItem('userTokenExpirationDate');
       removeServerCookie();
       window.location.reload();
     }


### PR DESCRIPTION
## Overview

A user shared their area with me: http://www.globalforestwatch.org/dashboards/aoi/6557f6b9695f90001af381ea (currently it’s set to public), but when a user chooses to change it to private, it’s no longer accessible: https://www.globalforestwatch.org/dashboards/aoi/6557f6b9695f90001af381ea/?lang=en in their own My GFW account.


## Notes

The issue was related to an specific cookie (gfw-token) that once expired, the user remained logged in because the same cookie is found in the localStorage. The token must be validated by cookies instead of local Storage, so I removed this validation to ensure that every time the cookie expires, a new login is required. 

Cookie was set to expires in 1 year.

