### PR TITLE
FLAG-1155: natural forest widget

### DIFF
--- a/components/analysis/components/show-analysis/component.jsx
+++ b/components/analysis/components/show-analysis/component.jsx
@@ -112,6 +112,10 @@ class ShowAnalysis extends PureComponent {
     } = this.props;
     const hasWidgets = widgetLayers && !!widgetLayers.length;
 
+    // NOTE: this is a horrible code smell but it was the only workaround
+    // I was able to find to avoid showing the Natural Forest data without widget in the map.
+    const filteredData = data?.filter((d) => d.label !== 'Natural forests');
+
     return (
       <div className="c-show-analysis">
         <div className="show-analysis-body">
@@ -208,7 +212,8 @@ class ShowAnalysis extends PureComponent {
             {(hasLayers || hasWidgets) && !loading && !error && (
               <Fragment>
                 <ul className="draw-stats">
-                  {data && data.map((d) => this.renderStatItem(d))}
+                  {filteredData &&
+                    filteredData.map((d) => this.renderStatItem(d))}
                 </ul>
                 <Widgets simple analysis />
                 <div className="disclaimers">

--- a/components/analysis/selectors.js
+++ b/components/analysis/selectors.js
@@ -93,6 +93,15 @@ export const getLayerEndpoints = createSelector(
   (layers, location, widgetLayers) => {
     if (!layers || !layers.length) return null;
 
+    // NOTE: this is a horrible code smell but it was the only workaround
+    // I was able to find to avoid showing the Natural Forest data without widget in the map.
+    const naturalForest = layers.find(
+      (layer) => layer.dataset === 'natural-forests'
+    );
+    if (naturalForest) {
+      return null;
+    }
+
     const { type, adm2 } = location;
     const routeType = type === 'country' ? 'admin' : type;
     const lossLayer = layers.find((l) => l.metadata === 'tree_cover_loss');

--- a/components/analysis/selectors.js
+++ b/components/analysis/selectors.js
@@ -93,15 +93,6 @@ export const getLayerEndpoints = createSelector(
   (layers, location, widgetLayers) => {
     if (!layers || !layers.length) return null;
 
-    // NOTE: this is a horrible code smell but it was the only workaround
-    // I was able to find to avoid showing the Natural Forest data without widget in the map.
-    const naturalForest = layers.find(
-      (layer) => layer.dataset === 'natural-forests'
-    );
-    if (naturalForest) {
-      return null;
-    }
-
     const { type, adm2 } = location;
     const routeType = type === 'country' ? 'admin' : type;
     const lossLayer = layers.find((l) => l.metadata === 'tree_cover_loss');

--- a/components/widgets/forest-change/tree-loss-plantations/index.js
+++ b/components/widgets/forest-change/tree-loss-plantations/index.js
@@ -70,7 +70,7 @@ export default {
     forestChange: 2,
   },
   sentence:
-    'From {startYear} to {endYear}, {percentage} of tree cover loss in {location} occurred within {lossPhrase}. The total loss within natural forest was {totalLoss} equivalent to {value} of CO\u2082e emissions.',
+    'From {startYear} to {endYear}, {percentage} of tree cover loss in {location} occurred within {lossPhrase}. The total loss within natural forest was {totalLoss}, equivalent to {value} of CO\u2082e emissions.',
   settings: {
     threshold: 30,
     startYear: MIN_YEAR,

--- a/components/widgets/forest-change/tree-loss-plantations/index.js
+++ b/components/widgets/forest-change/tree-loss-plantations/index.js
@@ -21,12 +21,15 @@ const MAX_YEAR = 2023;
 
 export default {
   widget: 'treeLossPlantations',
-  title: 'Forest loss in natural forest in {location}',
+  title: {
+    default: 'Forest loss in natural forest in {location}',
+    global: 'Forest loss in natural forest',
+  },
   large: true,
   categories: ['forest-change'],
   subcategories: ['forest-loss'],
-  types: ['country', 'aoi', 'wdpa'],
-  admins: ['adm0', 'adm1', 'adm2'],
+  types: ['global', 'country', 'aoi', 'wdpa'],
+  admins: ['global', 'adm0', 'adm1', 'adm2'],
   alerts: [
     {
       text: 'Not all natural forest area can be monitored with existing data on tree cover loss. See the metadata for more information.',
@@ -69,8 +72,12 @@ export default {
   sortOrder: {
     forestChange: 2,
   },
-  sentence:
-    'From {startYear} to {endYear}, {percentage} of tree cover loss in {location} occurred within {lossPhrase}. The total loss within natural forest was {totalLoss}, equivalent to {value} of CO\u2082e emissions.',
+  sentence: {
+    global:
+      'From {startYear} to {endYear}, {percentage} of tree cover loss <b>globally</b> occurred within {lossPhrase}. The total loss within natural forest was {totalLoss}, equivalent to {value} of CO\u2082e emissions.',
+    region:
+      'From {startYear} to {endYear}, {percentage} of tree cover loss in {location} occurred within {lossPhrase}. The total loss within natural forest was {totalLoss}, equivalent to {value} of CO\u2082e emissions.',
+  },
   settings: {
     threshold: 30,
     startYear: MIN_YEAR,

--- a/components/widgets/forest-change/tree-loss-plantations/index.js
+++ b/components/widgets/forest-change/tree-loss-plantations/index.js
@@ -1,22 +1,22 @@
 import { all, spread } from 'axios';
-import { getLoss } from 'services/analysis-cached';
+import { getLossNaturalForest } from 'services/analysis-cached';
 import { getYearsRangeFromMinMax } from 'components/widgets/utils/data';
 
 import {
   POLITICAL_BOUNDARIES_DATASET,
   FOREST_LOSS_DATASET,
-  TREE_PLANTATIONS_DATASET,
+  NATURAL_FOREST,
 } from 'data/datasets';
 import {
   DISPUTED_POLITICAL_BOUNDARIES,
   POLITICAL_BOUNDARIES,
   FOREST_LOSS,
-  TREE_PLANTATIONS,
+  NATURAL_FOREST_2020,
 } from 'data/layers';
 
 import getWidgetProps from './selectors';
 
-const MIN_YEAR = 2013;
+const MIN_YEAR = 2021;
 const MAX_YEAR = 2023;
 
 export default {
@@ -27,6 +27,12 @@ export default {
   subcategories: ['forest-loss'],
   types: ['country', 'aoi', 'wdpa'],
   admins: ['adm0', 'adm1', 'adm2'],
+  alerts: [
+    {
+      text: 'Not all natural forest area can be monitored with existing data on tree cover loss. See the metadata for more information.',
+      visible: ['global', 'country', 'geostore', 'aoi', 'wdpa', 'use'],
+    },
+  ],
   settingsConfig: [
     {
       key: 'years',
@@ -35,12 +41,6 @@ export default {
       startKey: 'startYear',
       type: 'range-select',
       border: true,
-    },
-    {
-      key: 'threshold',
-      label: 'canopy density',
-      type: 'mini-select',
-      metaKey: 'widget_canopy_density',
     },
   ],
   refetchKeys: ['threshold'],
@@ -53,10 +53,11 @@ export default {
       layers: [DISPUTED_POLITICAL_BOUNDARIES, POLITICAL_BOUNDARIES],
       boundary: true,
     },
+    // natural forest
     {
-      // global plantations
-      dataset: TREE_PLANTATIONS_DATASET,
-      layers: [TREE_PLANTATIONS],
+      dataset: NATURAL_FOREST,
+      layers: [NATURAL_FOREST_2020],
+      boundary: true,
     },
     // loss
     {
@@ -64,11 +65,12 @@ export default {
       layers: [FOREST_LOSS],
     },
   ],
+  dataType: 'naturalForest',
   sortOrder: {
     forestChange: 2,
   },
   sentence:
-    'From {startYear} to {endYear}, {percentage} of tree cover loss in {location} occurred within {lossPhrase}. The total loss within natural forest was equivalent to {value} of CO\u2082e emissions.',
+    'From {startYear} to {endYear}, {percentage} of tree cover loss in {location} occurred within {lossPhrase}. The total loss within natural forest was {totalLoss} equivalent to {value} of CO\u2082e emissions.',
   whitelists: {
     indicators: ['plantations'],
     checkStatus: true,
@@ -80,23 +82,12 @@ export default {
     extentYear: 2010,
   },
   getData: (params) =>
-    all([
-      getLoss({ ...params, forestType: 'plantations' }),
-      getLoss({ ...params, forestType: '' }),
-    ]).then(
-      spread((plantationsloss, gadmLoss) => {
+    all([getLossNaturalForest(params)]).then(
+      spread((gadmLoss) => {
         let data = {};
-        const lossPlantations =
-          plantationsloss.data && plantationsloss.data.data;
         const totalLoss = gadmLoss.data && gadmLoss.data.data;
-        if (
-          lossPlantations &&
-          totalLoss &&
-          lossPlantations.length &&
-          totalLoss.length
-        ) {
+        if (totalLoss && totalLoss.length) {
           data = {
-            lossPlantations,
             totalLoss,
           };
         }
@@ -118,8 +109,10 @@ export default {
       })
     ),
   getDataURL: (params) => [
-    getLoss({ ...params, forestType: 'plantations', download: true }),
-    getLoss({ ...params, forestType: '', download: true }),
+    getLossNaturalForest({
+      ...params,
+      download: true,
+    }),
   ],
   getWidgetProps,
 };

--- a/components/widgets/forest-change/tree-loss-plantations/index.js
+++ b/components/widgets/forest-change/tree-loss-plantations/index.js
@@ -71,10 +71,6 @@ export default {
   },
   sentence:
     'From {startYear} to {endYear}, {percentage} of tree cover loss in {location} occurred within {lossPhrase}. The total loss within natural forest was {totalLoss} equivalent to {value} of CO\u2082e emissions.',
-  whitelists: {
-    indicators: ['plantations'],
-    checkStatus: true,
-  },
   settings: {
     threshold: 30,
     startYear: MIN_YEAR,

--- a/components/widgets/forest-change/tree-loss-ranked/selectors.js
+++ b/components/widgets/forest-change/tree-loss-ranked/selectors.js
@@ -41,7 +41,7 @@ export const getSummedByYearsData = createSelector(
     const mappedData = regions.map((region) => {
       const isoLoss = Math.round(sumBy(groupedByRegion[region], 'loss')) || 0;
       const regionExtent = extent.find((e) => {
-        return e[regionKey].toString() === region.toString(); // iso is string while adm1 and 2 are numbers
+        return e[regionKey]?.toString() === region.toString(); // iso is string while adm1 and 2 are numbers
       });
       const isoExtent = (regionExtent && regionExtent.extent) || 0;
       const percentageLoss =

--- a/components/widgets/land-cover/natural-forest/index.js
+++ b/components/widgets/land-cover/natural-forest/index.js
@@ -34,7 +34,9 @@ export default {
   colors: 'extent',
   source: 'gadm',
   categories: ['land-cover', 'summary'],
-  types: ['global', 'country'], // this array dictates where do we want to show the widget in the map (i.e.: "only for countries but not for custom areas")
+  // NOTE: this `types` array dictates where do we want to show the widget in the map (i.e.: "only for countries but not for custom areas")
+  // see components/analysis/selectors.js getLayerEndpoints function since I had to do a workaround because it was showing an empty container
+  types: ['global', 'country'],
   admins: ['global', 'adm0', 'adm1', 'adm2'],
   visible: ['dashboard', 'analysis'],
   datasets: [

--- a/components/widgets/land-cover/natural-forest/index.js
+++ b/components/widgets/land-cover/natural-forest/index.js
@@ -1,0 +1,117 @@
+import { getNaturalForest } from 'services/analysis-cached';
+import { NATURAL_FOREST, POLITICAL_BOUNDARIES_DATASET } from 'data/datasets';
+import {
+  NATURAL_FOREST_2020,
+  DISPUTED_POLITICAL_BOUNDARIES,
+  POLITICAL_BOUNDARIES,
+} from 'data/layers';
+
+import getWidgetProps from './selectors';
+
+export default {
+  widget: 'naturalForest',
+  title: {
+    default: 'Natural forest in {location}',
+    global: 'Global natural forest',
+  },
+  sentence: {
+    default: {
+      global: `As of 2020, {naturalForestPercentage} of <b>global</b> land cover was natural forests and {nonNaturalForestPercentage} was non-natural tree cover.`,
+      region: `As of 2020, {naturalForestPercentage} of land cover in {location} was natural forests and {nonNaturalForestPercentage} was non-natural tree cover.`,
+    },
+    withIndicator: {
+      global: `As of 2020, {naturalForestPercentage} of <b>global</b> land cover in {indicator} was natural forests and {nonNaturalForestPercentage} was non-natural tree cover.`,
+      region: `As of 2020, {naturalForestPercentage} of land cover in {indicator} in {location} was natural forests and {nonNaturalForestPercentage} was non-natural tree cover.`,
+    },
+  },
+  metaKey: {
+    2000: 'sbtn_natural_forests_map',
+    2010: 'sbtn_natural_forests_map',
+    2020: 'sbtn_natural_forests_map',
+  },
+  chartType: 'pieChart',
+  large: false,
+  colors: 'extent',
+  source: 'gadm',
+  categories: ['land-cover', 'summary'],
+  types: ['global', 'country'], // this array dictates where do we want to show the widget in the map (i.e.: "only for countries but not for custom areas")
+  admins: ['global', 'adm0', 'adm1', 'adm2'],
+  visible: ['dashboard', 'analysis'],
+  datasets: [
+    {
+      dataset: POLITICAL_BOUNDARIES_DATASET,
+      layers: [DISPUTED_POLITICAL_BOUNDARIES, POLITICAL_BOUNDARIES],
+      boundary: true,
+    },
+    {
+      dataset: NATURAL_FOREST,
+      layers: [NATURAL_FOREST_2020],
+    },
+  ],
+  dataType: 'naturalForest',
+  sortOrder: {
+    summary: 6,
+    landCover: 1,
+  },
+  refetchKeys: ['threshold', 'decile', 'extentYear', 'landCategory'],
+  pendingKeys: ['threshold', 'decile', 'extentYear'],
+  settings: {
+    extentYear: 2000,
+  },
+  getSettingsConfig: () => {
+    return [
+      {
+        key: 'landCategory',
+        label: 'Land Category',
+        type: 'select',
+        placeholder: 'All categories',
+        clearable: true,
+        border: true,
+      },
+    ];
+  },
+  getData: (params) => {
+    const { threshold, decile, ...filteredParams } = params;
+
+    return getNaturalForest({ ...filteredParams }).then((response) => {
+      const extent = response.data;
+
+      let totalNaturalForest = 0;
+      let totalNonNaturalTreeCover = 0;
+      let unknown = 0;
+
+      let data = {};
+      if (extent && extent.length) {
+        // Sum values
+        extent.forEach((item) => {
+          switch (item.sbtn_natural_forests__class) {
+            case 'Natural Forest':
+              totalNaturalForest += item.area__ha;
+              break;
+            case 'Non-Natural Forest':
+              totalNonNaturalTreeCover += item.area__ha;
+              break;
+            default:
+              // 'Unknown'
+              unknown += item.area__ha;
+          }
+        });
+
+        data = {
+          totalNaturalForest,
+          unknown,
+          totalNonNaturalTreeCover,
+          totalArea: totalNaturalForest + unknown + totalNonNaturalTreeCover,
+        };
+      }
+
+      return data;
+    });
+  },
+  getDataURL: async (params) => {
+    const response = await getNaturalForest({ ...params, download: true });
+
+    return [response];
+  },
+  getWidgetProps,
+};

--- a/components/widgets/land-cover/natural-forest/index.js
+++ b/components/widgets/land-cover/natural-forest/index.js
@@ -35,7 +35,7 @@ export default {
   source: 'gadm',
   categories: ['land-cover', 'summary'],
   // NOTE: this `types` array dictates where do we want to show the widget in the map (i.e.: "only for countries but not for custom areas")
-  // see components/analysis/selectors.js getLayerEndpoints function since I had to do a workaround because it was showing an empty container
+  // see components/analysis/components/show-analysis/component.jsx filteredData since I had to do a workaround because it was showing a label we don't want to
   types: ['global', 'country'],
   admins: ['global', 'adm0', 'adm1', 'adm2'],
   visible: ['dashboard', 'analysis'],

--- a/components/widgets/land-cover/natural-forest/selectors.js
+++ b/components/widgets/land-cover/natural-forest/selectors.js
@@ -1,0 +1,126 @@
+import { createSelector, createStructuredSelector } from 'reselect';
+import isEmpty from 'lodash/isEmpty';
+import { formatNumber } from 'utils/format';
+
+const getData = (state) => state.data;
+const getSettings = (state) => state.settings;
+const getIndicator = (state) => state.indicator;
+const getWhitelist = (state) => state.polynamesWhitelist;
+const getSentence = (state) => state.sentence;
+const getTitle = (state) => state.title;
+const getLocationName = (state) => state.locationLabel;
+const getMetaKey = (state) => state.metaKey;
+const getAdminLevel = (state) => state.adminLevel;
+
+export const isoHasPlantations = createSelector(
+  [getWhitelist, getLocationName],
+  (whitelist, name) => {
+    const hasPlantations =
+      name === 'global'
+        ? true
+        : whitelist &&
+          whitelist.annual &&
+          whitelist.annual.includes('plantations');
+    return hasPlantations;
+  }
+);
+
+export const parseData = createSelector([getData], (data) => {
+  if (isEmpty(data)) {
+    return null;
+  }
+
+  const { totalNaturalForest, unknown, totalNonNaturalTreeCover, totalArea } =
+    data;
+  const parsedData = [
+    {
+      label: 'Natural forests',
+      value: totalNaturalForest,
+      color: '#2C6639',
+      percentage: (totalNaturalForest / totalArea) * 100,
+    },
+    {
+      label: 'Non-natural tree cover',
+      value: totalNonNaturalTreeCover,
+      color: '#A8DDB5',
+      percentage: (totalNonNaturalTreeCover / totalArea) * 100,
+    },
+    {
+      label: 'Other land cover',
+      value: unknown,
+      color: '#D3D3D3',
+      percentage: (unknown / totalArea) * 100,
+    },
+  ];
+
+  return parsedData;
+});
+
+export const parseTitle = createSelector(
+  [getTitle, getLocationName],
+  (title, name) => {
+    return name === 'global' ? title.global : title.default;
+  }
+);
+
+export const parseSentence = createSelector(
+  [
+    getData,
+    getSettings,
+    getLocationName,
+    getIndicator,
+    getSentence,
+    getAdminLevel,
+  ],
+  (data, settings, locationName, indicator, sentences, admLevel) => {
+    if (!data || !sentences) return null;
+
+    const { extentYear, threshold, decile } = settings;
+
+    const isTropicalTreeCover = extentYear === 2020;
+    const decileThreshold = isTropicalTreeCover ? decile : threshold;
+    const withIndicator = !!indicator;
+    const sentenceKey = withIndicator ? 'withIndicator' : 'default';
+    const sentenceSubkey = admLevel === 'global' ? 'global' : 'region';
+    const sentence = sentences[sentenceKey][sentenceSubkey];
+
+    const { totalNaturalForest, totalNonNaturalTreeCover, totalArea } = data;
+    const percentNaturalForest = (100 * totalNaturalForest) / totalArea;
+    const percentNonNaturalForest =
+      (100 * totalNonNaturalTreeCover) / totalArea;
+
+    const formattedNaturalForestPercentage = formatNumber({
+      num: percentNaturalForest,
+      unit: '%',
+    });
+    const formattedNonNaturalForestPercentage = formatNumber({
+      num: percentNonNaturalForest,
+      unit: '%',
+    });
+
+    const thresholdLabel = `>${decileThreshold}%`;
+
+    const params = {
+      year: extentYear,
+      location: locationName,
+      naturalForestPercentage: formattedNaturalForestPercentage,
+      nonNaturalForestPercentage: formattedNonNaturalForestPercentage,
+      indicator: indicator?.label,
+      threshold: thresholdLabel,
+    };
+
+    return { sentence, params };
+  }
+);
+
+export const parseMetaKey = createSelector(
+  [getMetaKey, getSettings],
+  (metaKey, settings) => metaKey[settings.extentYear]
+);
+
+export default createStructuredSelector({
+  data: parseData,
+  sentence: parseSentence,
+  title: parseTitle,
+  metaKey: parseMetaKey,
+});

--- a/components/widgets/land-cover/tree-cover-ranked/index.js
+++ b/components/widgets/land-cover/tree-cover-ranked/index.js
@@ -76,7 +76,7 @@ export default {
   ],
   sortOrder: {
     summary: 1,
-    landCover: 1,
+    landCover: 1.1,
   },
   refetchKeys: ['threshold', 'extentYear', 'forestType', 'landCategory'],
   settings: {

--- a/components/widgets/manifest.js
+++ b/components/widgets/manifest.js
@@ -42,6 +42,7 @@ import treeCoverLocated from 'components/widgets/land-cover/tree-cover-located';
 import USLandCover from 'components/widgets/land-cover/us-land-cover';
 import rankedForestTypes from 'components/widgets/land-cover/ranked-forest-types';
 import treeCoverDensity from 'components/widgets/land-cover/tree-cover-density';
+import naturalForest from 'components/widgets/land-cover/natural-forest';
 
 // Climate
 import woodyBiomass from 'components/widgets/climate/whrc-biomass/';
@@ -103,6 +104,7 @@ export default {
   treeCoverLocated,
   rankedForestTypes,
   treeCoverDensity,
+  naturalForest,
 
   // climate
   // emissions,

--- a/components/widgets/utils/config.js
+++ b/components/widgets/utils/config.js
@@ -440,6 +440,10 @@ export const getStatements = ({
     ...(indicatorStatements || []),
   ]);
 
+  if (dataType === 'naturalForest') {
+    return [];
+  }
+
   return statements;
 };
 

--- a/components/widgets/utils/data.js
+++ b/components/widgets/utils/data.js
@@ -477,6 +477,28 @@ export const zeroFillYears = (data, startYear, endYear, years, fillObj) => {
   return zeroFilledData;
 };
 
+export const zeroFillYearsFilter = (
+  data,
+  startYear,
+  endYear,
+  years,
+  fillObj
+) => {
+  const zeroFilledData = [];
+  if (years) {
+    years
+      .filter((year) => year >= startYear && year <= endYear)
+      .forEach((year) => {
+        const yearData = data.filter((o) => o.year === year) || {
+          ...fillObj,
+          year,
+        };
+        zeroFilledData.push(yearData);
+      });
+  }
+  return zeroFilledData;
+};
+
 export const getWeeksRange = (weeks) => {
   const endDate = moment().format('YYYY-MM-DD');
   const startDate = moment(endDate)

--- a/components/widgets/utils/data.js
+++ b/components/widgets/utils/data.js
@@ -493,6 +493,52 @@ export const zeroFillYearsFilter = (
           ...fillObj,
           year,
         };
+        const naturalForestItem = yearData.find(
+          (item) => item.sbtn_natural_forests__class === 'Natural Forest'
+        );
+        const nonNaturalForestItem = yearData.find(
+          (item) => item.sbtn_natural_forests__class === 'Non-Natural Forest'
+        );
+        const unknownItem = yearData.find(
+          (item) => item.sbtn_natural_forests__class === 'Unknown'
+        );
+
+        // if the response for `year` does not have sbtn_natural_forests__class: 'Natural Forest' then need to create one with 0 values so the widget displays the columns correctly
+        if (!naturalForestItem) {
+          yearData.push({
+            ...yearData[0],
+            area: 0,
+            emissions: 0,
+            gfw_gross_emissions_co2e_all_gases__mg: 0,
+            sbtn_natural_forests__class: 'Natural Forest',
+            umd_tree_cover_loss__ha: 0,
+          });
+        }
+
+        // same for Non-Natural Forest
+        if (!nonNaturalForestItem) {
+          yearData.push({
+            ...yearData[0],
+            area: 0,
+            emissions: 0,
+            gfw_gross_emissions_co2e_all_gases__mg: 0,
+            sbtn_natural_forests__class: 'Non-Natural Forest',
+            umd_tree_cover_loss__ha: 0,
+          });
+        }
+
+        // same for Unknown
+        if (!unknownItem) {
+          yearData.push({
+            ...yearData[0],
+            area: 0,
+            emissions: 0,
+            gfw_gross_emissions_co2e_all_gases__mg: 0,
+            sbtn_natural_forests__class: 'Unknown',
+            umd_tree_cover_loss__ha: 0,
+          });
+        }
+
         zeroFilledData.push(yearData);
       });
   }

--- a/data/datasets.js
+++ b/data/datasets.js
@@ -55,3 +55,4 @@ export const PRIMARY_FOREST_DATASET = 'primary-forests';
 export const MANGROVE_FORESTS_DATASET = 'mangrove-forests';
 export const GFW_STORIES_DATASET = 'mongabay-stories';
 export const TROPICAL_TREE_COVER_DATASET = 'tropical-tree-cover';
+export const NATURAL_FOREST = 'natural-forests';

--- a/data/layers.js
+++ b/data/layers.js
@@ -60,3 +60,4 @@ export const PRIMARY_FOREST = 'primary-forests-2001';
 export const MANGROVE_FORESTS = 'mangrove-forests-1996';
 export const TROPICAL_TREE_COVER_HECTARE = 'tropical-tree-cover-hectare';
 export const TROPICAL_TREE_COVER_METERS = 'tropical-tree-cover-meters';
+export const NATURAL_FOREST_2020 = 'natural-forests-2020';

--- a/services/get-where-query.js
+++ b/services/get-where-query.js
@@ -8,7 +8,9 @@ const isNumber = (value) => !!(typeof value === 'number' || !isNaN(value));
 
 // build {where} statement for query
 export const getWHEREQuery = (params = {}) => {
-  const { type, dataset } = params || {};
+  // umd_tree_cover_loss__year is being added for the dashboard sentences for natural forest
+  const { type, dataset, umd_tree_cover_loss__year, isNaturalForest } =
+    params || {};
 
   const allFilterOptions = forestTypes.concat(landCategories);
   const allowedParams = ALLOWED_PARAMS[params.dataset || 'annual'];
@@ -98,7 +100,11 @@ export const getWHEREQuery = (params = {}) => {
     }
 
     if (isLastParameter) {
-      WHERE = `${WHERE} `;
+      if (isNaturalForest) {
+        WHERE = `${WHERE} AND umd_tree_cover_loss__year=${umd_tree_cover_loss__year}`;
+      } else {
+        WHERE = `${WHERE} `;
+      }
     } else {
       WHERE = `${WHERE} AND `;
     }


### PR DESCRIPTION
## Overview

Given that: 

- the user is on the “land cover“ tab of the dashboards

- the user is viewing the “natural forest” widget

- the user is viewing the world or an admin area (no custom area analysis)

- this widget will appear before the current “tree cover by type” widget; it should be the first to appear in the “land cover” section of the dashboards

- this widget will appear before the “tree cover by type” widget

-  to the right of/after the “location of tree cover” widget

## Demo

If applicable: screenshots, gifs, etc.

## Notes

If applicable: ancilary topics, caveats, alternative strategies that didn't work out, etc.

## Testing

- Include any steps to verify the features this PR introduces.
- If this fixes a bug, include bug reproduction steps.

