### PR TITLE
[FLAG-1098] Priority 2: Rename the “tree cover by type” widget and add “Plantations” intersection

### DIFF
--- a/components/widgets/land-cover/tree-cover/index.js
+++ b/components/widgets/land-cover/tree-cover/index.js
@@ -24,9 +24,8 @@ import getWidgetProps from './selectors';
 export default {
   widget: 'treeCover',
   title: {
-    default: 'Tree Cover by type in {location}',
-    global: 'Global tree cover by type',
-    withPlantations: 'Forest cover by type in {location}',
+    default: 'Tree Cover in {location}',
+    global: 'Global tree cover',
   },
   alerts: [
     {

--- a/components/widgets/land-cover/tree-cover/index.js
+++ b/components/widgets/land-cover/tree-cover/index.js
@@ -108,7 +108,13 @@ export default {
     summary: 4,
     landCover: 1,
   },
-  refetchKeys: ['threshold', 'decile', 'extentYear', 'landCategory'],
+  refetchKeys: [
+    'threshold',
+    'decile',
+    'extentYear',
+    'landCategory',
+    'forestType',
+  ],
   pendingKeys: ['threshold', 'decile', 'extentYear'],
   settings: {
     threshold: 30,
@@ -138,6 +144,14 @@ export default {
         placeholder: 'All categories',
         clearable: true,
         border: true,
+      },
+      {
+        key: 'forestType',
+        whitelist: ['plantations'],
+        label: 'Forest Type',
+        type: 'select',
+        placeholder: 'All tree cover',
+        clearable: true,
       },
       {
         key: isTropicalTreeCover ? 'decile' : 'threshold',

--- a/components/widgets/land-cover/tree-cover/selectors.js
+++ b/components/widgets/land-cover/tree-cover/selectors.js
@@ -82,17 +82,8 @@ export const parseSentence = createSelector(
     getIndicator,
     getSentence,
     getAdminLevel,
-    isoHasPlantations,
   ],
-  (
-    data,
-    settings,
-    locationName,
-    indicator,
-    sentences,
-    admLevel,
-    isoPlantations
-  ) => {
+  (data, settings, locationName, indicator, sentences, admLevel) => {
     if (!data || !sentences) return null;
 
     const { extentYear, threshold, decile } = settings;
@@ -108,9 +99,11 @@ export const parseSentence = createSelector(
       : 'treeCover';
     const sentence =
       sentences[sentenceKey][sentenceSubkey][sentenceTreeCoverType];
+    const indicators = indicator?.value?.split('__') || [];
+    const hasPlantations = indicators.includes('plantations');
 
     const { cover, plantations, totalCover, totalArea } = data;
-    const top = isoPlantations ? cover - plantations : cover;
+    const top = !hasPlantations ? cover - plantations : plantations;
     const bottom = indicator ? totalCover : totalArea;
     const percentCover = (100 * top) / bottom;
 

--- a/components/widgets/land-cover/tree-cover/selectors.js
+++ b/components/widgets/land-cover/tree-cover/selectors.js
@@ -6,26 +6,12 @@ import { formatNumber } from 'utils/format';
 const getData = (state) => state.data;
 const getSettings = (state) => state.settings;
 const getIndicator = (state) => state.indicator;
-const getWhitelist = (state) => state.polynamesWhitelist;
 const getColors = (state) => state.colors;
 const getSentence = (state) => state.sentence;
 const getTitle = (state) => state.title;
 const getLocationName = (state) => state.locationLabel;
 const getMetaKey = (state) => state.metaKey;
 const getAdminLevel = (state) => state.adminLevel;
-
-export const isoHasPlantations = createSelector(
-  [getWhitelist, getLocationName],
-  (whitelist, name) => {
-    const hasPlantations =
-      name === 'global'
-        ? true
-        : whitelist &&
-          whitelist.annual &&
-          whitelist.annual.includes('plantations');
-    return hasPlantations;
-  }
-);
 
 export const parseData = createSelector(
   [getData, getColors, getIndicator],

--- a/data/colors.json
+++ b/data/colors.json
@@ -17,7 +17,7 @@
     "intactForest": "#6b8729",
     "primaryForest": "#84a637",
     "plantedForest": "#a0c746",
-    "otherCover": "#c7e67c",
+    "otherCover": "#a0c746",
     "nonForest": "#e7e5a4"
   },
   "loss": {

--- a/data/land-categories.js
+++ b/data/land-categories.js
@@ -93,6 +93,7 @@ export default [
   },
   {
     label: 'Indigenous and Community Lands',
+    preserveString: true,
     value: 'landmark',
     dataType: 'keyword',
     metaKey: 'landmark_icls_2020',


### PR DESCRIPTION
## Overview

### Story | Acceptance criteria

As a user, I can view how much tree cover and other land cover exists in my area of interest for 3 tree cover datasets (UMD tree cover 2000 and 2010, tropical tree cover 2020). I can also see the area of tree plantations in my area of interest.

Given that:
- The user is viewing the [“tree cover by type” widget](https://gfw.global/47W8RKt) on the summary or land cover tabs.
- The user has selected any of the options in the “Tree cover dataset” selector in the settings of this widget (“Tree cover 2000”, “Tree cover 2010”, or “Tropical tree cover 2020”)

#### Widget title

- We will change the name of the widget to: Global: “Global tree cover”Country/subnational: “Tree cover in [area]
- Change categories shown on the widget
- The default categories will now be:
  - tree cover (hex: #506917)
  - other land cover (hex: #E7E5A4)

- When the user hovers over the donut chart, it will still show that category name and percent value, just as it does in the current setup. Here is an example from the current widget - natural forests won’t actually show up in the finished product:

#### Add “forest type” dropdown

In the “settings” option, there will be a new “forest type” dropdown

- When the “info”  button is clicked, the SDPT (“Tree plantations”) metadata will appear. 
- The only option in the “forest type” category will be “Plantations”, which will pull from the updated SDPT data.
- When "plantations" is selected as the forest type option, categories are:
  - tree cover in plantations (hex: #506917)
  - other tree cover (hex: #A0C746)
  - other land cover (hex: #E7E5A4)

**This matches the same setup you'll see in the https://gfw.global/3U181Wy . The query should match up too - whatever we find from https://gfw.atlassian.net/browse/FLAG-1135  will inform how we structure this query. We will update the query to match what we use in the [location of tree cover widget:](https://gfw.global/46ZpWRP)**


