### PR TITLE
[FLAG-1035] Fix variables in the integrated deforestation alerts widget for translations to work properly

### DIFF
--- a/components/map/components/legend/components/layer-select-menu/component.jsx
+++ b/components/map/components/legend/components/layer-select-menu/component.jsx
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { trackEvent } from 'utils/analytics';
+import { translateText } from 'utils/lang';
 
 import { Tooltip } from 'react-tippy';
 import Tip from 'components/ui/tip';
@@ -32,8 +33,10 @@ class LayerSelectMenu extends PureComponent {
       <div className={`c-layer-select-menu ${className || ''}`}>
         <div className="selector">
           <button onClick={() => this.setState({ menuActive: !menuActive })}>
-            {activeLayer.name}
-            <span className="citation">{activeLayer.citation}</span>
+            {translateText(activeLayer.name)}
+            <span className="citation">
+              {translateText(activeLayer.citation)}
+            </span>
             <Icon
               icon={arrowDownIcon}
               className={`icon-arrow ${menuActive ? 'reverse' : ''}`}

--- a/components/widgets/fires/burned-area-cumulative/selectors.js
+++ b/components/widgets/fires/burned-area-cumulative/selectors.js
@@ -16,6 +16,7 @@ import {
   getDatesData,
   getChartConfig,
 } from 'components/widgets/utils/data';
+import { localizeWidgetSentenceDate } from 'utils/localize-date';
 
 const getAlerts = (state) => state.data && state.data.alerts;
 const getLatest = (state) => state.data && state.data.latest;
@@ -32,6 +33,7 @@ const getSentences = (state) => state.sentences || null;
 const getLocationName = (state) => state.locationLabel;
 const getOptionsSelected = (state) => state.optionsSelected;
 const getIndicator = (state) => state.indicator;
+const getLanguage = (state) => state.lang;
 
 export const getCompareYears = createSelector(
   [getCompareYear, getAllYears],
@@ -405,6 +407,7 @@ export const parseSentence = createSelector(
     getStartIndex,
     getOptionsSelected,
     getIndicator,
+    getLanguage,
   ],
   (
     raw_data,
@@ -414,7 +417,8 @@ export const parseSentence = createSelector(
     location,
     startIndex,
     options,
-    indicator
+    indicator,
+    language
   ) => {
     if (!data || isEmpty(data)) return null;
     const { allBurnWithInd, allBurn, thresholdStatement } = sentences;
@@ -486,12 +490,12 @@ export const parseSentence = createSelector(
       thresh && thresh > 0
         ? sentence + thresholdStatement
         : sentence.concat('.');
-    const formattedData = moment(date).format('Do of MMMM YYYY');
+
     const params = {
       location,
       indicator: indicatorLabel,
       thresh: `${thresh}%`,
-      date: formattedData,
+      date: localizeWidgetSentenceDate(date, language),
       latestYear,
       dataset_start_year: 2001,
       maxYear,

--- a/components/widgets/fires/burned-area/selectors.js
+++ b/components/widgets/fires/burned-area/selectors.js
@@ -10,6 +10,7 @@ import groupBy from 'lodash/groupBy';
 import max from 'lodash/max';
 import min from 'lodash/min';
 
+import { translateText } from 'utils/lang';
 import { localizeWidgetSentenceDate } from 'utils/localize-date';
 
 import {
@@ -425,11 +426,11 @@ export const parseSentence = createSelector(
     const seasonMonth = moment(seasonStartDate).format('MMMM');
     const seasonDay = parseInt(moment(seasonStartDate).format('D'), 10);
 
-    let seasonStatement = `late ${seasonMonth}`;
+    let seasonStatement = translateText('late {seasonMonth}', { seasonMonth });
     if (seasonDay <= 10) {
-      seasonStatement = `early ${seasonMonth}`;
+      seasonStatement = translateText('early {seasonMonth}', { seasonMonth });
     } else if (seasonDay > 10 && seasonDay <= 20) {
-      seasonStatement = `mid-${seasonMonth}`;
+      seasonStatement = translateText('mid-{seasonMonth}', { seasonMonth });
     }
 
     const total = sumBy(slicedData, 'count');
@@ -437,18 +438,18 @@ export const parseSentence = createSelector(
     let statusColor = colorRange[8];
     const { date } = lastDate || {};
 
-    let status = 'unusually low';
+    let status = translateText('unusually low');
     if (variance > 2) {
-      status = 'unusually high';
+      status = translateText('unusually high');
       statusColor = colorRange[0];
     } else if (variance <= 2 && variance > 1) {
-      status = 'high';
+      status = translateText('high');
       statusColor = colorRange[2];
     } else if (variance <= 1 && variance > -1) {
-      status = 'normal';
+      status = translateText('normal');
       statusColor = colorRange[4];
     } else if (variance <= -1 && variance > -2) {
-      status = 'low';
+      status = translateText('low');
       statusColor = colorRange[6];
     }
 

--- a/components/widgets/fires/burned-area/selectors.js
+++ b/components/widgets/fires/burned-area/selectors.js
@@ -10,6 +10,8 @@ import groupBy from 'lodash/groupBy';
 import max from 'lodash/max';
 import min from 'lodash/min';
 
+import { localizeWidgetSentenceDate } from 'utils/localize-date';
+
 import {
   getStatsData,
   getDatesData,
@@ -29,6 +31,7 @@ const getLocationName = (state) => state.locationLabel;
 const getLang = (state) => state.lang || null;
 const getOptionsSelected = (state) => state.optionsSelected;
 const getIndicator = (state) => state.indicator;
+const getLanguage = (state) => state.lang;
 
 const MINGAP = 4;
 
@@ -357,6 +360,7 @@ export const parseSentence = createSelector(
     getOptionsSelected,
     getLang,
     getIndicator,
+    getLanguage,
   ],
   (
     raw_data,
@@ -368,7 +372,8 @@ export const parseSentence = createSelector(
     indexes,
     options,
     lang,
-    indicator
+    indicator,
+    language
   ) => {
     if (!data || isEmpty(data)) return null;
     const {
@@ -458,16 +463,15 @@ export const parseSentence = createSelector(
         ? sentence + thresholdStatement
         : sentence.concat('.');
 
-    const formattedData = moment(date).format('Do of MMMM YYYY');
     const params = {
       location,
       indicator: indicatorLabel,
       thresh: `${thresh}%`,
-      date: formattedData,
+      date: localizeWidgetSentenceDate(date, language),
       fires_season_start: seasonStatement,
       fire_season_length: sortedPeakWeeks.length,
-      start_date: moment(firstDate.date).format('Do of MMMM YYYY'),
-      end_date: moment(lastDate.date).format('Do of MMMM YYYY'),
+      start_date: localizeWidgetSentenceDate(firstDate.date, language),
+      end_date: localizeWidgetSentenceDate(lastDate.date, language),
       dataset_start_year: 2001,
       dataset: 'MODIS',
       area: {

--- a/components/widgets/fires/fire-alerts-simple/selectors.js
+++ b/components/widgets/fires/fire-alerts-simple/selectors.js
@@ -2,8 +2,7 @@
 import { createSelector, createStructuredSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
 import { formatNumber } from 'utils/format';
-
-import moment from 'moment';
+import { localizeWidgetSentenceDate } from 'utils/localize-date';
 
 // get list data
 const selectAlerts = (state) => state.data && state.data.alerts;
@@ -13,6 +12,7 @@ const getIndicator = (state) => state.indicator || null;
 const getSettings = (state) => state.settings || null;
 const getLocationName = (state) => state.locationLabel;
 const getDataset = (state) => state.settings.dataset || null;
+const getLanguage = (state) => state.lang;
 
 export const parseData = createSelector([selectAlerts], (data) => {
   if (isEmpty(data)) return null;
@@ -89,13 +89,14 @@ export const parseSentence = createSelector(
     selectSentences,
     getIndicator,
     getLocationName,
+    getLanguage,
   ],
-  (data, dataset, settings, sentences, indicator, location) => {
+  (data, dataset, settings, sentences, indicator, location, language) => {
     if (!data) return null;
     const startDate = settings.startDate;
     const endDate = settings.endDate;
-    const formattedStartDate = moment(startDate).format('Do of MMMM YYYY');
-    const formattedEndDate = moment(endDate).format('Do of MMMM YYYY');
+    const formattedStartDate = localizeWidgetSentenceDate(startDate, language);
+    const formattedEndDate = localizeWidgetSentenceDate(endDate, language);
     const params = {
       indicator: indicator && indicator.label,
       location,

--- a/components/widgets/fires/fire-alerts-simple/selectors.js
+++ b/components/widgets/fires/fire-alerts-simple/selectors.js
@@ -2,6 +2,7 @@
 import { createSelector, createStructuredSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
 import { formatNumber } from 'utils/format';
+import { translateText } from 'utils/lang';
 import { localizeWidgetSentenceDate } from 'utils/localize-date';
 
 // get list data
@@ -53,11 +54,15 @@ export const parseConfig = createSelector(
       highConfidenceAlertPercentage,
     } = data;
     const alertsLabel = indicator
-      ? `Other alerts in ${indicator.label}`
-      : 'Other alerts';
+      ? translateText('Other alerts in {indicatorLabel}', {
+          indicatorLabel: indicator.label,
+        })
+      : translateText('Other alerts');
     const highConfidenceAlertsLabel = indicator
-      ? `High confidence alerts in ${indicator.label}`
-      : 'High confidence alerts';
+      ? translateText('High confidence alerts in {indicatorLabel}', {
+          indicatorLabel: indicator.label,
+        })
+      : translateText('High confidence alerts');
 
     const highConfidenceColour = colors.main;
     const otherColour = colors.otherColor; // hslShift(mainColour)

--- a/components/widgets/fires/fires-alerts-cumulative/selectors.js
+++ b/components/widgets/fires/fires-alerts-cumulative/selectors.js
@@ -16,6 +16,7 @@ import {
   getDatesData,
   getChartConfig,
 } from 'components/widgets/utils/data';
+import { localizeWidgetSentenceDate } from 'utils/localize-date';
 
 const getAlerts = (state) => state.data && state.data.alerts;
 const getLatest = (state) => state.data && state.data.latest;
@@ -33,6 +34,7 @@ const getLocationName = (state) => state.locationLabel;
 const getOptionsSelected = (state) => state.optionsSelected;
 const getIndicator = (state) => state.indicator;
 const getSettings = (state) => state.settings;
+const getLanguage = (state) => state.lang;
 
 export const getCompareYears = createSelector(
   [getCompareYear, getAllYears],
@@ -430,6 +432,7 @@ export const parseSentence = createSelector(
     getOptionsSelected,
     getIndicator,
     getSettings,
+    getLanguage,
   ],
   (
     raw_data,
@@ -441,7 +444,8 @@ export const parseSentence = createSelector(
     startIndex,
     options,
     indicator,
-    settings
+    settings,
+    language
   ) => {
     if (!data || isEmpty(data)) return null;
 
@@ -532,11 +536,10 @@ export const parseSentence = createSelector(
           : allAlertsWithInd;
     }
 
-    const formattedData = moment(date).format('Do of MMMM YYYY');
     const params = {
       location,
       indicator: indicatorLabel,
-      date: formattedData,
+      date: localizeWidgetSentenceDate(date, language),
       latestYear,
       dataset_start_year: dataset === 'viirs' ? 2012 : 2001,
       maxYear,

--- a/components/widgets/fires/fires-alerts-historical-daily/selectors.js
+++ b/components/widgets/fires/fires-alerts-historical-daily/selectors.js
@@ -6,6 +6,7 @@ import sumBy from 'lodash/sumBy';
 import sortBy from 'lodash/sortBy';
 
 import { getChartConfig } from 'components/widgets/utils/data';
+import { localizeWidgetSentenceDate } from 'utils/localize-date';
 
 const getAlerts = (state) => state.data;
 const getColors = (state) => state.colors || null;
@@ -16,6 +17,7 @@ const getSentences = (state) => state.sentences || null;
 const getLocationObject = (state) => state.location;
 const getOptionsSelected = (state) => state.optionsSelected;
 const getIndicator = (state) => state.indicator;
+const getLanguage = (state) => state.lang;
 
 const zeroFillDays = (startDate, endDate) => {
   const start = moment(startDate);
@@ -89,6 +91,7 @@ export const parseSentence = createSelector(
     getOptionsSelected,
     getIndicator,
     getSettings,
+    getLanguage,
   ],
   (
     data,
@@ -99,7 +102,8 @@ export const parseSentence = createSelector(
     endDate,
     options,
     indicator,
-    settings
+    settings,
+    language
   ) => {
     if (!data) return null;
     const { initial, withInd, highConfidence } = sentences;
@@ -128,8 +132,8 @@ export const parseSentence = createSelector(
     const params = {
       location: location.label || '',
       indicator: indicatorLabel,
-      start_date: moment(startDate).format('Do of MMMM YYYY'),
-      end_date: moment(endDate).format('Do of MMMM YYYY'),
+      start_date: localizeWidgetSentenceDate(startDate, language),
+      end_date: localizeWidgetSentenceDate(endDate, language),
       dataset: dataset && dataset.label,
       total_alerts: {
         value: total ? formatNumber({ num: total, unit: ',' }) : 0,

--- a/components/widgets/fires/fires-alerts-historical-weekly/selectors.js
+++ b/components/widgets/fires/fires-alerts-historical-weekly/selectors.js
@@ -6,6 +6,8 @@ import isEmpty from 'lodash/isEmpty';
 import sumBy from 'lodash/sumBy';
 import sortBy from 'lodash/sortBy';
 
+import { localizeWidgetSentenceDate } from 'utils/localize-date';
+
 import { getChartConfig, getDatesData } from 'components/widgets/utils/data';
 
 const getAlerts = (state) => state.data && state.data.alerts;
@@ -17,6 +19,7 @@ const getOptionsSelected = (state) => state.optionsSelected;
 const getIndicator = (state) => state.indicator;
 const getStartIndex = (state) => state.settings.startIndex;
 const getEndIndex = (state) => state.settings.endIndex || null;
+const getLanguage = (state) => state.lang;
 
 const INITIAL_WINDOW_WEEKS = 3 * 52 + 1;
 
@@ -223,8 +226,9 @@ export const parseSentence = createSelector(
     getLocationObject,
     getOptionsSelected,
     getIndicator,
+    getLanguage,
   ],
-  (data, colors, sentences, location, options, indicator) => {
+  (data, colors, sentences, location, options, indicator, language) => {
     if (!data || !data.length) return null;
     const { initial, withInd, highConfidence } = sentences;
     const { confidence, dataset } = options;
@@ -244,8 +248,8 @@ export const parseSentence = createSelector(
     const params = {
       location: location.label || '',
       indicator: indicatorLabel,
-      start_date: moment(startDate).format('Do of MMMM YYYY'),
-      end_date: moment(endDate).format('Do of MMMM YYYY'),
+      start_date: localizeWidgetSentenceDate(startDate, language),
+      end_date: localizeWidgetSentenceDate(endDate, language),
       dataset: dataset && dataset.label,
       total_alerts: {
         value: total ? formatNumber({ num: total, unit: ',' }) : 0,

--- a/components/widgets/fires/fires-alerts-historical/selectors.js
+++ b/components/widgets/fires/fires-alerts-historical/selectors.js
@@ -5,6 +5,8 @@ import isEmpty from 'lodash/isEmpty';
 import sumBy from 'lodash/sumBy';
 import sortBy from 'lodash/sortBy';
 
+import { localizeWidgetSentenceDate } from 'utils/localize-date';
+
 import { getChartConfig } from 'components/widgets/utils/data';
 
 const getAlerts = (state) => state.data && state.data.alerts;
@@ -17,6 +19,7 @@ const getOptionsSelected = (state) => state.optionsSelected;
 const getIndicator = (state) => state.indicator;
 const getStartIndex = (state) => state.settings.startIndex;
 const getEndIndex = (state) => state.settings.endIndex || null;
+const getLanguage = (state) => state.lang;
 
 const zeroFillDays = (startDate, endDate) => {
   const start = moment(startDate);
@@ -164,8 +167,9 @@ export const parseSentence = createSelector(
     getLocationObject,
     getOptionsSelected,
     getIndicator,
+    getLanguage,
   ],
-  (data, colors, sentences, location, options, indicator) => {
+  (data, colors, sentences, location, options, indicator, language) => {
     if (!data || !data.length) return null;
     const { initial, withInd, highConfidence } = sentences;
     const { confidence, dataset } = options;
@@ -185,14 +189,15 @@ export const parseSentence = createSelector(
     const params = {
       location: location.label || '',
       indicator: indicatorLabel,
-      start_date: moment(startDate).format('Do of MMMM YYYY'),
-      end_date: moment(endDate).format('Do of MMMM YYYY'),
+      start_date: localizeWidgetSentenceDate(startDate, language),
+      end_date: localizeWidgetSentenceDate(endDate, language),
       dataset: dataset && dataset.label,
       total_alerts: {
         value: total ? format(',')(total) : 0,
         color: colors.main,
       },
     };
+
     return { sentence, params };
   }
 );

--- a/components/widgets/fires/fires-alerts/selectors.js
+++ b/components/widgets/fires/fires-alerts/selectors.js
@@ -10,6 +10,7 @@ import {
 } from 'date-fns';
 import moment from 'moment';
 import { formatNumber } from 'utils/format';
+import { translateText } from 'utils/lang';
 import { localizeDate, localizeWidgetSentenceDate } from 'utils/localize-date';
 import isEmpty from 'lodash/isEmpty';
 import sortBy from 'lodash/sortBy';
@@ -535,11 +536,11 @@ export const parseSentence = createSelector(
       10
     );
 
-    let seasonStatement = `late ${seasonMonth}`;
+    let seasonStatement = translateText('late {seasonMonth}', { seasonMonth });
     if (seasonDay <= 10) {
-      seasonStatement = `early ${seasonMonth}`;
+      seasonStatement = translateText('early {seasonMonth}', { seasonMonth });
     } else if (seasonDay > 10 && seasonDay <= 20) {
-      seasonStatement = `mid-${seasonMonth}`;
+      seasonStatement = translateText('mid-{seasonMonth}', { seasonMonth });
     }
 
     const total = sumBy(slicedData, 'count');
@@ -547,18 +548,18 @@ export const parseSentence = createSelector(
     let statusColor = colorRange[8];
     const { date } = lastDate || {};
 
-    let status = 'unusually low';
+    let status = translateText('unusually low');
     if (variance > 2) {
-      status = 'unusually high';
+      status = translateText('unusually high');
       statusColor = colorRange[0];
     } else if (variance <= 2 && variance > 1) {
-      status = 'high';
+      status = translateText('high');
       statusColor = colorRange[2];
     } else if (variance <= 1 && variance > -1) {
-      status = 'normal';
+      status = translateText('normal');
       statusColor = colorRange[4];
     } else if (variance <= -1 && variance > -2) {
-      status = 'low';
+      status = translateText('low');
       statusColor = colorRange[6];
     }
 

--- a/components/widgets/fires/fires-alerts/selectors.js
+++ b/components/widgets/fires/fires-alerts/selectors.js
@@ -10,6 +10,7 @@ import {
 } from 'date-fns';
 import moment from 'moment';
 import { formatNumber } from 'utils/format';
+import { localizeDate, localizeWidgetSentenceDate } from 'utils/localize-date';
 import isEmpty from 'lodash/isEmpty';
 import sortBy from 'lodash/sortBy';
 import orderBy from 'lodash/orderBy';
@@ -38,6 +39,7 @@ const getLocationName = (state) => state.locationLabel;
 const getLang = (state) => state.lang || null;
 const getOptionsSelected = (state) => state.optionsSelected;
 const getIndicator = (state) => state.indicator;
+const getLanguage = (state) => state.lang;
 
 const MINGAP = 4;
 
@@ -465,6 +467,7 @@ export const parseSentence = createSelector(
     getOptionsSelected,
     getLang,
     getIndicator,
+    getLanguage,
   ],
   (
     raw_data,
@@ -476,7 +479,8 @@ export const parseSentence = createSelector(
     indexes,
     options,
     lang,
-    indicator
+    indicator,
+    language
   ) => {
     if (!data || isEmpty(data)) return null;
     const {
@@ -525,8 +529,11 @@ export const parseSentence = createSelector(
     const seasonStartDate =
       sortedPeakWeeks.length > 0 && sortedPeakWeeks[0]?.date;
 
-    const seasonMonth = moment(seasonStartDate).format('MMMM');
-    const seasonDay = parseInt(moment(seasonStartDate).format('D'), 10);
+    const seasonMonth = localizeDate(seasonStartDate, language, 'MMMM');
+    const seasonDay = parseInt(
+      localizeDate(seasonStartDate, language, 'd'),
+      10
+    );
 
     let seasonStatement = `late ${seasonMonth}`;
     if (seasonDay <= 10) {
@@ -568,15 +575,14 @@ export const parseSentence = createSelector(
           : allAlertsWithInd;
     }
 
-    const formattedData = moment(date).format('Do of MMMM YYYY');
     const params = {
       location,
       indicator: indicatorLabel,
-      date: formattedData,
+      date: localizeWidgetSentenceDate(date, language),
       fires_season_start: seasonStatement,
       fire_season_length: sortedPeakWeeks.length,
-      start_date: moment(firstDate.date).format('Do of MMMM YYYY'),
-      end_date: moment(lastDate.date).format('Do of MMMM YYYY'),
+      start_date: localizeWidgetSentenceDate(firstDate.date, language),
+      end_date: localizeWidgetSentenceDate(lastDate.date, language),
       dataset_start_year: dataset === 'viirs' ? 2012 : 2001,
       dataset: dataset.toUpperCase(),
       count: {

--- a/components/widgets/forest-change/glad-alerts-simple/selectors.js
+++ b/components/widgets/forest-change/glad-alerts-simple/selectors.js
@@ -2,8 +2,7 @@
 import { createSelector, createStructuredSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
 import { formatNumber } from 'utils/format';
-
-import moment from 'moment';
+import { localizeWidgetSentenceDate } from 'utils/localize-date';
 
 // get list data
 const selectAlerts = (state) => state.data && state.data.alerts;
@@ -12,6 +11,7 @@ const selectSentences = (state) => state.sentence;
 const getIndicator = (state) => state.indicator || null;
 const getSettings = (state) => state.settings || null;
 const getLocationName = (state) => state.locationLabel;
+const getLanguage = (state) => state.lang;
 
 export const parseData = createSelector([selectAlerts], (data) => {
   if (!data || isEmpty(data)) return null;
@@ -75,14 +75,22 @@ export const parseConfig = createSelector(
 );
 
 export const parseSentence = createSelector(
-  [parseData, getSettings, selectSentences, getIndicator, getLocationName],
-  (data, settings, sentences, indicator, location) => {
+  [
+    parseData,
+    getSettings,
+    selectSentences,
+    getIndicator,
+    getLocationName,
+    getLanguage,
+  ],
+  (data, settings, sentences, indicator, location, language) => {
     if (!data || isEmpty(data)) return null;
 
     const startDate = settings.startDate;
     const endDate = settings.endDate;
-    const formattedStartDate = moment(startDate).format('Do of MMMM YYYY');
-    const formattedEndDate = moment(endDate).format('Do of MMMM YYYY');
+    const formattedStartDate = localizeWidgetSentenceDate(startDate, language);
+    const formattedEndDate = localizeWidgetSentenceDate(endDate, language);
+
     const params = {
       indicator: indicator && indicator.label,
       location,

--- a/components/widgets/forest-change/glad-alerts/selectors.js
+++ b/components/widgets/forest-change/glad-alerts/selectors.js
@@ -13,6 +13,7 @@ import {
   getDatesData,
   getChartConfig,
 } from 'components/widgets/utils/data';
+import { localizeWidgetSentenceDate } from 'utils/localize-date';
 
 // get list data
 const selectAlerts = (state) => state.data && state.data.alerts;
@@ -21,8 +22,8 @@ const selectColors = (state) => state.colors;
 const selectInteraction = (state) => state.interaction;
 const selectWeeks = (state) => state.settings && state.settings.weeks;
 const selectSentences = (state) => state.sentence;
-const selectLang = (state) => state.lang;
 const getIndicator = (state) => state.indicator || null;
+const getLanguage = (state) => state.lang;
 
 export const parsePayload = (payload) => {
   const payloadData = payload && payload.find((p) => p.name === 'count');
@@ -153,9 +154,9 @@ export const parseSentence = createSelector(
     selectInteraction,
     selectSentences,
     getIndicator,
-    selectLang,
+    getLanguage,
   ],
-  (data, colors, interaction, sentences, indicator) => {
+  (data, colors, interaction, sentences, indicator, language) => {
     if (!data) return null;
 
     let lastDate = data[data.length - 1] || {};
@@ -201,10 +202,10 @@ export const parseSentence = createSelector(
       status = 'low';
       statusColor = colorRange[3];
     }
-    const formattedDate = moment(date).format('Do of MMMM YYYY');
+
     const params = {
       indicator: indicator && indicator.label,
-      date: formattedDate,
+      date: localizeWidgetSentenceDate(date, language),
       count: {
         value: lastDate.count ? format(',')(lastDate.count) : 0,
         color: colors.main,

--- a/components/widgets/forest-change/integrated-deforestation-alerts/selectors.js
+++ b/components/widgets/forest-change/integrated-deforestation-alerts/selectors.js
@@ -4,6 +4,7 @@ import isEmpty from 'lodash/isEmpty';
 import sumBy from 'lodash/sumBy';
 import filter from 'lodash/filter';
 import { formatNumber } from 'utils/format';
+import { translateText } from 'utils/lang';
 import { localizeWidgetSentenceDate } from 'utils/localize-date';
 
 import moment from 'moment';
@@ -176,9 +177,8 @@ export const parseSentence = createSelector(
       highestAlertPercentage,
     } = data;
 
-    const {
-      deforestationAlertsDataset = { label: null, value: null },
-    } = options;
+    const { deforestationAlertsDataset = { label: null, value: null } } =
+      options;
     const { label: system, value: systemSlug } = deforestationAlertsDataset;
 
     const selectedDate = settings.startDate;
@@ -200,11 +200,12 @@ export const parseSentence = createSelector(
       system,
       totalArea: !totalArea
         ? ' '
-        : `covering a total of ${formatNumber({
+        : translateText('covering a total of {area}', {
+          area: formatNumber({
             num: totalArea,
             unit: 'ha',
             spaceUnit: true,
-          })}`,
+          })}),
       total: formatNumber({ num: totalAlertCount, unit: ',' }),
       highConfPerc:
         highAlertPercentage === 0

--- a/components/widgets/forest-change/integrated-deforestation-alerts/selectors.js
+++ b/components/widgets/forest-change/integrated-deforestation-alerts/selectors.js
@@ -4,6 +4,7 @@ import isEmpty from 'lodash/isEmpty';
 import sumBy from 'lodash/sumBy';
 import filter from 'lodash/filter';
 import { formatNumber } from 'utils/format';
+import { localizeWidgetSentenceDate } from 'utils/localize-date';
 
 import moment from 'moment';
 
@@ -15,6 +16,7 @@ const getIndicator = (state) => state.indicator || null;
 const getSettings = (state) => state.settings || null;
 const getLocationName = (state) => state.locationLabel;
 const getOptionsSelected = (state) => state.optionsSelected;
+const getLanguage = (state) => state.lang;
 
 export const parseData = createSelector([selectAlerts], (data) => {
   if (!data || isEmpty(data)) return null;
@@ -159,8 +161,9 @@ export const parseSentence = createSelector(
     getIndicator,
     getLocationName,
     getOptionsSelected,
+    getLanguage,
   ],
-  (data, settings, sentences, indicator, currentLabel, options) => {
+  (data, settings, sentences, indicator, currentLabel, options, language) => {
     if (!data || isEmpty(data)) return null;
     // TODO explore why the getOptionsSelected is returning null
 
@@ -188,8 +191,8 @@ export const parseSentence = createSelector(
     const diff = possibleStartDateMoment.diff(startDateMoment, 'days');
     const startDate = diff > 0 ? possibleStartDate : selectedDate;
 
-    const formattedStartDate = moment(startDate).format('Do of MMMM YYYY');
-    const formattedEndDate = moment(endDate).format('Do of MMMM YYYY');
+    const formattedStartDate = localizeWidgetSentenceDate(startDate, language);
+    const formattedEndDate = localizeWidgetSentenceDate(endDate, language);
 
     const params = {
       location: currentLabel === 'global' ? 'globally' : currentLabel,

--- a/utils/localize-date.js
+++ b/utils/localize-date.js
@@ -1,0 +1,41 @@
+import dateFnsformat from 'date-fns/format';
+import { enUS, es, ptBR, zhCN, fr, id } from 'date-fns/locale';
+
+// TX language codes (set in localStorage) mapping to ISO codes that date-fns uses for locales
+export const TX_LANGUAGE_TO_DATEFNS_LOCALE_MAPPING = {
+  en: enUS,
+  zh: zhCN,
+  fr,
+  id,
+  pt_BR: ptBR,
+  es_MX: es,
+};
+
+// General localization function
+export const localizeDate = (date, lang = 'en', format = 'PP') => {
+  const dateFnsLocale = TX_LANGUAGE_TO_DATEFNS_LOCALE_MAPPING[lang];
+
+  // Format the date.
+  const localizedDate = dateFnsformat(new Date(date), format, {
+    locale: dateFnsLocale,
+  });
+
+  return localizedDate;
+};
+
+// Localization function specific for widgets' sentences
+export const localizeWidgetSentenceDate = (date, lang = 'en') => {
+  const DATE_FORMAT_MAPPING = {
+    en: "do 'of' LLLL yyyy",
+    zh: "do LLLL yyyy",
+    fr: "do LLLL yyyy",
+    id: "do LLLL yyyy",
+    pt_BR: "d 'de' LLLL 'de' yyyy",
+    es_MX: "d 'de' LLLL 'de' yyyy",
+  };
+
+  const format = DATE_FORMAT_MAPPING[lang];
+  const localizedDate = localizeDate(date, lang, format);
+
+  return localizedDate;
+}


### PR DESCRIPTION
## Overview

This PR aims to address _a few_ issues with _the integration deforestation alerts_ widget's translations, as well as a few others. This implementation focuses mainly on two aspects:  
- Localize dates 
  _with a setup similar (but not quite the same, due to the requirements and implementation) to the one [implemented for the blog](https://github.com/wri/gfw-blog/pull/155)_
- Address issues with strings (some with value interpolation) not being correctly sent to Transifex
  _in a way that'd allow for variable interpolation (in Transifex)_   
- Integrated deforestation alerts dropdown not translating for the selected item  

&nbsp;  

**Date localization**  

A similar setup to the one used for localizing dates in the blog (see here)[https://github.com/wri/gfw-blog/pull/155] was implemented. It makes use of `date-fns`, which already exists in the application.

An util/helper was created that contains:  
- Transifex to DateFNS mapping, similar to the blog setup  
- A generic function to localize dates that makes use of the mapping, and can have language and format passed to it  
- A specific version for widget's sentences  
  - This specific version exists to keep all the date formatting in widget's sentences consistent between them.   
  - Because the widget's sentences use a more formal way of having dates written, there is also a mapping between language and date-fns formats   
  - I tried to google the correct form of writing the dates in a way that feels like a translation of the originally defined English version where I could. If we need to change this in the future, we have a single point (`utils/localize-date.js`) where we can tweak the format and have it apply to all widget's sentences; the goal is to save future trouble with the changes, instead of having to find and replace in all widgets.    

I did notice that many widget use `moment.js` for date calculations, I did not change this. The change is only for localization of the dates. 

&nbsp;  

**Interpolation and Transifex**  

This was a bit more confusing but from what I gathered, translation with variable interpolation works correctly for sentences defined in a widget's `index.js`, due to the use of `<DynamicSentence />` (we may need to deep dive into this in the future).

However, I've noticed some widgets do have extra text additions specified in a widget's `selectors.js`'s `parseSentence`. 
In this case, when these sentences _also_ include an interpolation, we end up with an interpolation inside another interpolation, so this second nested level doesn't get automatically processed.

I did find, however, that we already have an `translateText` in `utils/lang` to address scenarios where we need to have the strings translated w/ interpolation of values; it is used in many places of the app. I tried to find as many widgets as I could that needed this change and added it to them. 

I do not currently have a Transifex account, but I am making an educated guess (from what I've learned from other parts of the application, and the next section below) that these smaller strings are now being sent to transifex; they will need to be translated. 

&nbsp;  

**Integrated deforestation alerts dropdown**  

Transifex already has the translations for the sentences that weren't being translated (as the sub-items in the dropdown were being translated), so adding the `translateText` to the main button caused them to work again. 


## Tracking  

[FLAG-1035](https://gfw.atlassian.net/browse/FLAG-1035)



[FLAG-1035]: https://gfw.atlassian.net/browse/FLAG-1035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ