### PR TITLE
fix(tree-gain): widgets are not displaying data

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@
 /cypress/support
 /cypress/plugins
 /newrelic
+/services/country-links.json

--- a/components/widgets/forest-change/tree-cover-gain/index.js
+++ b/components/widgets/forest-change/tree-cover-gain/index.js
@@ -1,6 +1,6 @@
 import { all, spread } from 'axios';
 
-import { getGain } from 'services/analysis-cached';
+import { getGainGrouped } from 'services/analysis-cached';
 
 import {
   POLITICAL_BOUNDARIES_DATASET,
@@ -104,12 +104,12 @@ export default {
       adm2: null,
     };
 
-    return all([getGain({ ...rest, ...parentLocation })]).then(
+    return all([getGainGrouped({ ...rest, ...parentLocation })]).then(
       spread((gainResponse) => {
         let groupKey = 'iso';
 
-        if (adm1) groupKey = adm1;
-        if (adm2) groupKey = adm2;
+        if (adm1) groupKey = 'adm1';
+        if (adm2) groupKey = 'adm2';
 
         const gainData = gainResponse.data.data;
         let mappedData = [];
@@ -120,7 +120,10 @@ export default {
             const extent = item.extent || 0;
 
             return {
-              id: groupKey !== 'iso' ? parseInt(groupKey, 10) : item[groupKey],
+              id:
+                groupKey !== 'iso'
+                  ? parseInt(item[groupKey], 10)
+                  : item[groupKey],
               gain,
               extent,
               percentage: extent ? (100 * gain) / extent : 0,
@@ -132,6 +135,6 @@ export default {
       })
     );
   },
-  getDataURL: (params) => [getGain({ ...params, download: true })],
+  getDataURL: (params) => [getGainGrouped({ ...params, download: true })],
   getWidgetProps,
 };

--- a/components/widgets/forest-change/tree-cover-gain/index.js
+++ b/components/widgets/forest-change/tree-cover-gain/index.js
@@ -107,25 +107,27 @@ export default {
     return all([getGain({ ...rest, ...parentLocation })]).then(
       spread((gainResponse) => {
         let groupKey = 'iso';
-        if (adm1) groupKey = 'adm1';
-        if (adm2) groupKey = 'adm2';
+
+        if (adm1) groupKey = adm1;
+        if (adm2) groupKey = adm2;
+
         const gainData = gainResponse.data.data;
         let mappedData = [];
+
         if (gainData && gainData.length) {
           mappedData = gainData.map((item) => {
             const gain = item.gain || 0;
             const extent = item.extent || 0;
+
             return {
-              id:
-                groupKey !== 'iso'
-                  ? parseInt(item[groupKey], 10)
-                  : item[groupKey],
+              id: groupKey !== 'iso' ? parseInt(groupKey, 10) : item[groupKey],
               gain,
               extent,
               percentage: extent ? (100 * gain) / extent : 0,
             };
           });
         }
+
         return mappedData;
       })
     );

--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -110,7 +110,7 @@ const typeByGrouped = {
   },
   adm1: {
     default: 'adm1',
-    grouped: 'adm1',
+    grouped: 'adm2',
   },
   adm2: {
     default: 'adm2',


### PR DESCRIPTION
## Overview

We have an object called `typeByGrouped` used to set the correct adm level depending if we need a "grouped" data (comparing regions and subregions for example). I changed the value for adm1 to keep using adm1 even for grouped data, however it didn't work as expected for some widgets. I rolled it back to use adm2. 

```
const typeByGrouped = {
  global: {
    default: 'adm0',
    grouped: 'adm0',
  },
  adm0: {
    default: 'adm0',
    grouped: 'adm1',
  },
  adm1: {
    default: 'adm1',
    grouped: 'adm2', // here
  },
  adm2: {
    default: 'adm2',
    grouped: 'adm2',
  },
};
```

