### PR TITLE
FLAG-861: replace /zonal with /query

### DIFF
--- a/components/widgets/forest-change/tree-cover-gain-simple/index.js
+++ b/components/widgets/forest-change/tree-cover-gain-simple/index.js
@@ -1,5 +1,4 @@
-import { getGain } from 'services/analysis-cached';
-import OTFAnalysis from 'services/otf-analysis';
+import { getGain, getTreeCoverGainOTF } from 'services/analysis-cached';
 
 import { shouldQueryPrecomputedTables } from 'components/widgets/utils/helpers';
 
@@ -14,26 +13,6 @@ import {
 } from 'data/layers';
 
 import getWidgetProps from './selectors';
-
-const getOTFAnalysis = async (params) => {
-  const analysis = new OTFAnalysis(params.geostore.id);
-  analysis.setDates({
-    startDate: params.startDate,
-    endDate: params.endDate,
-  });
-  analysis.setData(['gain'], params);
-
-  return analysis.getData().then((response) => {
-    const { gain } = response;
-    const totalGain = gain?.[0]?.area__ha;
-    const totalExtent = params?.geostore?.areaHa || 0;
-
-    return {
-      gain: totalGain,
-      extent: totalExtent,
-    };
-  });
-};
 
 export default {
   widget: 'treeCoverGainSimple',
@@ -85,7 +64,7 @@ export default {
       });
     }
 
-    return getOTFAnalysis(params);
+    return getTreeCoverGainOTF(params);
   },
   getDataURL: (params) => {
     return [getGain({ ...params, download: true })];

--- a/components/widgets/land-cover/tree-cover/index.js
+++ b/components/widgets/land-cover/tree-cover/index.js
@@ -1,6 +1,9 @@
 import { all, spread } from 'axios';
-import { getExtent, getTropicalExtent } from 'services/analysis-cached';
-import OTFAnalysis from 'services/otf-analysis';
+import {
+  getExtent,
+  getTreeCoverOTF,
+  getTropicalExtent,
+} from 'services/analysis-cached';
 
 import { shouldQueryPrecomputedTables } from 'components/widgets/utils/helpers';
 import {
@@ -18,28 +21,6 @@ import {
 
 import getWidgetProps from './selectors';
 
-const getOTFAnalysis = async (params) => {
-  const analysis = new OTFAnalysis(params.geostore.id);
-  analysis.setDates({
-    startDate: params.startDate,
-    endDate: params.endDate,
-  });
-  analysis.setData(['areaHa', 'extent'], params);
-
-  return analysis.getData().then((response) => {
-    const { areaHa, extent } = response;
-    const totalArea = areaHa?.[0]?.area__ha;
-    const totalCover = extent?.[0]?.area__ha;
-
-    return {
-      totalArea,
-      totalCover,
-      cover: totalCover,
-      plantations: 0,
-    };
-  });
-};
-
 export default {
   widget: 'treeCover',
   title: {
@@ -50,8 +31,7 @@ export default {
   alerts: [
     {
       id: 'tree-cover-alert-1',
-      text:
-        'Datasets available here (Tree Cover 2000/ 2010 and Tropical Tree Cover 2020) use different methodologies to measure tree cover. Read [our blog](https://www.globalforestwatch.org/blog/data-and-research/tree-cover-data-comparison/) for more information.',
+      text: 'Datasets available here (Tree Cover 2000/ 2010 and Tropical Tree Cover 2020) use different methodologies to measure tree cover. Read [our blog](https://www.globalforestwatch.org/blog/data-and-research/tree-cover-data-comparison/) for more information.',
       visible: [
         'global',
         'country',
@@ -225,7 +205,7 @@ export default {
       );
     }
 
-    return getOTFAnalysis(params);
+    return getTreeCoverOTF(params);
   },
   getDataURL: (params) => {
     const { threshold, decile, ...filteredParams } = params;

--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -94,7 +94,7 @@ const SQL_QUERIES = {
   treeLossOTF:
     'SELECT umd_tree_cover_loss__year, SUM(area__ha) FROM data WHERE umd_tree_cover_loss__year >= {startYear} AND umd_tree_cover_loss__year <= {endYear} AND umd_tree_cover_density_2000__threshold >= {threshold} GROUP BY umd_tree_cover_loss__year&geostore_id={geostoreId}',
   treeLossOTFExtent:
-    'SELECT SUM(area__ha) FROM data WHERE umd_tree_cover_loss__year >= {startYear} AND umd_tree_cover_loss__year <= {endYear} AND umd_tree_cover_density_2000__threshold >= {threshold}&geostore_id={geostoreId}',
+    'SELECT SUM(area__ha) FROM data WHERE umd_tree_cover_density_2000__threshold >= {threshold}&geostore_id={geostoreId}',
 };
 
 const typeByGrouped = {
@@ -696,22 +696,21 @@ export const getTreeLossOTF = async (params) => {
   } = params || {};
 
   const geostoreId = geostore.id || adm0;
-  const urlBase = '/dataset/umd_tree_cover_gain/latest/query';
+  const urlForList = '/dataset/umd_tree_cover_loss/latest/query';
+  const urlForExtent = '/dataset/umd_tree_cover_density_2000/latest/query';
   const sqlLoss = `?sql=${SQL_QUERIES.treeLossOTF}`;
   const sqlExtent = `?sql=${SQL_QUERIES.treeLossOTFExtent}`;
 
   const urlLoss = encodeURI(
-    `${urlBase + sqlLoss}`
+    `${urlForList + sqlLoss}`
       .replace('{geostoreId}', geostoreId)
       .replace('{startYear}', startYear)
       .replace('{endYear}', endYear)
       .replace('{threshold}', threshold)
   );
   const urlExtent = encodeURI(
-    `${urlBase + sqlExtent}`
+    `${urlForExtent + sqlExtent}`
       .replace('{geostoreId}', geostoreId)
-      .replace('{startYear}', startYear)
-      .replace('{endYear}', endYear)
       .replace('{threshold}', threshold)
   );
 

--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -79,6 +79,8 @@ const SQL_QUERIES = {
   treeCoverOTF:
     'SELECT SUM(area__ha) FROM data WHERE umd_tree_cover_density_2000__threshold >= {threshold}&geostore_id={geostoreId}',
   treeCoverOTFExtent: 'SELECT SUM(area__ha) FROM data&geostore_id={geostoreId}',
+  treeCoverGainSimpleOTF:
+    'SELECT SUM(area__ha) FROM data&geostore_id={geostoreId}',
   netChangeIso:
     'SELECT {select_location}, stable, loss, gain, disturb, net, change, gfw_area__ha FROM data {WHERE}',
   netChange:
@@ -770,6 +772,22 @@ export const getTreeCoverOTF = async (params) => {
     totalCover: treeCover.data[0]?.area__ha,
     cover: treeCover.data[0]?.area__ha,
     plantations: 0,
+  };
+};
+
+export const getTreeCoverGainOTF = async (params) => {
+  const { adm0, geostore } = params || {};
+  const geostoreId = geostore.id || adm0;
+  const urlBase = '/dataset/umd_tree_cover_gain/latest/query';
+  const sql = `?sql=${SQL_QUERIES.treeCoverGainSimpleOTF}`;
+
+  const url = encodeURI(`${urlBase + sql}`.replace('{geostoreId}', geostoreId));
+
+  const response = await dataRequest.get(url);
+
+  return {
+    gain: response.data[0]?.area__ha,
+    extent: params?.geostore?.areaHa || 0,
   };
 };
 

--- a/services/otf-analysis.js
+++ b/services/otf-analysis.js
@@ -4,6 +4,7 @@ import { dataRequest } from 'utils/request';
 
 import otfData from 'data/otf-data';
 
+// TODO: the use of /analysis/zonal is deorecated, removing this file soon
 // Perform a OTF(on the fly) analysis for un-cached widgets
 // https://data-api.globalforestwatch.org/#tag/Analysis
 class OTFAnalysis {
@@ -117,14 +118,8 @@ class OTFAnalysis {
   }
 
   buildQuery(sumFields = null, groupFields = null, filters = null) {
-    const {
-      endpoint,
-      path,
-      geostoreId,
-      geostoreOrigin,
-      startDate,
-      endDate,
-    } = this;
+    const { endpoint, path, geostoreId, geostoreOrigin, startDate, endDate } =
+      this;
     let url = '';
     if (!sumFields) {
       this.throwError(


### PR DESCRIPTION
## Overview

Replacing `zonal` with `query` endpoints on the following widgets:

- treeCoverGainSimple
- treeLoss
- treeCover


## Demo

If applicable: screenshots, gifs, etc.

## Notes

If applicable: ancilary topics, caveats, alternative strategies that didn't work out, etc.

## Testing

- Include any steps to verify the features this PR introduces.
- If this fixes a bug, include bug reproduction steps.

