### PR TITLE
FLAG-1199: move tooltips to correct place

### DIFF
--- a/components/widgets/climate/emissions-deforestation-drivers/selectors.js
+++ b/components/widgets/climate/emissions-deforestation-drivers/selectors.js
@@ -162,6 +162,21 @@ export const parseConfig = createSelector(
         .reverse()
     );
 
+    const forestryIndex = tooltip.findIndex(
+      (element) => element.key === 'class_Forestry'
+    );
+    const agricultureIndex = tooltip.findIndex(
+      (element) => element.key === 'class_Shifting agriculture'
+    );
+
+    const rearrengedTooltips = [...tooltip];
+
+    delete rearrengedTooltips[forestryIndex];
+    delete rearrengedTooltips[agricultureIndex];
+
+    rearrengedTooltips.splice(2, 0, tooltip[forestryIndex]);
+    rearrengedTooltips.splice(3, 0, tooltip[agricultureIndex]);
+
     // Example on how to add columns & titles to the Chart Legend
     // See: https://gfw.atlassian.net/browse/FLAG-1145
     // const chartLegend = {
@@ -180,9 +195,11 @@ export const parseConfig = createSelector(
     //   ],
     // };
 
-    const insertIndex = findIndex(tooltip, { key: 'class_Urbanization' });
+    const insertIndex = findIndex(rearrengedTooltips, {
+      key: 'class_Urbanization',
+    });
     if (insertIndex > -1) {
-      tooltip.splice(insertIndex, 0, {
+      rearrengedTooltips.splice(insertIndex, 0, {
         key: 'break',
         label: 'Drivers of permanent deforestation:',
       });
@@ -199,7 +216,7 @@ export const parseConfig = createSelector(
       unitFormat: (value) =>
         formatNumber({ num: value, specialSpecifier: '.2s', spaceUnit: true }),
       unit: 'tCO2e',
-      tooltip,
+      tooltip: rearrengedTooltips,
       // chartLegend,
     };
   }


### PR DESCRIPTION
## Overview

before:

<img width="886" alt="Screenshot 2024-12-10 at 8 53 56 a m" src="https://github.com/user-attachments/assets/791bf6ec-c0d4-448e-86eb-30bb7e272f69">

---
after:

<img width="899" alt="Screenshot 2024-12-10 at 8 54 02 a m" src="https://github.com/user-attachments/assets/9dd83dd1-0e9c-433e-a068-d2a64ec42db6">


## Demo

If applicable: screenshots, gifs, etc.

## Notes

If applicable: ancilary topics, caveats, alternative strategies that didn't work out, etc.

## Testing

- Include any steps to verify the features this PR introduces.
- If this fixes a bug, include bug reproduction steps.

