### PR TITLE
[FLAG-875] Fix widgets never using precalc tables due to missing `status`

### DIFF
--- a/components/widget/index.js
+++ b/components/widget/index.js
@@ -136,6 +136,7 @@ class WidgetContainer extends Component {
       dashboard,
       embed,
       analysis,
+      status,
     } = this.props;
     this.cancelWidgetDataFetch();
     this.widgetDataFetch = CancelToken.source();
@@ -147,6 +148,9 @@ class WidgetContainer extends Component {
       dashboard,
       embed,
       analysis,
+      // Needed for widgets that will decide whether to use precalculated tables
+      // (when status is 'saved') or OTF (when the nightly run has not occurred yet)
+      status,
     })
       .then((data) => {
         setWidgetData(data);


### PR DESCRIPTION
## Overview

Many widgets (list below) use the `shouldQueryPrecomputedTables` helper to decide whether they should query precomputed tables for AOIs or do an on-the-fly analysis. When an area was not yet precomputed, OTF should be used, but if there was a nightly run the data will have a `saved` `status`, and precomputed tables should be used instead. 

The issue is that `status` is always `undefined`, as it is not being passed to the widgets `getData` function. This PR passes that data again, and adds a comment so that we know what the `status` is used for. 

## Tracking

[FLAG-875](https://gfw.atlassian.net/browse/FLAG-875)

