### PR TITLE
[FLAG-1145][FLAG-1110] Support legend in bar chart widgets + add legend primary forest loss widget

### DIFF
--- a/components/charts/composed-chart/component.jsx
+++ b/components/charts/composed-chart/component.jsx
@@ -46,7 +46,7 @@ const XAxisTickWithoutGap = ({ x, y, payload }) => {
     </g>
   );
 
-  /* 
+  /*
     Work around to show number 100 in the end of X axis in the chart
     since the Data API sends 0 to 90 percent in the tree cover density widget
     0 stands to 0%-9% as 90 stands to 90%-99%

--- a/components/widget/component.jsx
+++ b/components/widget/component.jsx
@@ -13,6 +13,7 @@ class Widget extends PureComponent {
     title: PropTypes.string.isRequired,
     type: PropTypes.string,
     active: PropTypes.bool,
+    analysis: PropTypes.bool,
     downloadDisabled: PropTypes.bool,
     filterSelected: PropTypes.bool,
     maxSize: PropTypes.number,
@@ -85,6 +86,7 @@ class Widget extends PureComponent {
       colors,
       type,
       active,
+      analysis,
       downloadDisabled,
       filterSelected,
       maxSize,
@@ -218,6 +220,7 @@ class Widget extends PureComponent {
               large={large}
               autoHeight={autoHeight}
               embed={embed}
+              analysis={analysis}
               location={location}
               locationName={locationLabelFull}
               active={active}

--- a/components/widget/components/widget-chart-legend/component.jsx
+++ b/components/widget/components/widget-chart-legend/component.jsx
@@ -1,0 +1,75 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+
+import cx from 'classnames';
+
+class WidgetChartLegend extends PureComponent {
+  render() {
+    const { className, data = {} } = this.props;
+    const { columns = [] } = data;
+
+    const anyColumnsHaveTitle = !!columns.find((column) => column.title);
+
+    return (
+      <div className={cx("c-widget-chart-legend", className)}>
+        {columns.map(({ title, items }, columnIdx) => {
+          return (
+            <div key={columnIdx} className="c-widget-chart-legend__column">
+              <span className="c-widget-chart-legend__column-title">
+                {title}
+              </span>
+              <ul
+                className={cx("c-widget-chart-legend__column-items", {
+                  padded: anyColumnsHaveTitle && !title,
+                })}
+              >
+                {items.map(({ label, color, dashline }, titleIdx) => {
+                  return (
+                    <li
+                      key={titleIdx}
+                      className="c-widget-chart-legend__column-item"
+                    >
+                      {dashline ? (
+                        <span
+                          className="c-widget-chart-legend__column-item--dashline"
+                          style={{
+                            borderColor: color,
+                          }}
+                        />
+                      ) : (
+                        <span
+                          className="c-widget-chart-legend__column-item--circle"
+                          style={{
+                            backgroundColor: color,
+                          }}
+                        />
+                      )}
+                      <p>{label}</p>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+}
+
+WidgetChartLegend.propTypes = {
+  className: PropTypes.string,
+  data: {
+    columns: {
+      title: PropTypes.string,
+      items: PropTypes.arrayOf(
+        PropTypes.shape({
+          color: PropTypes.string.isRequired,
+          label: PropTypes.string.isRequired,
+        })
+      ),
+    },
+  },
+};
+
+export default WidgetChartLegend;

--- a/components/widget/components/widget-chart-legend/component.jsx
+++ b/components/widget/components/widget-chart-legend/component.jsx
@@ -5,21 +5,23 @@ import cx from 'classnames';
 
 class WidgetChartLegend extends PureComponent {
   render() {
-    const { className, data = {} } = this.props;
+    const { className, vertical = false, data = {} } = this.props;
     const { columns = [] } = data;
 
     const anyColumnsHaveTitle = !!columns.find((column) => column.title);
 
     return (
-      <div className={cx("c-widget-chart-legend", className)}>
+      <div className={cx('c-widget-chart-legend', className, { vertical })}>
         {columns.map(({ title, items }, columnIdx) => {
           return (
             <div key={columnIdx} className="c-widget-chart-legend__column">
-              <span className="c-widget-chart-legend__column-title">
-                {title}
-              </span>
+              {title && (
+                <span className="c-widget-chart-legend__column-title">
+                  {title}
+                </span>
+              )}
               <ul
-                className={cx("c-widget-chart-legend__column-items", {
+                className={cx('c-widget-chart-legend__column-items', {
                   padded: anyColumnsHaveTitle && !title,
                 })}
               >
@@ -59,6 +61,7 @@ class WidgetChartLegend extends PureComponent {
 
 WidgetChartLegend.propTypes = {
   className: PropTypes.string,
+  vertical: PropTypes.bool,
   data: {
     columns: {
       title: PropTypes.string,

--- a/components/widget/components/widget-chart-legend/index.js
+++ b/components/widget/components/widget-chart-legend/index.js
@@ -1,0 +1,3 @@
+import Component from './component';
+
+export default Component;

--- a/components/widget/components/widget-chart-legend/styles.scss
+++ b/components/widget/components/widget-chart-legend/styles.scss
@@ -11,7 +11,7 @@
       display: block;
       font-weight: 500;
       font-size: rem(13px);
-      margin: 0 0 rem(10px) 0;
+      margin: 0 0 rem(8px) 0;
     }
 
     &-items {
@@ -20,7 +20,7 @@
       gap: 5px;
 
       &.padded {
-        padding-top: rem(30px);
+        padding-top: rem(2px);
       }
     }
 

--- a/components/widget/components/widget-chart-legend/styles.scss
+++ b/components/widget/components/widget-chart-legend/styles.scss
@@ -1,0 +1,61 @@
+@import '~styles/settings.scss';
+
+.c-widget-chart-legend {
+  display: flex;
+  margin: 20px 0 0;
+  width: 100%;
+  gap: 40px;
+
+  &__column {
+    &-title {
+      font-weight: 500;
+      font-size: rem(12px);
+      margin-top: -rem(8px);
+    }
+
+    &-items {
+      display: flex;
+      flex-direction: column;
+      gap: 5px;
+
+      &.padded {
+        padding-top: rem(26px);
+      }
+    }
+
+    &-item {
+      font-size: rem(12px);
+      display: flex;
+
+      &--circle,
+      &--dashline {
+        display: inline-block;
+        width: rem(12px);
+        min-width: rem(12px);
+        min-height: rem(12px);
+        height: rem(12px);
+        margin-right: rem(7px);
+      }
+
+      &--circle {
+        border-radius: 100%;
+        align-self: flex-start;
+        margin-top: 1px;
+      }
+
+      &--dashline {
+        border-radius: 0;
+        border: none;
+        border-top: 2px dotted;
+        align-self: center;
+        transform: translateY(4px);
+      }
+
+      p {
+        color: $slate;
+        font-size: rem(12px);
+        line-height: 1.4;
+      }
+    }
+  }
+}

--- a/components/widget/components/widget-chart-legend/styles.scss
+++ b/components/widget/components/widget-chart-legend/styles.scss
@@ -20,7 +20,7 @@
       gap: 5px;
 
       &.padded {
-        padding-top: rem(20px);
+        padding-top: rem(30px);
       }
     }
 

--- a/components/widget/components/widget-chart-legend/styles.scss
+++ b/components/widget/components/widget-chart-legend/styles.scss
@@ -59,4 +59,23 @@
       }
     }
   }
+
+  &.vertical {
+    flex-direction: column;
+    gap: 5px;
+
+    .c-widget-chart-legend {
+      &__column {
+        &-title {
+          margin-top: rem(8px);
+        }
+
+        &-items {
+          &.padded {
+            padding-top: 0;
+          }
+        }
+      }
+    }
+  }
 }

--- a/components/widget/components/widget-chart-legend/styles.scss
+++ b/components/widget/components/widget-chart-legend/styles.scss
@@ -4,13 +4,14 @@
   display: flex;
   margin: 20px 0 0;
   width: 100%;
-  gap: 40px;
+  gap: 60px;
 
   &__column {
     &-title {
+      display: block;
       font-weight: 500;
-      font-size: rem(12px);
-      margin-top: -rem(8px);
+      font-size: rem(13px);
+      margin: 0 0 rem(10px) 0;
     }
 
     &-items {
@@ -19,7 +20,7 @@
       gap: 5px;
 
       &.padded {
-        padding-top: rem(26px);
+        padding-top: rem(20px);
       }
     }
 

--- a/components/widget/components/widget-composed-chart/component.jsx
+++ b/components/widget/components/widget-composed-chart/component.jsx
@@ -5,6 +5,7 @@ import debounce from 'lodash/debounce';
 import ComposedChart from 'components/charts/composed-chart';
 import Brush from 'components/charts/brush-chart';
 import Legend from 'components/charts/components/chart-legend';
+import ChartLegend from '../widget-chart-legend';
 
 class WidgetComposedChart extends Component {
   static propTypes = {
@@ -72,7 +73,7 @@ class WidgetComposedChart extends Component {
       barBackground,
       toggleSettingsMenu,
     } = this.props;
-    const { brush, legend } = config;
+    const { brush, legend, chartLegend } = config;
     const showLegendSettingsBtn =
       settingsConfig &&
       settingsConfig.some((conf) => conf.key === 'compareYear');
@@ -106,6 +107,10 @@ class WidgetComposedChart extends Component {
             data={originalData}
             onBrushEnd={this.handleBrushEnd}
           />
+        )}
+
+        { chartLegend && (
+          <ChartLegend data={chartLegend} />
         )}
       </div>
     );

--- a/components/widget/components/widget-composed-chart/component.jsx
+++ b/components/widget/components/widget-composed-chart/component.jsx
@@ -9,6 +9,7 @@ import ChartLegend from '../widget-chart-legend';
 
 class WidgetComposedChart extends Component {
   static propTypes = {
+    analysis: PropTypes.bool,
     originalData: PropTypes.array,
     data: PropTypes.array,
     config: PropTypes.object,
@@ -64,6 +65,7 @@ class WidgetComposedChart extends Component {
 
   render() {
     const {
+      analysis,
       originalData,
       data,
       config,
@@ -109,9 +111,7 @@ class WidgetComposedChart extends Component {
           />
         )}
 
-        { chartLegend && (
-          <ChartLegend data={chartLegend} />
-        )}
+        {chartLegend && <ChartLegend data={chartLegend} vertical={analysis} />}
       </div>
     );
   }

--- a/components/widgets/climate/emissions-deforestation-drivers/selectors.js
+++ b/components/widgets/climate/emissions-deforestation-drivers/selectors.js
@@ -162,21 +162,23 @@ export const parseConfig = createSelector(
         .reverse()
     );
 
-    const chartLegend = {
-      columns: [
-        {
-          items: ['Wildfire', 'Forestry', 'Shifting agriculture']?.map(
-            (name) => ({ label: name, color: categoryColors[name] })
-          ),
-        },
-        {
-          title: 'Drivers of permanent deforestation',
-          items: ['Commodity driven deforestation', 'Urbanization']?.map(
-            (name) => ({ label: name, color: categoryColors[name] })
-          ),
-        },
-      ],
-    };
+    // Example on how to add columns & titles to the Chart Legend
+    // See: https://gfw.atlassian.net/browse/FLAG-1145
+    // const chartLegend = {
+    //   columns: [
+    //     {
+    //       items: ['Wildfire', 'Forestry', 'Shifting agriculture']?.map(
+    //         (name) => ({ label: name, color: categoryColors[name] })
+    //       ),
+    //     },
+    //     {
+    //       title: 'Drivers of permanent deforestation',
+    //       items: ['Commodity driven deforestation', 'Urbanization']?.map(
+    //         (name) => ({ label: name, color: categoryColors[name] })
+    //       ),
+    //     },
+    //   ],
+    // };
 
     const insertIndex = findIndex(tooltip, { key: 'class_Urbanization' });
     if (insertIndex > -1) {
@@ -198,7 +200,7 @@ export const parseConfig = createSelector(
         formatNumber({ num: value, specialSpecifier: '.2s', spaceUnit: true }),
       unit: 'tCO2e',
       tooltip,
-      chartLegend,
+      // chartLegend,
     };
   }
 );

--- a/components/widgets/climate/emissions-deforestation-drivers/selectors.js
+++ b/components/widgets/climate/emissions-deforestation-drivers/selectors.js
@@ -161,6 +161,23 @@ export const parseConfig = createSelector(
         })
         .reverse()
     );
+
+    const chartLegend = {
+      columns: [
+        {
+          items: ['Wildfire', 'Forestry', 'Shifting agriculture']?.map(
+            (name) => ({ label: name, color: categoryColors[name] })
+          ),
+        },
+        {
+          title: 'Drivers of permanent deforestation',
+          items: ['Commodity driven deforestation', 'Urbanization']?.map(
+            (name) => ({ label: name, color: categoryColors[name] })
+          ),
+        },
+      ],
+    };
+
     const insertIndex = findIndex(tooltip, { key: 'class_Urbanization' });
     if (insertIndex > -1) {
       tooltip.splice(insertIndex, 0, {
@@ -181,6 +198,7 @@ export const parseConfig = createSelector(
         formatNumber({ num: value, specialSpecifier: '.2s', spaceUnit: true }),
       unit: 'tCO2e',
       tooltip,
+      chartLegend,
     };
   }
 );

--- a/components/widgets/component.jsx
+++ b/components/widgets/component.jsx
@@ -31,6 +31,7 @@ class Widgets extends PureComponent {
     setMapSettings: PropTypes.func.isRequired,
     handleClickWidget: PropTypes.func.isRequired,
     embed: PropTypes.bool,
+    analysis: PropTypes.bool,
     dashboard: PropTypes.bool,
     groupBySubcategory: PropTypes.bool,
     modalClosing: PropTypes.bool,
@@ -60,6 +61,7 @@ class Widgets extends PureComponent {
       groupBySubcategory = false,
       embed,
       dashboard,
+      analysis,
       simple,
       modalClosing,
       noDataMessage,
@@ -112,6 +114,7 @@ class Widgets extends PureComponent {
                     authenticated={authenticated}
                     active={activeWidget && activeWidget.widget === w.widget}
                     embed={embed}
+                    analysis={analysis}
                     dashboard={dashboard}
                     simple={simple}
                     location={location}

--- a/components/widgets/forest-change/tree-loss-primary/selectors.js
+++ b/components/widgets/forest-change/tree-loss-primary/selectors.js
@@ -151,6 +151,23 @@ const parseConfig = createSelector([getColors], (colors) => ({
       color: colors.primaryForestLoss,
     },
   ],
+  chartLegend: {
+    columns: [
+      {
+        items: [
+          {
+            label: 'Area of tree cover loss within 2001 primary forest extent',
+            color: colors.primaryForestLoss,
+          },
+          {
+            label: 'Total remaining area of primary forest',
+            color: colors.primaryForestExtent,
+            dashline: true,
+          },
+        ],
+      },
+    ],
+  },
 }));
 
 export const parseTitle = createSelector(

--- a/components/widgets/forest-change/tree-loss-primary/selectors.js
+++ b/components/widgets/forest-change/tree-loss-primary/selectors.js
@@ -160,7 +160,7 @@ const parseConfig = createSelector([getColors], (colors) => ({
             color: colors.primaryForestLoss,
           },
           {
-            label: 'Total remaining area of primary forest',
+            label: 'Percent of primary forest area in 2001 remaining',
             color: colors.primaryForestExtent,
             dashline: true,
           },

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -276,6 +276,7 @@ import '../components/widget/styles.scss';
 import '../components/widgets/styles.scss';
 import '../components/widget/components/widget-alert/styles.scss';
 import '../components/widget/components/widget-body/styles.scss';
+import '../components/widget/components/widget-chart-legend/styles.scss';
 import '../components/widget/components/widget-chart-and-list/styles.scss';
 import '../components/widget/components/widget-chart-list/styles.scss';
 import '../components/widget/components/widget-footer/styles.scss';


### PR DESCRIPTION
## Overview

This PR adds a new `WidgetChartLegend` component to display legends below _a_ chart.  
Although it's currently being imported in `WidgetComposedChart`, it is made to be very generic and to work in a widget's body. It could potentially be displayed below other chart types.

Although it is built focused on column support (with optional titles), it does have a `vertical` prop to display columns vertically. This support is due to the inability to display columns in the map/analysis, but could be used if added to other widgets that are half size. 

**Notes:** 
- This PR is primarily to add support for this type of legend as requested; I've added a legend quickly to the emissions widget just for demonstration of the multi-column & title support. There is no active task to add the legend to the widget, so I just quickly matched it to the designs. 
  - I'll be ensuring that support is to be removed before this PR gets merged  
- This PR does include implementation for display in the forest loss widget, FLAG-1110. 

## Screenshots  
![legend_pfl_dashboard](https://github.com/user-attachments/assets/16024d68-5eb9-4730-8ed9-267539cb807b)
![legend_drivers_dashboard](https://github.com/user-attachments/assets/4f866e61-bd31-4d4c-ae14-1ce7ef6abd37)
![legend_pfl_analysis](https://github.com/user-attachments/assets/b279a855-eba7-4e6d-91bd-01573734910c)
![legend_drivers_analysis](https://github.com/user-attachments/assets/190ac10e-38e2-4288-93a9-014e1028b6c7)

## Testing

Where to find two widgets with examples in order to verify the new legend support and options:  
- Gas emissions by dominant driver:  
  - Dashboard:  
    - Select "Brazil"  
    - Click on the "Climate" tab  
  - Map  
    - Run analysis on "Brazil"  
    - Select on "Climate"  
    - Select the "Forest greenhouse gas emissions" layer  
- Primary forest loss   
  - Dashboard  
    - Visit the "Summary" tab  
  - Map  
    - Run analysis on "Brazil"  
    - Select "Forest change"  
    - Activate the "Tree cover loss" layer  

## Tracking  

- [FLAG-1145](https://gfw.atlassian.net/browse/FLAG-1145) | Support legend in bar chart widgets
- [FLAG-1110](https://gfw.atlassian.net/browse/FLAG-1110) | Add annotation for dotted line on primary forest loss widget



[FLAG-1145]: https://gfw.atlassian.net/browse/FLAG-1145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FLAG-1110]: https://gfw.atlassian.net/browse/FLAG-1110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ