### PR TITLE
[FLAG-1121] soilOrganic widget to pull data from the precalculated tables instead of the carto ones

### DIFF
--- a/components/widgets/climate/soil-organic/index.js
+++ b/components/widgets/climate/soil-organic/index.js
@@ -1,4 +1,4 @@
-import { getSoilOrganicCarbon } from 'services/climate';
+import { getOrganicSoilCarbonGrouped } from 'services/analysis-cached';
 
 import {
   POLITICAL_BOUNDARIES_DATASET,
@@ -23,10 +23,10 @@ export default {
   admins: ['global', 'adm0', 'adm1', 'adm2'],
   settingsConfig: [
     {
-      key: 'variable',
-      label: 'variable',
+      key: 'unit',
+      label: 'unit',
       type: 'switch',
-      whitelist: ['totalbiomass', 'biomassdensity'],
+      whitelist: ['totalBiomass', 'biomassDensity'],
     },
   ],
   datasets: [
@@ -35,13 +35,12 @@ export default {
       layers: [DISPUTED_POLITICAL_BOUNDARIES, POLITICAL_BOUNDARIES],
       boundary: true,
     },
-    // soil organis carbon
     {
       dataset: SOIL_CARBON_DENSITY_DATASET,
       layers: [SOIL_CARBON_DENSITY],
     },
   ],
-  refetchKeys: ['variable'],
+  refetchKeys: ['unit'],
   chartType: 'rankedList',
   visible: ['dashboard', 'analysis'],
   colors: 'climate',
@@ -55,18 +54,50 @@ export default {
     endYear: 2018,
     pageSize: 5,
     page: 0,
-    variable: 'totalbiomass',
+    unit: 'totalBiomass',
   },
   sentences: {
-    initial:
+    region:
       'In 2000, {location} had a soil organic carbon density of {biomassDensity}, and a total carbon storage of {totalBiomass}.',
-    totalbiomass:
+    globalBiomass:
       'Around {value} of the world’s {label} is contained in the top 5 countries.',
-    biomassdensity:
+    globalDensity:
       'The average {label} of the world’s top 5 countries is {value}.',
   },
-  getData: (params) =>
-    getSoilOrganicCarbon(params).then((res) => res.data && res.data.rows),
-  getDataURL: (params) => [getSoilOrganicCarbon({ ...params, download: true })],
+  getData: ({ type, adm0, adm1, adm2, ...rest } = {}) => {
+    const location =
+      type === 'country'
+        ? {
+          type,
+          adm0: adm0 && !adm1 ? null : adm0,
+          adm1: adm1 && !adm2 ? null : adm1,
+          adm2: null,
+        }
+        : {
+          type,
+          adm0,
+          adm1,
+          adm2,
+        };
+
+    return getOrganicSoilCarbonGrouped({ ...rest, ...location });
+  },
+  getDataURL: ({ type, adm0, adm1, adm2, ...rest } = {}) => {
+    const location =
+      type === 'country'
+        ? {
+          type,
+          adm0: adm0 && !adm1 ? null : adm0,
+          adm1: adm1 && !adm2 ? null : adm1,
+          adm2: null,
+        }
+        : {
+          type,
+          adm0,
+          adm1,
+          adm2,
+        };
+    return [getOrganicSoilCarbonGrouped({ ...rest, ...location, download: true })];
+  },
   getWidgetProps,
 };

--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -2564,7 +2564,7 @@ export const getOrganicSoilCarbonGrouped = (params) => {
   });
 
   if (!requestUrl) {
-    return new Promise(() => { });
+    return new Promise(() => {});
   }
 
   const url = encodeURI(
@@ -2580,8 +2580,9 @@ export const getOrganicSoilCarbonGrouped = (params) => {
   if (download) {
     const indicator = getIndicator(forestType, landCategory, ifl);
     return {
-      name: `whrc_biomass_by_region${indicator ? `_in_${snakeCase(indicator.label)}` : ''
-        }__ha`,
+      name: `soil_organic_carbon_by_region${
+        indicator ? `_in_${snakeCase(indicator.label)}` : ''
+      }__ha`,
       url: getDownloadUrl(url),
     };
   }
@@ -2591,7 +2592,7 @@ export const getOrganicSoilCarbonGrouped = (params) => {
       ...d,
       biomass: d.gfw_soil_carbon_stocks_2000__Mg_C,
       biomassDensity: d.soil_carbon_density__t_ha,
-    }))
+    }));
   });
 };
 

--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -75,6 +75,8 @@ const SQL_QUERIES = {
     'SELECT SUM("whrc_aboveground_biomass_stock_2000__Mg") AS "whrc_aboveground_biomass_stock_2000__Mg", SUM("whrc_aboveground_co2_stock_2000__Mg") AS "whrc_aboveground_co2_stock_2000__Mg", SUM(umd_tree_cover_extent_2000__ha) AS umd_tree_cover_extent_2000__ha, SUM("gfw_aboveground_carbon_stocks_2000__Mg_C") as gfw_aboveground_carbon_stocks_2000__Mg_C, SUM("gfw_belowground_carbon_stocks_2000__Mg_C") as gfw_belowground_carbon_stocks_2000__Mg_C, SUM("gfw_soil_carbon_stocks_2000__Mg_C") as gfw_soil_carbon_stocks_2000__Mg_C FROM data {WHERE}',
   biomassStockGrouped:
     'SELECT {select_location}, SUM("whrc_aboveground_biomass_stock_2000__Mg") AS "whrc_aboveground_biomass_stock_2000__Mg", SUM("whrc_aboveground_co2_stock_2000__Mg") AS "whrc_aboveground_co2_stock_2000__Mg", SUM(umd_tree_cover_extent_2000__ha) AS umd_tree_cover_extent_2000__ha FROM data {WHERE} GROUP BY {location} ORDER BY {location}',
+  organicSoilCarbonGrouped:
+    'SELECT {select_location}, CASE WHEN SUM("umd_tree_cover_extent_2000__ha") = 0 THEN NULL ELSE SUM("gfw_soil_carbon_stocks_2000__Mg_C") END AS "gfw_soil_carbon_stocks_2000__Mg_C", CASE WHEN SUM("umd_tree_cover_extent_2000__ha") = 0 THEN NULL ELSE SUM("gfw_soil_carbon_stocks_2000__Mg_C") / SUM("umd_tree_cover_extent_2000__ha") END AS soil_carbon_density__t_ha FROM data {WHERE} GROUP BY {location} ORDER BY {location}',
   treeCoverGainByPlantationType: `SELECT CASE WHEN gfw_planted_forests__type IS NULL THEN 'Outside of Plantations' ELSE gfw_planted_forests__type END AS plantation_type, SUM(umd_tree_cover_gain__ha) as gain_area_ha FROM data {WHERE} GROUP BY gfw_planted_forests__type`,
   treeCoverOTF:
     'SELECT SUM(area__ha) FROM data WHERE umd_tree_cover_density_2000__threshold >= {threshold}&geostore_id={geostoreId}',
@@ -2548,6 +2550,49 @@ export const getBiomassStock = (params) => {
       })),
     },
   }));
+};
+
+// organic soil carbon grouped by location
+export const getOrganicSoilCarbonGrouped = (params) => {
+  const { forestType, landCategory, ifl, download } = params || {};
+
+  const requestUrl = getRequestUrl({
+    ...params,
+    dataset: 'annual',
+    datasetType: 'summary',
+    grouped: true,
+  });
+
+  if (!requestUrl) {
+    return new Promise(() => { });
+  }
+
+  const url = encodeURI(
+    `${requestUrl}${SQL_QUERIES.organicSoilCarbonGrouped}`
+      .replace(/{location}/g, getLocationSelect({ ...params, grouped: true }))
+      .replace(
+        /{select_location}/g,
+        getLocationSelect({ ...params, grouped: true, cast: false })
+      )
+      .replace('{WHERE}', getWHEREQuery({ ...params, dataset: 'annual' }))
+  );
+
+  if (download) {
+    const indicator = getIndicator(forestType, landCategory, ifl);
+    return {
+      name: `whrc_biomass_by_region${indicator ? `_in_${snakeCase(indicator.label)}` : ''
+        }__ha`,
+      url: getDownloadUrl(url),
+    };
+  }
+
+  return dataRequest.get(url).then((response) => {
+    return response?.data?.map((d) => ({
+      ...d,
+      biomass: d.gfw_soil_carbon_stocks_2000__Mg_C,
+      biomassDensity: d.soil_carbon_density__t_ha,
+    }))
+  });
 };
 
 // Additional conditional fetches for providing context for queries.


### PR DESCRIPTION
## Overview

This PR adds a new request to `analysis-cached` to get request the widget's data from the pre-calculated tables and adapts the widget to work with the new data. The original call `getSoilOrganicCarbon` found in `services/climate.js` was not removed as it is still used by the carbon stock widget. 

In order to keep the implementation/calculations (`selectors.js`), the implementation implements the same logic found in the `whrc-biomass` widget (albeit adapted), as it is a known good one with a similar display. 

## Testing  

Verify that the widget is pulling data from the precalculated tables, and not the carto query. 

## Screenshot

![soil_organic](https://github.com/user-attachments/assets/560b4d12-88f6-4149-9f3c-488762bf51d9)


## Tracking
[FLAG-1121](https://gfw.atlassian.net/browse/FLAG-1121)



[FLAG-1121]: https://gfw.atlassian.net/browse/FLAG-1121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ