### PR TITLE
[FLAG-1131] Public areas cannot be viewed by other users

### DIFF
--- a/utils/request.js
+++ b/utils/request.js
@@ -31,6 +31,8 @@ const DATA_API_KEY = GFW_API_KEY;
 
 const isServer = typeof window === 'undefined';
 
+const userToken = !isServer && localStorage.getItem('userToken');
+
 const defaultRequestConfig = {
   timeout: 30 * 1000,
 };
@@ -92,7 +94,9 @@ export const apiAuthRequest = axios.create({
     baseURL: PROXIES.GFW_API,
     headers: {
       'content-type': 'application/json',
-      Authorization: `Bearer ${localStorage.getItem('userToken')}`,
+      ...(userToken && {
+        Authorization: `Bearer ${userToken}`,
+      }),
     },
   }),
 });


### PR DESCRIPTION
## Overview

Observed behavior: When I set my area of interest to public and I share the link to that area, other users see a non-stop spinner and cannot see the area of interest when they visit the link. I also see authorization errors in the browser network panel.

[Public areas cannot be viewed by other users](https://www.loom.com/share/a8478e7b1e0f47cda6546ca8dce75e6c?sid=8a595233-fe08-404c-8795-8b4c4f7d375d) 

Expected behavior: When I share a link to an area of interest set to public, then other users can visit the link and see the area of interest without errors.
