### PR TITLE
[FLAG-1128] Incorrect query in weekly VIIRS alert widget

### DIFF
--- a/components/widgets/fires/fires-alerts/index.js
+++ b/components/widgets/fires/fires-alerts/index.js
@@ -327,26 +327,24 @@ const defaultConfig = {
         const maxYear = Math.max(...years);
         const latestDate = latest && latest.date;
 
-        return (
-          {
-            alerts: data,
-            latest: latestDate,
-            options: {
-              compareYear: years
-                .filter((y) => y !== maxYear)
-                .map((y) => ({
-                  label: y,
-                  value: y,
-                })),
-            },
-            settings: {
-              startDateAbsolute: moment(latestDate)
-                .add(-3, 'month')
-                .format('YYYY-MM-DD'),
-              endDateAbsolute: latestDate,
-            },
-          } || {}
-        );
+        return {
+          alerts: data,
+          latest: latestDate,
+          options: {
+            compareYear: years
+              .filter((y) => y !== maxYear)
+              .map((y) => ({
+                label: y,
+                value: y,
+              })),
+          },
+          settings: {
+            startDateAbsolute: moment(latestDate)
+              .add(-3, 'month')
+              .format('YYYY-MM-DD'),
+            endDateAbsolute: latestDate,
+          },
+        };
       })
     );
   },

--- a/components/widgets/fires/fires-alerts/selectors.js
+++ b/components/widgets/fires/fires-alerts/selectors.js
@@ -59,7 +59,7 @@ const generateYearWeekArray = (startDate, endDate) => {
 const getAllAlerts = createSelector([getAlerts], (alerts) => {
   if (!alerts) return null;
 
-  const filler = { iso: alerts[0]?.iso, alert__count: 0 };
+  const filler = { iso: alerts[0]?.iso, alert__count: 0, confidence__cat: 'h' };
   const minYear = '2012';
   const maxYear = new Date();
 
@@ -180,18 +180,11 @@ export const getData = createSelector(
           ? yearDataByWeek[i].length - 1
           : 0;
 
-        let objectsReduced = {};
-
         for (let index = 0; index <= yearDataLength; index += 1) {
           if (yearDataByWeek[i]) {
-            objectsReduced = Object.assign(objectsReduced, {
-              ...yearDataByWeek[i][index],
-              count: yearDataByWeek[i][index].count,
-            });
+            formattedData.push(yearDataByWeek[i][index]);
           }
         }
-
-        formattedData.push(objectsReduced);
       }
     });
 

--- a/components/widgets/fires/fires-alerts/selectors.js
+++ b/components/widgets/fires/fires-alerts/selectors.js
@@ -383,10 +383,10 @@ export const parseConfig = createSelector(
     return {
       ...getChartConfig(colors, moment(latest), {}, ''),
       xAxis: {
+        dataKey: 'month',
         tickCount: 12,
-        interval: 4,
-        scale: 'point',
-        tickFormatter: (t) => moment(t).format('MMM'),
+        interval: 0,
+        tickFormatter: (t) => t.charAt(0).toUpperCase() + t.slice(1),
         ...(typeof endIndex === 'number' &&
           typeof startIndex === 'number' &&
           endIndex - startIndex < 10 && {

--- a/components/widgets/fires/fires-alerts/selectors.js
+++ b/components/widgets/fires/fires-alerts/selectors.js
@@ -1,5 +1,13 @@
 /* eslint-disable prefer-destructuring */
 import { createSelector, createStructuredSelector } from 'reselect';
+import {
+  isWithinInterval,
+  startOfWeek,
+  endOfWeek,
+  eachWeekOfInterval,
+  getYear,
+  getWeek,
+} from 'date-fns';
 import moment from 'moment';
 import { formatNumber } from 'utils/format';
 import isEmpty from 'lodash/isEmpty';
@@ -33,8 +41,85 @@ const getIndicator = (state) => state.indicator;
 
 const MINGAP = 4;
 
+const generateYearWeekArray = (startDate, endDate) => {
+  const weeks = eachWeekOfInterval(
+    {
+      start: startOfWeek(startDate, { weekStartsOn: 1 }),
+      end: endOfWeek(endDate, { weekStartsOn: 1 }),
+    },
+    { weekStartsOn: 1 }
+  );
+
+  return weeks.map((date) => ({
+    year: getYear(date),
+    week: getWeek(date, { weekStartsOn: 1 }),
+  }));
+};
+
+const getAllAlerts = createSelector([getAlerts], (alerts) => {
+  if (!alerts) return null;
+
+  const filler = { iso: alerts[0]?.iso, alert__count: 0 };
+  const minYear = '2012';
+  const maxYear = new Date();
+
+  const yearProperty = 'alert__year';
+  const weekProperty = 'alert__week';
+
+  const start = new Date(minYear?.toString());
+  const end = new Date(maxYear?.toString());
+  const completeYearWeekArray = generateYearWeekArray(start, end);
+
+  // Create a set of existing year-week combinations for quick lookup
+  const existingAlerts = new Set(
+    alerts.map((alert) => `${alert[yearProperty]}-${alert[weekProperty]}`)
+  );
+
+  // Iterate through the complete array and add missing values
+  const mockedAlerts = completeYearWeekArray.map((item) => {
+    const weekStartDate = startOfWeek(
+      new Date(item.year, 0, (item.week - 1) * 7),
+      { weekStartsOn: 1 }
+    );
+    const weekEndDate = endOfWeek(new Date(item.year, 0, (item.week - 1) * 7), {
+      weekStartsOn: 1,
+    });
+
+    if (
+      isWithinInterval(weekStartDate, { start, end }) ||
+      isWithinInterval(weekEndDate, { start, end })
+    ) {
+      const key = `${item.year}-${item.week}`;
+
+      if (!existingAlerts.has(key)) {
+        const mockedAlert = {
+          [yearProperty]: item.year,
+          [weekProperty]: item.week,
+          ...filler,
+        };
+
+        return mockedAlert;
+      }
+    }
+
+    return null;
+  });
+
+  const allAlerts = [...alerts, ...mockedAlerts.filter((item) => !!item)];
+
+  // Sort the array again by year and week properties to maintain order
+  allAlerts.sort((a, b) => {
+    if (a[yearProperty] === b[yearProperty]) {
+      return a[weekProperty] - b[weekProperty];
+    }
+    return a[yearProperty] - b[yearProperty];
+  });
+
+  return allAlerts;
+});
+
 export const getData = createSelector(
-  [getAlerts, getLatest],
+  [getAllAlerts, getLatest],
   (data, latest) => {
     if (!data || isEmpty(data)) return null;
 
@@ -272,7 +357,7 @@ export const parseConfig = createSelector(
         unit: ` ${dataset.toUpperCase()} alerts`,
         color: colors.main,
         unitFormat: (value) =>
-          Number.isInteger(value) && formatNumber({ num: value, unit: ',' }),
+          Number.isInteger(value) ? formatNumber({ num: value, unit: ',' }) : 0,
       },
     ];
 
@@ -291,7 +376,7 @@ export const parseConfig = createSelector(
         color: '#49b5e3',
         nullValue: 'No data available',
         unitFormat: (value) =>
-          Number.isInteger(value) && formatNumber({ num: value, unit: ',' }),
+          Number.isInteger(value) ? formatNumber({ num: value, unit: ',' }) : 0,
       });
     }
 

--- a/components/widgets/fires/fires-alerts/selectors.js
+++ b/components/widgets/fires/fires-alerts/selectors.js
@@ -383,7 +383,7 @@ export const parseConfig = createSelector(
     return {
       ...getChartConfig(colors, moment(latest), {}, ''),
       xAxis: {
-        dataKey: 'month',
+        dataKey: 'monthLabel',
         tickCount: 12,
         interval: 0,
         tickFormatter: (t) => t.charAt(0).toUpperCase() + t.slice(1),

--- a/components/widgets/fires/fires-alerts/selectors.js
+++ b/components/widgets/fires/fires-alerts/selectors.js
@@ -125,7 +125,7 @@ export const getData = createSelector(
 
     const parsedData = data.map((d) => ({
       ...d,
-      count: d.alert__count || d.area_ha,
+      count: d.alert__count || d.area_ha || 0,
       week: parseInt(d.alert__week, 10),
       year: parseInt(d.alert__year, 10),
     }));
@@ -273,7 +273,7 @@ export const parseData = createSelector(
         return {
           ...d,
           compareYear,
-          compareCount: compareWeek ? compareWeek.count : null,
+          compareCount: compareWeek ? compareWeek.count : 0,
         };
       }
 

--- a/components/widgets/fires/fires-alerts/selectors.js
+++ b/components/widgets/fires/fires-alerts/selectors.js
@@ -7,6 +7,7 @@ import sortBy from 'lodash/sortBy';
 import orderBy from 'lodash/orderBy';
 import sumBy from 'lodash/sumBy';
 import groupBy from 'lodash/groupBy';
+import toArray from 'lodash/toArray';
 import max from 'lodash/max';
 import min from 'lodash/min';
 
@@ -71,7 +72,7 @@ export const getData = createSelector(
     };
 
     years.forEach((year) => {
-      const yearDataByWeek = groupBy(groupedByYear[year], 'week');
+      const yearDataByWeek = toArray(groupBy(groupedByYear[year], 'week'));
       const lastWeekOfYearIso = moment(`${year}-12-31`).isoWeek();
       const yearLength = { [year]: moment(`${year}-12-31`).isoWeek() };
 
@@ -86,7 +87,7 @@ export const getData = createSelector(
       }
 
       for (let i = 1; i <= yearLength[year]; i += 1) {
-        if (Object.keys(yearDataByWeek).length < i) {
+        if (yearDataByWeek.length < i) {
           return;
         }
 
@@ -94,13 +95,13 @@ export const getData = createSelector(
           ? yearDataByWeek[i].length - 1
           : 0;
 
-        let objectsReduced = { count: 0, week: i, year: parseInt(year, 10) };
+        let objectsReduced = {};
 
         for (let index = 0; index <= yearDataLength; index += 1) {
           if (yearDataByWeek[i]) {
             objectsReduced = Object.assign(objectsReduced, {
               ...yearDataByWeek[i][index],
-              count: objectsReduced.count + yearDataByWeek[i][index].count,
+              count: yearDataByWeek[i][index].count,
             });
           }
         }
@@ -193,6 +194,7 @@ export const parseData = createSelector(
 
       return d;
     });
+
     return parsedData;
   }
 );

--- a/components/widgets/utils/data.js
+++ b/components/widgets/utils/data.js
@@ -317,9 +317,10 @@ export const getDatesData = (data) =>
 
     return {
       ...d,
-      ...((firstDayOfWeek.date() <= 7 || index === 0) && {
-        monthLabel: moment().year(d.year).isoWeek(d.week).format('MMM'),
-      }),
+      ...((firstDayOfWeek.date() <= 7 || index === 0) &&
+        d?.confidence__cat === 'h' && {
+          monthLabel: moment().year(d.year).isoWeek(d.week).format('MMM'),
+        }),
       date: d.date
         ? moment(d.date).format('YYYY-MM-DD')
         : moment()

--- a/components/widgets/utils/data.js
+++ b/components/widgets/utils/data.js
@@ -5,7 +5,6 @@ import concat from 'lodash/concat';
 import maxBy from 'lodash/maxBy';
 import minBy from 'lodash/minBy';
 import sumBy from 'lodash/sumBy';
-import upperCase from 'lodash/upperCase';
 import moment from 'moment';
 import range from 'lodash/range';
 
@@ -309,17 +308,26 @@ export const getCumulativeStatsData = (data) => {
 };
 
 export const getDatesData = (data) =>
-  data.map((d) => ({
-    ...d,
-    date: d.date
-      ? moment(d.date).format('YYYY-MM-DD')
-      : moment()
-          .year(d.year)
-          .isoWeek(d.week)
-          .startOf('isoWeek')
-          .format('YYYY-MM-DD'),
-    month: upperCase(moment().year(d.year).isoWeek(d.week).format('MMM')),
-  }));
+  data.map((d, index) => {
+    const firstDayOfWeek = moment()
+      .year(d.year)
+      .isoWeek(d.week)
+      .startOf('isoWeek');
+
+    return {
+      ...d,
+      ...((firstDayOfWeek.date() <= 7 || index === 0) && {
+        month: moment().year(d.year).isoWeek(d.week).format('MMM'),
+      }),
+      date: d.date
+        ? moment(d.date).format('YYYY-MM-DD')
+        : moment()
+            .year(d.year)
+            .isoWeek(d.week)
+            .startOf('isoWeek')
+            .format('YYYY-MM-DD'),
+    };
+  });
 
 export const getChartConfig = (
   colors,

--- a/components/widgets/utils/data.js
+++ b/components/widgets/utils/data.js
@@ -7,6 +7,7 @@ import minBy from 'lodash/minBy';
 import sumBy from 'lodash/sumBy';
 import moment from 'moment';
 import range from 'lodash/range';
+import upperCase from 'lodash';
 
 const translateMeans = (means, latest) => {
   if (!means || !means.length) return null;
@@ -317,7 +318,7 @@ export const getDatesData = (data) =>
     return {
       ...d,
       ...((firstDayOfWeek.date() <= 7 || index === 0) && {
-        month: moment().year(d.year).isoWeek(d.week).format('MMM'),
+        monthLabel: moment().year(d.year).isoWeek(d.week).format('MMM'),
       }),
       date: d.date
         ? moment(d.date).format('YYYY-MM-DD')
@@ -326,6 +327,7 @@ export const getDatesData = (data) =>
             .isoWeek(d.week)
             .startOf('isoWeek')
             .format('YYYY-MM-DD'),
+      month: upperCase(moment().year(d.year).isoWeek(d.week).format('MMM')),
     };
   });
 


### PR DESCRIPTION
## Overview

[In Slack](https://globalforestwatch.slack.com/archives/C0V94B8PK/p1719242065970669), Jimmy noted that something seems to be wrong with weekly VIIRS alert widget; he thinks it is a front end issue and has to do with the way it is being queried. The downloaded data looks correct and has data through this week. 
Alongside this task, new bugs were found.

Example from Yukon, Canada:
![yukon](https://github.com/wri/gfw/assets/23243868/bcf959fc-3763-4a6b-84f6-111d4fa0a4d1)

## Demo
![Screenshot 2024-07-11 at 14 48 05](https://github.com/wri/gfw/assets/23243868/adb8a944-416c-467b-afaf-96a65ed1b94f)


