### PR TITLE
Data/dist decoding

### DIFF
--- a/components/map-menu/sections.js
+++ b/components/map-menu/sections.js
@@ -107,7 +107,7 @@ export const datasetsSections = compact([
     subCategories: [
       {
         slug: 'deforestationAlerts',
-        title: 'Deforestation Alerts',
+        title: 'Disturbance Alerts',
       },
       {
         slug: 'fireAlerts',

--- a/providers/datasets-provider/config.js
+++ b/providers/datasets-provider/config.js
@@ -568,7 +568,8 @@ const decodes = {
       day > 0. &&
       day >= startDayIndex &&
       day <= endDayIndex  &&
-      confidence >= confidenceValue
+      confidence >= confidenceValue &&
+      alpha > 0.
     ) {
       // get intensity
       float intensity = mod(b, 100.) * 50.;

--- a/providers/datasets-provider/config.js
+++ b/providers/datasets-provider/config.js
@@ -547,6 +547,50 @@ const decodes = {
       alpha = 0.;
     }
   `,
+  distAlerts: `
+  // values for creating power scale, domain (input), and range (output)
+    float confidenceValue = 0.;
+    if (confirmedOnly > 0.) {
+      confidenceValue = 1.;
+    }
+
+    float r = color.r * 255.;
+    float g = color.g * 255.;
+    float b = color.b * 255.;
+
+    // **** CHECK THIS
+    // 1461 = days from 2019/01/01 to 2014/12/31
+    // 1870 = days from 2020/02/14 to 2014/12/31
+    float day = (r * 255.) + g;
+
+    float confidence = floor(b / 100.);
+    if (
+      day > 0. &&
+      day >= startDayIndex &&
+      day <= endDayIndex  &&
+      confidence >= confidenceValue
+    ) {
+      // get intensity
+      float intensity = mod(b, 100.) * 50.;
+      // float intensity = 255.;
+      if (intensity > 255.) {
+        intensity = 255.;
+      }
+      if (confidence < 2.) {
+        color.r = 238. / 255.;
+        color.g = 177. / 255.;
+        color.b = 177. / 255.;
+        alpha = intensity / 255.;
+      } else {
+        color.r = 137. / 255.;
+        color.g = 82. / 255.;
+        color.b = 119. / 255.;
+        alpha = intensity / 255.;
+      }
+    } else {
+      alpha = 0.;
+    }
+  `,
   RADDsCoverage: `
     float red = color.r;
     float green = color.g;
@@ -1058,6 +1102,7 @@ export default {
   GLADs: decodes.GLADs,
   RADDs: decodes.RADDs,
   RADDs2yearsTimeline: decodes.RADDs2yearsTimeline,
+  distAlerts: decodes.distAlerts,
   RADDsCoverage: decodes.RADDsCoverage,
   staticRemap: decodes.staticRemap,
   staticRemapAlpha: decodes.staticRemapAlpha,


### PR DESCRIPTION
## Overview

Create a new decoding function `distAlerts` to decode the new _DIST-ALERT_ layer.

## Demo

The decoding function is used to properly the encoded tile cache, enabling the filtering by date, and correctly displaying confidence and intensity.  
<img width="872" alt="Screenshot 2024-12-03 at 18 41 22" src="https://github.com/user-attachments/assets/082c50bb-3c56-4cfc-928c-be5cff13a9aa">

## Notes
The decoding function is based on the one used by RADD alerts layer (`RADDs2yearsTimeline`), modified to fit the details in the [tile cache documentation](https://staging-tiles.globalforestwatch.org/#tag/Raster-Tiles/operation/glad_dist_alerts_raster_tile_umd_glad_dist_alerts__version__dynamic__z___x___y__png_get)


