### PR TITLE
[FLAG-927] Remove space between percentage and numbers for the forestry-employment widget

### DIFF
--- a/components/widgets/land-use/forestry-employment/selectors.js
+++ b/components/widgets/land-use/forestry-employment/selectors.js
@@ -30,7 +30,10 @@ export const parseData = createSelector(
       const color = colors[key];
 
       if (!value) return acc;
-      return [...acc, { label, value: percentage, percentage, color }];
+      return [
+        ...acc,
+        { label, value: percentage, percentage, color, unit: '%' },
+      ];
     }, []);
 
     return formattedData;


### PR DESCRIPTION
## Overview

This PR adds the `unit` to the forestry-employment widget chart data, in order to eliminate the space between value and unit (`%`)

## Screenshot

![no-space-unit](https://github.com/user-attachments/assets/41f0acb0-d5bb-4a16-bc96-c1c423a6a851)


## Tracking 

[FLAG-927](https://gfw.atlassian.net/browse/FLAG-927)
