### PR TITLE
[FLAG-1208]: Dashboard error in the forest change tab for Gujarat region in India

### DIFF
--- a/components/widgets/forest-change/tree-loss-plantations/selectors.js
+++ b/components/widgets/forest-change/tree-loss-plantations/selectors.js
@@ -54,7 +54,8 @@ export const parseData = createSelector(
             areaLoss: summedPlatationsLoss || 0,
             totalLoss: totalLossForYear.area || 0,
             outsideCo2Loss:
-              totalLossByYear[d.year][0].emissions - summedPlatationsEmissions,
+              totalLossByYear[d.year]?.[0]?.emissions -
+              summedPlatationsEmissions,
             co2Loss: summedPlatationsEmissions || 0,
           };
           return returnData;


### PR DESCRIPTION
## Overview

A user reported an issue with the Forest Change tab for the [Gujarat region](https://www.globalforestwatch.org/dashboards/country/IND/11/?category=forest-change&map=eyJjYW5Cb3VuZCI6dHJ1ZX0%3D) in India. When selecting this region and switching to the Forest Change tab, an error occurs.

It appears to be a front-end issue, as the system is reading an undefined value, which causes the error.

