### PR TITLE
[FLAG-927]  Change design/layout for existing FAO forestry employment 

### DIFF
--- a/components/widgets/land-use/economic-impact/index.js
+++ b/components/widgets/land-use/economic-impact/index.js
@@ -27,7 +27,7 @@ export default {
   ],
   chartType: 'chartList',
   dataType: 'fao',
-  colors: 'employment',
+  colors: 'economicImpact',
   metaKey: 'widget_economic_impact',
   sortOrder: {
     landUse: 2

--- a/components/widgets/land-use/economic-impact/selectors.js
+++ b/components/widgets/land-use/economic-impact/selectors.js
@@ -85,13 +85,13 @@ export const chartData = createSelector(
         ...data[0],
         name: 'Expenditure',
         value: data[0].exp,
-        color: colors.male,
+        color: colors.expenditure,
       },
       {
         ...data[0],
         name: 'Revenue',
         value: data[0].rev,
-        color: colors.female,
+        color: colors.revenue,
       },
     ];
   }

--- a/components/widgets/land-use/forestry-employment/index.js
+++ b/components/widgets/land-use/forestry-employment/index.js
@@ -1,4 +1,4 @@
-import { getFAOEcoLive } from 'services/forest-data';
+import { getFAOEmployment } from 'services/forest-data';
 
 import getWidgetProps from './selectors';
 
@@ -24,17 +24,16 @@ export default {
   },
   settings: {
     year: 2010,
-    unit: 'countsK',
+    unit: '%',
   },
-  colors: 'employment',
+  colors: 'forestryEmployment',
   sentences: {
     initial:
-      'According to the FAO there were {value} people employed in {location} Forestry sector in {year}.',
+      'According to the FAO there were {numPeople} people employed in {location} Forestry sector in {year}.',
     withFemales:
-      'According to the FAO there were {value} people employed in {location} Forestry sector in {year}, of which {percent} were female.',
+      'According to the FAO, there were {numPeople} people employed in {location} Forestry sector in {year}, of which {femalePercent} were female.',
   },
-  getData: (params) =>
-    getFAOEcoLive(params.token).then((response) => response.data.rows),
-  getDataURL: () => [getFAOEcoLive({ download: true })],
+  getData: (params) => getFAOEmployment(params),
+  getDataURL: (params) => getFAOEmployment({ ...params, download: true }),
   getWidgetProps,
 };

--- a/components/widgets/land-use/forestry-employment/index.js
+++ b/components/widgets/land-use/forestry-employment/index.js
@@ -23,7 +23,7 @@ export default {
     landUse: 3,
   },
   settings: {
-    year: 2010,
+    year: 2015,
     unit: '%',
   },
   colors: 'forestryEmployment',

--- a/components/widgets/land-use/forestry-employment/index.js
+++ b/components/widgets/land-use/forestry-employment/index.js
@@ -12,7 +12,7 @@ export default {
     {
       key: 'year',
       label: 'year',
-      options: [1990, 2000, 2005, 2010].map((y) => ({ label: y, value: y })),
+      options: [2000, 2010].map((y) => ({ label: y, value: y })),
       type: 'select',
     },
   ],

--- a/components/widgets/land-use/forestry-employment/index.js
+++ b/components/widgets/land-use/forestry-employment/index.js
@@ -34,6 +34,6 @@ export default {
       'According to the FAO, there were {numPeople} people employed in {location} Forestry sector in {year}, of which {femalePercent} were female.',
   },
   getData: (params) => getFAOEmployment(params),
-  getDataURL: (params) => getFAOEmployment({ ...params, download: true }),
+  getDataURL: (params) => [getFAOEmployment({ ...params, download: true })],
   getWidgetProps,
 };

--- a/components/widgets/land-use/forestry-employment/index.js
+++ b/components/widgets/land-use/forestry-employment/index.js
@@ -12,7 +12,7 @@ export default {
     {
       key: 'year',
       label: 'year',
-      options: [2000, 2010].map((y) => ({ label: y, value: y })),
+      options: [2000, 2010, 2015].map((y) => ({ label: y, value: y })),
       type: 'select',
     },
   ],

--- a/components/widgets/land-use/forestry-employment/selectors.js
+++ b/components/widgets/land-use/forestry-employment/selectors.js
@@ -10,11 +10,9 @@ const getSettings = (state) => state.settings;
 export const parseData = createSelector(
   [getData, getColors, getSettings],
   (data, colors, settings) => {
-    const yearData = data?.filter(({ year }) => year === settings?.year);
-    const dataUngendered = yearData?.find(({ gender }) => gender === null);
-    const dataAll = yearData?.find(({ gender }) => gender === 'all');
+    if (!data?.length) return null;
 
-    if (!dataUngendered || !dataAll) return null;
+    const yearData = data.find((entry) => entry?.year === settings?.year)
 
     const items = {
       logging: 'Logging',
@@ -25,8 +23,8 @@ export const parseData = createSelector(
 
     const formattedData = Object.keys(items).reduce((acc, key) => {
       const label = items[key];
-      const value = dataUngendered[key];
-      const percentage = (100 * value) / dataAll?.all;
+      const value = yearData[key];
+      const percentage = (100 * value) / yearData?.all;
       const color = colors[key];
 
       if (!value) return acc;
@@ -40,19 +38,16 @@ export const parseData = createSelector(
 export const parseSentence = createSelector(
   [getSentences, getData, getSettings, getLocation],
   (sentences, data, settings, location) => {
-    const yearData = data?.filter(({ year }) => year === settings?.year);
-    const dataFemale = yearData?.find(({ gender }) => gender === 'female');
-    const dataAll = yearData?.find(({ gender }) => gender === 'all');
+    if (!data?.length) return null;
 
-    const sentence = dataFemale?.all ? sentences.withFemales : sentences.initial;
-    const femalePercentage = (dataFemale?.all * 100) / dataAll?.all;
-
-    if (!dataAll?.all) return null;
+    const yearData = data.find((entry) => entry?.year === settings?.year)
+    const sentence = yearData?.female ? sentences.withFemales : sentences.initial;
+    const femalePercentage = (yearData?.female * 100) / yearData?.all;
 
     return {
       sentence,
       params: {
-        numPeople: formatNumber({ num: dataAll?.all, unit: 'countsK' }),
+        numPeople: formatNumber({ num: yearData?.all, unit: 'countsK' }),
         year: settings?.year,
         femalePercent: formatNumber({ num: femalePercentage, unit: '%' }),
         location: location?.label

--- a/components/widgets/land-use/forestry-employment/selectors.js
+++ b/components/widgets/land-use/forestry-employment/selectors.js
@@ -12,7 +12,9 @@ export const parseData = createSelector(
   (data, colors, settings) => {
     if (!data?.length) return null;
 
-    const yearData = data.find((entry) => entry?.year === settings?.year)
+    const yearData = data.find((entry) => entry?.year === settings?.year);
+
+    if (yearData?.all === null) return null;
 
     const items = {
       logging: 'Logging',
@@ -40,9 +42,13 @@ export const parseSentence = createSelector(
   (sentences, data, settings, location) => {
     if (!data?.length) return null;
 
-    const yearData = data.find((entry) => entry?.year === settings?.year)
-    const sentence = yearData?.female ? sentences.withFemales : sentences.initial;
+    const yearData = data.find((entry) => entry?.year === settings?.year);
+    const sentence = yearData?.female
+      ? sentences.withFemales
+      : sentences.initial;
     const femalePercentage = (yearData?.female * 100) / yearData?.all;
+
+    if (yearData?.all === null) return null;
 
     return {
       sentence,
@@ -50,7 +56,7 @@ export const parseSentence = createSelector(
         numPeople: formatNumber({ num: yearData?.all, unit: 'countsK' }),
         year: settings?.year,
         femalePercent: formatNumber({ num: femalePercentage, unit: '%' }),
-        location: location?.label
+        location: location?.label,
       },
     };
   }

--- a/components/widgets/land-use/forestry-employment/selectors.js
+++ b/components/widgets/land-use/forestry-employment/selectors.js
@@ -1,90 +1,62 @@
 import { createSelector, createStructuredSelector } from 'reselect';
-import isEmpty from 'lodash/isEmpty';
 import { formatNumber } from 'utils/format';
 
-// get list data
 const getData = (state) => state.data;
-const getSettings = (state) => state.settings;
-const getLocationObject = (state) => state.location;
 const getColors = (state) => state.colors;
+const getLocation = (state) => state.location;
 const getSentences = (state) => state.sentences;
-
-// get lists selected
-export const getFilteredData = createSelector(
-  [getData, getLocationObject],
-  (data, locationObject) => {
-    if (isEmpty(data) || !locationObject) return null;
-    return data
-      .filter(
-        (item) => item.country === locationObject.value && item.year !== 9999
-      )
-      .map((item) => ({
-        male: item.femempl
-          ? (item.forempl - item.femempl) * 1000
-          : item.forempl * 1000,
-        female: item.femempl ? item.femempl * 1000 : null,
-        year: item.year,
-      }));
-  }
-);
+const getSettings = (state) => state.settings;
 
 export const parseData = createSelector(
-  [getFilteredData, getSettings, getColors],
-  (data, settings, colors) => {
-    if (isEmpty(data)) return null;
+  [getData, getColors, getSettings],
+  (data, colors, settings) => {
+    const yearData = data?.filter(({ year }) => year === settings?.year);
+    const dataUngendered = yearData?.find(({ gender }) => gender === null);
+    const dataAll = yearData?.find(({ gender }) => gender === 'all');
 
-    const { year } = settings;
-    const selectedFAO = data.filter((item) => item.year === year);
-    const { male, female } =
-      selectedFAO && selectedFAO.length && selectedFAO[0];
-    if (!female) return null;
+    if (!dataUngendered || !dataAll) return null;
 
-    const total = male + female;
-    const formatedData = [
-      {
-        label: 'Male',
-        value: male,
-        color: colors.male,
-        percentage: (male / total) * 100,
-      },
-      {
-        label: 'Female',
-        value: female,
-        color: colors.female,
-        percentage: (female / total) * 100,
-      },
-    ];
-    return formatedData;
+    const items = {
+      logging: 'Logging',
+      gathering: 'Gathering of non-wood products',
+      support: 'Support services to forestry',
+      silviculture: 'Silviculture and other forestry activities',
+    };
+
+    const formattedData = Object.keys(items).reduce((acc, key) => {
+      const label = items[key];
+      const value = dataUngendered[key];
+      const percentage = (100 * value) / dataAll?.all;
+      const color = colors[key];
+
+      if (!value) return acc;
+      return [...acc, { label, value: percentage, percentage, color }];
+    }, []);
+
+    return formattedData;
   }
 );
 
 export const parseSentence = createSelector(
-  [getFilteredData, getSettings, getLocationObject, getSentences],
-  (data, settings, locationObject, sentences) => {
-    if (!data) return null;
-    const { year } = settings;
-    const { initial, withFemales } = sentences;
-    const selectedFAO = data.find((item) => item.year === year);
-    let employees = 0;
-    let females = 0;
-    if (selectedFAO) {
-      employees = selectedFAO.female
-        ? selectedFAO.male + selectedFAO.female
-        : selectedFAO.male;
-      females = parseInt(selectedFAO.female, 10);
-    }
-    const percentage = (100 * females) / employees;
+  [getSentences, getData, getSettings, getLocation],
+  (sentences, data, settings, location) => {
+    const yearData = data?.filter(({ year }) => year === settings?.year);
+    const dataFemale = yearData?.find(({ gender }) => gender === 'female');
+    const dataAll = yearData?.find(({ gender }) => gender === 'all');
 
-    const params = {
-      location: `${locationObject && locationObject && locationObject.label}'s`,
-      value: `${employees ? formatNumber({ num: employees }) : 'no'}`,
-      percent: formatNumber({ num: percentage, unit: '%' }),
-      year,
-    };
+    const sentence = dataFemale?.all ? sentences.withFemales : sentences.initial;
+    const femalePercentage = (dataFemale?.all * 100) / dataAll?.all;
+
+    if (!dataAll?.all) return null;
 
     return {
-      sentence: females ? withFemales : initial,
-      params,
+      sentence,
+      params: {
+        numPeople: formatNumber({ num: dataAll?.all, unit: 'countsK' }),
+        year: settings?.year,
+        femalePercent: formatNumber({ num: femalePercentage, unit: '%' }),
+        location: location?.label
+      },
     };
   }
 );

--- a/data/colors.json
+++ b/data/colors.json
@@ -1,7 +1,18 @@
 {
   "extent": {
     "main": "#a0c746",
-    "ramp": ["#364a08", "#42590E", "#506917", "#6b8729", "#84a637", "#a0c746", "#b8d86d", "#c7e67c", "#d2f189", "#dff7a6"],
+    "ramp": [
+      "#364a08",
+      "#42590E",
+      "#506917",
+      "#6b8729",
+      "#84a637",
+      "#a0c746",
+      "#b8d86d",
+      "#c7e67c",
+      "#d2f189",
+      "#dff7a6"
+    ],
     "naturalForest": "#506917",
     "intactForest": "#6b8729",
     "primaryForest": "#84a637",
@@ -16,7 +27,17 @@
     "integratedHigh": "#dc6699",
     "integratedHighest": "#c92a6d",
     "integratedLow": "#eda4c3",
-    "ramp": ["#510626", "#7a1e41", "#a4355c", "#d04d7a", "#fe6598", "#ff84ac", "#ffa0c0", "#ffbad4", "#ffd4e9"],
+    "ramp": [
+      "#510626",
+      "#7a1e41",
+      "#a4355c",
+      "#d04d7a",
+      "#fe6598",
+      "#ff84ac",
+      "#ffa0c0",
+      "#ffbad4",
+      "#ffd4e9"
+    ],
     "noLoss": "#e7e5a4",
     "primaryForestLoss": "#bed65c",
     "primaryForestExtent": "#658434",
@@ -31,13 +52,23 @@
   },
   "gain": {
     "main": "#6d6de5",
-    "ramp": ["#070752", "#231f74", "#3c3898", "#5452be", "#6d6de5", "#8a86ec", "#a49ff3", "#bdb9f9", "#d4d4ff"],
+    "ramp": [
+      "#070752",
+      "#231f74",
+      "#3c3898",
+      "#5452be",
+      "#6d6de5",
+      "#8a86ec",
+      "#a49ff3",
+      "#bdb9f9",
+      "#d4d4ff"
+    ],
     "noGain": "#e7e5a4",
     "extent": "#a0c746"
-  },  
+  },
   "climate": {
     "main": "#5b80a0",
-    "ramp": [ "#EDD093", "#BFBC35", "#007F53", "#123A33"],
+    "ramp": ["#EDD093", "#BFBC35", "#007F53", "#123A33"],
     "carbon": ["#895122", "#898522", "#892227"],
     "carbonFlux": {
       "emissions": "#912f34",
@@ -113,11 +144,31 @@
   },
   "emissions": {
     "main": "#5b80a0",
-    "ramp": ["#073452", "#204665", "#345978", "#476c8c", "#5b80a0", "#799ab7", "#97b4cf", "#b5cfe7", "#d4ebff"]
+    "ramp": [
+      "#073452",
+      "#204665",
+      "#345978",
+      "#476c8c",
+      "#5b80a0",
+      "#799ab7",
+      "#97b4cf",
+      "#b5cfe7",
+      "#d4ebff"
+    ]
   },
   "fires": {
     "main": "#f14600",
-    "ramp": ["#940f07", "#b11509", "#cd2009", "#e73108", "#fe4605", "#ff7104", "#ff9203", "#ffb004", "#fecc05"],
+    "ramp": [
+      "#940f07",
+      "#b11509",
+      "#cd2009",
+      "#e73108",
+      "#fe4605",
+      "#ff7104",
+      "#ff9203",
+      "#ffb004",
+      "#fecc05"
+    ],
     "compareYear": "#49b5e3",
     "compareYearRamp": ["#49b5e3", "#D0ECF8"],
     "otherColor": "#AAAAAA"
@@ -133,11 +184,16 @@
     "loss": "#A25A94",
     "disturb": "#FF7F5F"
   },
-  "employment": {
+  "economicImpact": {
     "main": "#A878F3",
-    "ramp": ["#A878F3", "#7C38C5"],
-    "male": "#A878F3",
-    "female": "#7C38C5"
+    "expenditure": "#A878F3",
+    "revenue": "#7C38C5"
+  },
+  "forestryEmployment": {
+    "logging": "#EEE8D6",
+    "gathering": "#BCADDA",
+    "support" : "#9A85DD",
+    "silviculture" : "#5A50A7"
   },
   "biodiversity": {
     "main": "#6d00e1",

--- a/services/forest-data.js
+++ b/services/forest-data.js
@@ -18,6 +18,8 @@ const NEW_SQL_QUERIES = {
     'SELECT iso, country, "deforestation (ha per year)" as def_per_year FROM mytable WHERE "deforestation (ha per year)" IS NOT NULL AND year = {yearRange} ORDER BY def_per_year DESC',
   faoEcoLive:
     'SELECT fao.country as iso, fao.forempl as total_forest_employees, fao.femempl as female_forest_employees, fao.usdrev as revenue__usd, fao.usdexp as expenditure__usd, fao.gdpusd2012 as gdp_2012__usd, fao.totpop1000, fao.year FROM table_7_economics_livelihood as fao WHERE fao.year = 2000 or fao.year = 2005 or fao.year = 2010 or fao.year = 9999',
+  faoEmployment:
+    'SELECT iso, year, "all (FTE)" AS all, "gender (FTE)" AS gender, "logging (FTE)" AS logging, "gathering (FTE)" AS gathering, "support (FTE)" AS support, "silviculture and other (FTE)" AS silviculture FROM data WHERE {location}',
   globalLandCover: 'SELECT * FROM global_land_cover_adm2 WHERE {location}',
   globalLandCoverURL: `SELECT
   cartodb_id,
@@ -187,6 +189,25 @@ export const getFAODeforestRank = ({ yearRange = '2015-2020', download }) => {
       }),
     },
   }));
+};
+
+export const getFAOEmployment = (params) => {
+  const { adm0, adm1, adm2, download } = params || {};
+  const target = download ? 'download/csv' : 'query';
+
+  const url = `/dataset/fao_forestry_employment/v2020/${target}?sql=${NEW_SQL_QUERIES.faoEmployment}`
+    .replace('{location}', getLocationQuery(adm0, adm1, adm2))
+
+  if (download) {
+    return {
+      name: 'fao_forestry_employment',
+      url: new URL(
+        `${window.location.origin}${PROXIES.DATA_API}${url}`
+      ).toString()
+    };
+  }
+
+  return dataRequest.get(url).then((response) => response?.data);
 };
 
 export const getFAOEcoLive = (params) => {

--- a/services/forest-data.js
+++ b/services/forest-data.js
@@ -19,7 +19,7 @@ const NEW_SQL_QUERIES = {
   faoEcoLive:
     'SELECT fao.country as iso, fao.forempl as total_forest_employees, fao.femempl as female_forest_employees, fao.usdrev as revenue__usd, fao.usdexp as expenditure__usd, fao.gdpusd2012 as gdp_2012__usd, fao.totpop1000, fao.year FROM table_7_economics_livelihood as fao WHERE fao.year = 2000 or fao.year = 2005 or fao.year = 2010 or fao.year = 9999',
   faoEmployment:
-    'SELECT iso, year, "all (FTE)" AS all, "gender (FTE)" AS gender, "logging (FTE)" AS logging, "gathering (FTE)" AS gathering, "support (FTE)" AS support, "silviculture and other (FTE)" AS silviculture FROM data WHERE {location}',
+    'SELECT iso, year, "all (FTE)" AS all, "female (FTE)" AS female, "logging (FTE)" AS logging, "gathering (FTE)" AS gathering, "support (FTE)" AS support, "silviculture and other (FTE)" AS silviculture FROM data WHERE {location}',
   globalLandCover: 'SELECT * FROM global_land_cover_adm2 WHERE {location}',
   globalLandCoverURL: `SELECT
   cartodb_id,
@@ -196,7 +196,7 @@ export const getFAOEmployment = (params) => {
   const target = download ? 'download/csv' : 'query';
 
   const url = `/dataset/fao_forestry_employment/v2020/${target}?sql=${NEW_SQL_QUERIES.faoEmployment}`
-    .replace('{location}', getLocationQuery(adm0, adm1, adm2))
+    .replace('{location}', getLocationQuery(adm0, adm1, adm2));
 
   if (download) {
     return {


### PR DESCRIPTION
## Overview

**In this PR:**  
- FAO forestry employment widget:  
  - Now pulls data from the data API, instead of Carto  
  - Now displays percentages by sector in the donut chart  
    _instead of the percentage by male/female_  
  - Donut chart colors have been tweaked  
    _It used to use the same colors as the Economic Impact widget, now the color definitions are separate due to the changes_  
  - Minor tweaks to the sentence wording  
  - New query for fetching the data, following the same standards as other calls in the same `forest-data` service  
  - Adapted the years that can be selected to match the acceptance criteria: 
    - We removed `1990` and '2005', added `2015`  
    - `2015` is now the default  
  - Download URL is working, with the csv provided by the dataset endpoint  

**Notes:**  

- The codebase for this widget had a provision for when we have sufficient data to display the widget, but *not* data to display the female percentage. The new revision still accounts for that in the sentence.   
- If there is no data for a particular year/location, "No data" will be shown, matching the all other widgets. 

## Screenshots  

**Before:** 
![Screenshot 2024-07-16 at 13 14 40](https://github.com/user-attachments/assets/71fe4278-921f-47c4-bcd4-c112ee185739)

**After:**  
![fao_forestry_employment_brazil](https://github.com/user-attachments/assets/ed388017-b6d9-4b8f-bba6-8b0908afd8f5)



## Tracking  

[FLAG-927](https://gfw.atlassian.net/browse/FLAG-927)