### PR TITLE
[FLAG-1197] Fix the TCL compared to other areas widget

### DIFF
--- a/components/widgets/forest-change/tree-loss-ranked/index.js
+++ b/components/widgets/forest-change/tree-loss-ranked/index.js
@@ -95,9 +95,9 @@ export default {
     globalWithIndicator:
       'From {startYear} to {endYear}, {topLocationLabel} within {indicator} had the highest relative tree cover loss in the world, eqivalent to a loss of {topLocationLoss}, which represents {topLocationPerc} of the tree cover in the year {extentYear}.',
     initial:
-      'From {startYear} to {endYear}, {location} lost {loss} of relative tree cover, equivalent to a {localPercent} decrease since {extentYear} and {globalPercent} of all tree cover loss in {parent}',
+      'From {startYear} to {endYear}, {location} lost {loss} of relative tree cover, equivalent to a {localPercent} decrease since {extentYear} and {globalPercent} of all tree cover loss in {parent}.',
     withIndicator:
-      'From {startYear} to {endYear}, {location} lost {loss} of tree relative cover in {indicator}, equivalent to a {localPercent} decrease since {extentYear} and {globalPercent} of all tree cover loss in {parent}',
+      'From {startYear} to {endYear}, {location} lost {loss} of tree relative cover in {indicator}, equivalent to a {localPercent} decrease since {extentYear} and {globalPercent} of all tree cover loss in {parent}.',
     noLoss: 'There was no relative tree cover loss identified in {location}.',
   },
   settings: {

--- a/components/widgets/forest-change/tree-loss-ranked/index.js
+++ b/components/widgets/forest-change/tree-loss-ranked/index.js
@@ -95,9 +95,9 @@ export default {
     globalWithIndicator:
       'From {startYear} to {endYear}, {topLocationLabel} within {indicator} had the highest relative tree cover loss in the world, eqivalent to a loss of {topLocationLoss}, which represents {topLocationPerc} of the tree cover in the year {extentYear}.',
     initial:
-      'From {startYear} to {endYear}, {location} lost {loss} of relative tree cover, equivalent to a {localPercent} decrease since {extentYear} and {globalPercent} of the global total.',
+      'From {startYear} to {endYear}, {location} lost {loss} of relative tree cover, equivalent to a {localPercent} decrease since {extentYear} and {globalPercent} of all tree cover loss in {location}',
     withIndicator:
-      'From {startYear} to {endYear}, {location} lost {loss} of tree relative cover in {indicator}, equivalent to a {localPercent} decrease since {extentYear} and {globalPercent} of the global total.',
+      'From {startYear} to {endYear}, {location} lost {loss} of tree relative cover in {indicator}, equivalent to a {localPercent} decrease since {extentYear} and {globalPercent} of all tree cover loss in {location}',
     noLoss: 'There was no relative tree cover loss identified in {location}.',
   },
   settings: {

--- a/components/widgets/forest-change/tree-loss-ranked/index.js
+++ b/components/widgets/forest-change/tree-loss-ranked/index.js
@@ -95,9 +95,9 @@ export default {
     globalWithIndicator:
       'From {startYear} to {endYear}, {topLocationLabel} within {indicator} had the highest relative tree cover loss in the world, eqivalent to a loss of {topLocationLoss}, which represents {topLocationPerc} of the tree cover in the year {extentYear}.',
     initial:
-      'From {startYear} to {endYear}, {location} lost {loss} of relative tree cover, equivalent to a {localPercent} decrease since {extentYear} and {globalPercent} of all tree cover loss in {location}',
+      'From {startYear} to {endYear}, {location} lost {loss} of relative tree cover, equivalent to a {localPercent} decrease since {extentYear} and {globalPercent} of all tree cover loss in {parent}',
     withIndicator:
-      'From {startYear} to {endYear}, {location} lost {loss} of tree relative cover in {indicator}, equivalent to a {localPercent} decrease since {extentYear} and {globalPercent} of all tree cover loss in {location}',
+      'From {startYear} to {endYear}, {location} lost {loss} of tree relative cover in {indicator}, equivalent to a {localPercent} decrease since {extentYear} and {globalPercent} of all tree cover loss in {parent}',
     noLoss: 'There was no relative tree cover loss identified in {location}.',
   },
   settings: {

--- a/components/widgets/forest-change/tree-loss-ranked/selectors.js
+++ b/components/widgets/forest-change/tree-loss-ranked/selectors.js
@@ -9,7 +9,6 @@ import { formatNumber } from 'utils/format';
 
 // get list data
 const getData = (state) => state.data;
-const getExtent = (state) => state.data && state.data.extent;
 const getSettings = (state) => state.settings;
 const getLocationData = (state) => state.locationData;
 const getLocation = (state) => state.location;
@@ -21,6 +20,7 @@ const getAdm2 = (state) => state.adm2;
 const getSentences = (state) => state && state.sentence;
 const getTitle = (state) => state.title;
 const getLocationName = (state) => state.locationLabel;
+const getParent = (state) => state.parent;
 
 export const getSummedByYearsData = createSelector(
   [getData, getSettings, getAdm1, getAdm2],
@@ -125,14 +125,14 @@ export const parseData = createSelector(
 export const parseSentence = createSelector(
   [
     sortData,
-    getExtent,
     getSettings,
     getIndicator,
     getLocation,
     getSentences,
     getLocationData,
+    getParent,
   ],
-  (data, extent, settings, indicator, location, sentences, meta) => {
+  (data, settings, indicator, location, sentences, meta, parent) => {
     if (!data || !data.length || !location) return null;
     const { startYear, endYear } = settings;
     const {
@@ -174,6 +174,7 @@ export const parseSentence = createSelector(
       localPercent: formatNumber({ num: locationData?.percentage, unit: '%' }),
       globalPercent: formatNumber({ num: lossPercent, unit: '%' }),
       extentYear: settings.extentYear,
+      parent: parent?.label || null,
     };
 
     return {


### PR DESCRIPTION
## Overview

There are a couple of issues with the TCL compared to other areas widget https://gfw.global/4dDrVi3:

The percentage in the sentence equivalent to a 100% decrease since 2000 is incorrect and instead should be equivalent to a 6.3% decrease in tree cover since 2000. Please reference this widget for the correct query: https://gfw.global/3A1zhyg.

Replace part of the sentence and 0.20% of the global total with and X% of all tree cover loss in [name of region]. Please reference the tree cover compared to other areas widget: https://gfw.global/486J02Q .
