### PR TITLE
[FLAG-1095] Split RW and GFW API's keys to make it more flexible

### DIFF
--- a/pages/api/metadata/[...params].js
+++ b/pages/api/metadata/[...params].js
@@ -1,7 +1,7 @@
 import { GFW_METADATA_API, GFW_STAGING_METADATA_API } from 'utils/apis';
 import axios from 'axios';
 
-const ENVIRONMENT = process.env.NEXT_PUBLIC_FEATURE_ENV;
+const ENVIRONMENT = process.env.NEXT_PUBLIC_RW_FEATURE_ENV;
 const GFW_METADATA_API_URL =
   ENVIRONMENT === 'staging' ? GFW_STAGING_METADATA_API : GFW_METADATA_API;
 

--- a/providers/datasets-provider/actions.js
+++ b/providers/datasets-provider/actions.js
@@ -14,7 +14,7 @@ export const setDatasets = createAction('setDatasets');
 export const setDatasetsWithMetadata = createAction('setDatasetsWithMetadata');
 
 const handleFeatureEnvLock = (env) => {
-  const currEnv = process.env.NEXT_PUBLIC_FEATURE_ENV;
+  const currEnv = process.env.NEXT_PUBLIC_RW_FEATURE_ENV;
   const MIXED_ENV = 'preproduction-staging';
   if (env === MIXED_ENV && currEnv !== 'production') {
     return true;

--- a/services/datasets.js
+++ b/services/datasets.js
@@ -1,7 +1,7 @@
 import { rwRequest, dataRequest } from 'utils/request';
 
 const environmentString = () => {
-  const env = process.env.NEXT_PUBLIC_FEATURE_ENV;
+  const env = process.env.NEXT_PUBLIC_RW_FEATURE_ENV;
   let envString = 'production';
   if (env === 'preproduction') {
     envString += ',preproduction';

--- a/services/shape.js
+++ b/services/shape.js
@@ -3,7 +3,9 @@ import request from 'utils/request';
 import { GFW_API, GFW_STAGING_API } from 'utils/apis';
 
 const GFW_API_URL =
-  process.env.NEXT_PUBLIC_FEATURE_ENV === 'staging' ? GFW_STAGING_API : GFW_API;
+  process.env.NEXT_PUBLIC_RW_FEATURE_ENV === 'staging'
+    ? GFW_STAGING_API
+    : GFW_API;
 
 const QUERIES = {
   ogrConvert: '/v2/ogr/convert',


### PR DESCRIPTION
## Overview

Now we can set each API separatedly, making it easier to test different environments at once

## Demo

If applicable: screenshots, gifs, etc.

## Notes

If applicable: ancilary topics, caveats, alternative strategies that didn't work out, etc.

## Testing

- Include any steps to verify the features this PR introduces.
- If this fixes a bug, include bug reproduction steps.

