### PR TITLE
[FLAG-923] Pasting a special character into search by location lead to an error occurred

### DIFF
--- a/utils/url-param.js
+++ b/utils/url-param.js
@@ -1,0 +1,15 @@
+const encode = (param) => {
+  return btoa(JSON.stringify(param));
+};
+
+const decode = (param) => {
+  // we use Buffer as atob is node native to node for SSR
+  return JSON.parse(Buffer.from(param, 'base64').toString('binary'));
+};
+
+const urlParam = {
+  encode,
+  decode
+};
+
+export default urlParam;

--- a/utils/url-param.js
+++ b/utils/url-param.js
@@ -1,13 +1,26 @@
+// We encode url params into Base64 to add them to the URL by using window.btoa().
+// However, this method can fail if the string being encoded includes characters
+// outside of the Latin1 alphabet. Eg: "Bình Thuận".
+// This file offers a couple utilities to encode and decode a param, by first encoding
+// it with the use of TextEncoder(), and reversing it when decoding with the use of
+// TextDecoder(). This is the solution advised by the MDN web docs.
+// See: https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem
+
 const base64ToBytes = (base64) => {
+  // we use Buffer as atob() is a window method, and we may be decoding the param
+  // server side.
   const binString = Buffer.from(base64, 'base64').toString('binary');
   return Uint8Array.from(binString, (m) => m.codePointAt(0));
 };
 
 const bytesToBase64 = (bytes) => {
-  const binString = Array.from(bytes, (byte) => String.fromCodePoint(byte)).join('');
+  const binString = Array.from(bytes, (byte) =>
+    String.fromCodePoint(byte)
+  ).join('');
   return btoa(binString);
 };
 
+// Decode an URL param according to the suggestion presented in the MDN web docs.
 const decode = (param) => {
   const base64DecodedParam = base64ToBytes(param);
   const textDecodedParam = new TextDecoder().decode(base64DecodedParam);
@@ -15,6 +28,7 @@ const decode = (param) => {
   return parsedStringifiedParam;
 };
 
+// Encode an URL param according to the suggestion presented in the MDN web docs.
 const encode = (param) => {
   const stringifiedParam = JSON.stringify(param);
   const textEncodedParam = new TextEncoder().encode(stringifiedParam);
@@ -24,7 +38,7 @@ const encode = (param) => {
 
 const urlParam = {
   encode,
-  decode
+  decode,
 };
 
 export default urlParam;

--- a/utils/url-param.js
+++ b/utils/url-param.js
@@ -1,10 +1,25 @@
-const encode = (param) => {
-  return btoa(JSON.stringify(param));
+const base64ToBytes = (base64) => {
+  const binString = Buffer.from(base64, 'base64').toString('binary');
+  return Uint8Array.from(binString, (m) => m.codePointAt(0));
+};
+
+const bytesToBase64 = (bytes) => {
+  const binString = Array.from(bytes, (byte) => String.fromCodePoint(byte)).join('');
+  return btoa(binString);
 };
 
 const decode = (param) => {
-  // we use Buffer as atob is node native to node for SSR
-  return JSON.parse(Buffer.from(param, 'base64').toString('binary'));
+  const base64DecodedParam = base64ToBytes(param);
+  const textDecodedParam = new TextDecoder().decode(base64DecodedParam);
+  const parsedStringifiedParam = JSON.parse(textDecodedParam);
+  return parsedStringifiedParam;
+};
+
+const encode = (param) => {
+  const stringifiedParam = JSON.stringify(param);
+  const textEncodedParam = new TextEncoder().encode(stringifiedParam);
+  const base64EncodedParam = bytesToBase64(textEncodedParam);
+  return base64EncodedParam;
 };
 
 const urlParam = {

--- a/utils/url.js
+++ b/utils/url.js
@@ -2,6 +2,7 @@ import { stringify } from 'query-string';
 import isEmpty from 'lodash/isEmpty';
 
 import legacyIds from 'data/legacy-ids.json';
+import urlParam from 'utils/url-param';
 
 const idToSlugDict = legacyIds.reduce(
   (obj, item) => ({
@@ -44,10 +45,7 @@ export const decodeQueryParams = (params) => {
     try {
       return {
         ...obj,
-        // we use Buffer as atob is node native to node for SSR
-        [key]: JSON.parse(
-          Buffer.from(params[key], 'base64').toString('binary')
-        ),
+        [key]: urlParam.decode(params[key]),
       };
     } catch (err) {
       try {
@@ -82,7 +80,7 @@ export const encodeQueryParams = (params, options) => {
       typeof params[key] === 'object' &&
       !isEmpty(params[key])
     ) {
-      return { ...obj, [key]: btoa(JSON.stringify(params[key])) };
+      return { ...obj, [key]: urlParam.encode(params[key]) };
     }
     // if params is a valid key and not falsey
     if (typeof params[key] !== 'object' && params[key]) {


### PR DESCRIPTION
## Overview

The FE makes use of [btoa()](https://developer.mozilla.org/en-US/docs/Web/API/Window/btoa) to Base64 encode parameters for the URL. However, [this method fails when strings include characters that take more than one byte](https://developer.mozilla.org/en-US/docs/Web/API/Window/btoa#unicode_strings), which is the case of _"Bình Thuận"_, the string that when searched caused the FE to crash. 

This is known as [the Unicode Problem](https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem). 

The MDN Web Docs offer a solution, which passes by first encoding the string with [TextEncoder](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder) (and later using the [TextDecoder](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder) counterpart to reverse it), which is what this PR implements. 

I've created a separate util (`utils/url-param.js`) exclusive for this processing, with comments so that future developers are aware of this issue. I've chosen not to add these methods to `utils/url.js` as that file contains extra processing, including functions to remap legacy datasets, and I feel like the objective of these new very specific functions would not be clear. 

## Testing

 1. Visit https://gfw-staging-pr-4836.herokuapp.com/map
 2. On the sidebar, click "Search"  
 3. Fill in "Bình Thuận" in the search box  
 4. Verify that the application does not crash

## Tracking 

[FLAG-923](https://gfw.atlassian.net/browse/FLAG-923)


[FLAG-923]: https://gfw.atlassian.net/browse/FLAG-923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ