### PR TITLE
[FLAG-1226] Support grouped legend in doughnut charts

### DIFF
--- a/components/charts/components/pie-chart-legend/component.jsx
+++ b/components/charts/components/pie-chart-legend/component.jsx
@@ -36,9 +36,13 @@ class PieChartLegend extends PureComponent {
         >
           {Object.entries(groupedItems).map(([category, categoryItems]) => (
             <div style={{ display: 'flex', flexDirection: 'column' }}>
-              <h2>{category}</h2>
+              <h2 className="legend-group-title">{category}</h2>
               <ul
-                style={{ display: 'flex', justifyContent: 'space-between' }}
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  flexWrap: 'wrap',
+                }}
                 className={cx({ simple, sizeClass })}
               >
                 {categoryItems.map((item, index) => {

--- a/components/charts/components/pie-chart-legend/component.jsx
+++ b/components/charts/components/pie-chart-legend/component.jsx
@@ -3,10 +3,12 @@ import PropTypes from 'prop-types';
 import { formatNumber } from 'utils/format';
 import cx from 'classnames';
 
+import groupBy from 'lodash/groupBy';
+
 class PieChartLegend extends PureComponent {
   render() {
     const { data, chartSettings = {}, config, className, simple } = this.props;
-    const { size, legend } = chartSettings;
+    const { size, legend, groupedLegends } = chartSettings;
 
     const sizeClass = (() => {
       if (size) return size;
@@ -23,6 +25,58 @@ class PieChartLegend extends PureComponent {
           spaceUnit: item.unit !== '%' && config.unit !== 'countsK',
         })}`?.length > 9
     );
+
+    if (groupedLegends) {
+      const groupedItems = groupBy(data, 'category');
+
+      return (
+        <div
+          className={cx('c-pie-chart-legend', className)}
+          style={{ flexDirection: 'column' }}
+        >
+          {Object.entries(groupedItems).map(([category, categoryItems]) => (
+            <div style={{ display: 'flex', flexDirection: 'column' }}>
+              <h2>{category}</h2>
+              <ul
+                style={{ display: 'flex', justifyContent: 'space-between' }}
+                className={cx({ simple, sizeClass })}
+              >
+                {categoryItems.map((item, index) => {
+                  const value = `${formatNumber({
+                    num: item[config.key],
+                    unit: item.unit ? item.unit : config.unit,
+                    spaceUnit: item.unit !== '%' && config.unit !== 'countsK',
+                  })}`;
+
+                  return (
+                    <li className="legend-item" key={index.toString()}>
+                      <div className="legend-title">
+                        <span style={{ backgroundColor: item.color }}>{}</span>
+                        <p>
+                          {item.label}
+                          {sizeClass === 'x-small' && `- ${value}`}
+                        </p>
+                      </div>
+                      {sizeClass !== 'x-small' && (
+                        <div
+                          className={cx({
+                            'legend-value': true,
+                            'legend-value--small': shouldDisplaySmallerValues,
+                          })}
+                          style={{ color: item.color }}
+                        >
+                          {value}
+                        </div>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          ))}
+        </div>
+      );
+    }
 
     return (
       <div

--- a/components/charts/components/pie-chart-legend/component.jsx
+++ b/components/charts/components/pie-chart-legend/component.jsx
@@ -7,7 +7,14 @@ import groupBy from 'lodash/groupBy';
 
 class PieChartLegend extends PureComponent {
   render() {
-    const { data, chartSettings = {}, config, className, simple } = this.props;
+    const {
+      data,
+      chartSettings = {},
+      config,
+      className,
+      simple,
+      onMap,
+    } = this.props;
     const { size, legend, groupedLegends } = chartSettings;
 
     const sizeClass = (() => {
@@ -31,20 +38,19 @@ class PieChartLegend extends PureComponent {
 
       return (
         <div
-          className={cx('c-pie-chart-legend', className)}
-          style={{ flexDirection: 'column' }}
+          className={cx(
+            {
+              'c-pie-chart-legend': true,
+              'c-pie-chart-legend-grouped': groupedLegends,
+              'top-margin-20': groupedLegends && onMap,
+            },
+            className
+          )}
         >
           {Object.entries(groupedItems).map(([category, categoryItems]) => (
-            <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <div className="legend-group">
               <h2 className="legend-group-title">{category}</h2>
-              <ul
-                style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  flexWrap: 'wrap',
-                }}
-                className={cx({ simple, sizeClass })}
-              >
+              <ul className={cx('legend-group-list', simple, sizeClass)}>
                 {categoryItems.map((item, index) => {
                   const value = `${formatNumber({
                     num: item[config.key],
@@ -127,12 +133,14 @@ class PieChartLegend extends PureComponent {
 }
 
 PieChartLegend.propTypes = {
+  onMap: PropTypes.bool,
   data: PropTypes.array,
   config: PropTypes.object,
   chartSettings: PropTypes.shape({
     size: PropTypes.oneOf(['small', 'x-small']),
     legend: PropTypes.shape({ style: PropTypes.object }),
     chart: PropTypes.shape({ style: PropTypes.object }),
+    groupedLegends: PropTypes.bool,
   }),
   simple: PropTypes.bool,
   className: PropTypes.string,

--- a/components/charts/components/pie-chart-legend/styles.scss
+++ b/components/charts/components/pie-chart-legend/styles.scss
@@ -4,13 +4,30 @@
   display: inline-block;
   width: 100%;
 
-  .legend-group-title {
-    margin-bottom: 15px;
-    font-weight: 500;
+  &-grouped {
+    flex-direction: column;
+  }
+
+  .legend-group {
+    display: flex;
+    flex-direction: column;
+
+    .legend-group-title {
+      margin-bottom: 0.9375rem;
+      font-weight: 500;
+      font-size: 0.875rem;
+    }
+
+    .legend-group-list {
+      display: flex;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      margin-bottom: 1.25rem;
+    }
   }
 
   .legend-title {
-    font-size: rem(12px);
+    font-size: 0.75rem;
     line-height: 1;
     color: $slate;
     position: relative;
@@ -19,19 +36,19 @@
 
     span {
       display: inline-block;
-      width: rem(12px);
-      min-width: rem(12px);
-      min-height: rem(12px);
-      height: rem(12px);
-      margin-right: rem(7px);
+      width: 0.75rem;
+      min-width: 0.75rem;
+      min-height: 0.75rem;
+      height: 0.75rem;
+      margin-right: 0.4375rem;
       border-radius: 100%;
       align-self: flex-start;
-      margin-top: 1px;
+      margin-top: 0.0625rem;
     }
 
     p {
       color: $slate;
-      font-size: rem(12px);
+      font-size: 0.75rem;
       line-height: 1.4;
     }
   }
@@ -76,4 +93,8 @@
       }
     }
   }
+}
+
+.top-margin-20 {
+  margin-top: 1.25rem;
 }

--- a/components/charts/components/pie-chart-legend/styles.scss
+++ b/components/charts/components/pie-chart-legend/styles.scss
@@ -4,6 +4,11 @@
   display: inline-block;
   width: 100%;
 
+  .legend-group-title {
+    margin-bottom: 15px;
+    font-weight: 500;
+  }
+
   .legend-title {
     font-size: rem(12px);
     line-height: 1;

--- a/components/widget/components/widget-pie-chart-legend/component.jsx
+++ b/components/widget/components/widget-pie-chart-legend/component.jsx
@@ -2,6 +2,8 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { formatNumber } from 'utils/format';
 
+import cx from 'classnames';
+
 import PieChart from 'components/charts/pie-chart';
 import PieChartLegend from 'components/charts/components/pie-chart-legend';
 import Button from 'components/ui/button';
@@ -21,6 +23,9 @@ class WidgetPieChart extends PureComponent {
     } = this.props;
     const { pathname } = location;
     const { chartHeight } = settings;
+    const { groupedLegends } = chartSettings;
+
+    const onMap = pathname.indexOf('map') !== -1;
 
     const showSettingsBtn =
       settingsBtnConfig &&
@@ -47,7 +52,12 @@ class WidgetPieChart extends PureComponent {
             {settingsBtnConfig.text}
           </Button>
         )}
-        <div className="pie-and-legend">
+        <div
+          className={cx({
+            'pie-and-legend': true,
+            'pie-and-legend-grouped': groupedLegends && onMap,
+          })}
+        >
           <PieChartLegend
             className="cover-legend"
             data={legendData || data}
@@ -57,6 +67,7 @@ class WidgetPieChart extends PureComponent {
               key: 'value',
               ...settings,
             }}
+            onMap={onMap}
             simple={simple}
             chartSettings={chartSettings}
           />

--- a/components/widget/components/widget-pie-chart-legend/styles.scss
+++ b/components/widget/components/widget-pie-chart-legend/styles.scss
@@ -6,6 +6,10 @@
     flex-direction: row;
     justify-content: space-between;
     gap: 4%;
+
+    &-grouped {
+      flex-direction: column-reverse;
+    }
   }
 
   .cover-legend {

--- a/components/widgets/forest-change/_tree-loss-drivers/index.js
+++ b/components/widgets/forest-change/_tree-loss-drivers/index.js
@@ -20,25 +20,25 @@ export default {
   },
   types: ['global', 'country'],
   admins: ['global', 'adm0'],
-  alerts: {
-    default: [
-      {
-        id: 'tree-loss-drivers-alert-1',
-        text: `The methods behind this data have changed over time. Be cautious comparing old and new, data especially before/after 2015. [Read more here](https://www.globalforestwatch.org/blog/data-and-research/tree-cover-loss-satellite-data-trend-analysis/).`,
-        icon: 'warning',
-        visible: ['global', 'country', 'geostore', 'aoi', 'wdpa', 'use'],
-      },
-    ],
-    indonesia: [
-      {
-        id: 'tree-loss-drivers-indonesia-alert-1',
-        text: `Indonesia’s rates of deforestation have slowed significantly in recent years (2016-2021), largely due to reductions in commodity-driven expansion. Much of the primary forest loss from commodity-driven deforestation in Indonesia according to the GFW data actually took place in areas legally classified as secondary forests, not primary forests. Please note that ground verification is recommended before any hard conclusions are drawn about the type of forest affected, or cause of loss, in specific patches of loss on the GFW map.`,
-        icon: 'warning',
-        visible: ['global', 'country', 'geostore', 'aoi', 'wdpa', 'use'],
-        areaWhitelist: ['IDN'],
-      },
-    ],
-  },
+  // alerts: {
+  //   default: [
+  //     {
+  //       id: 'tree-loss-drivers-alert-1',
+  //       text: `The methods behind this data have changed over time. Be cautious comparing old and new, data especially before/after 2015. [Read more here](https://www.globalforestwatch.org/blog/data-and-research/tree-cover-loss-satellite-data-trend-analysis/).`,
+  //       icon: 'warning',
+  //       visible: ['global', 'country', 'geostore', 'aoi', 'wdpa', 'use'],
+  //     },
+  //   ],
+  //   indonesia: [
+  //     {
+  //       id: 'tree-loss-drivers-indonesia-alert-1',
+  //       text: `Indonesia’s rates of deforestation have slowed significantly in recent years (2016-2021), largely due to reductions in commodity-driven expansion. Much of the primary forest loss from commodity-driven deforestation in Indonesia according to the GFW data actually took place in areas legally classified as secondary forests, not primary forests. Please note that ground verification is recommended before any hard conclusions are drawn about the type of forest affected, or cause of loss, in specific patches of loss on the GFW map.`,
+  //       icon: 'warning',
+  //       visible: ['global', 'country', 'geostore', 'aoi', 'wdpa', 'use'],
+  //       areaWhitelist: ['IDN'],
+  //     },
+  //   ],
+  // },
   categories: ['summary', 'forest-change'],
   subcategories: ['forest-loss'],
   large: true,
@@ -99,6 +99,7 @@ export default {
 
     return {
       ...((dashboard || embed) && {
+        groupedLegends: true,
         size: 'small',
         legend: {
           style: {

--- a/components/widgets/forest-change/_tree-loss-drivers/index.js
+++ b/components/widgets/forest-change/_tree-loss-drivers/index.js
@@ -113,7 +113,6 @@ export default {
             display: 'flex',
             height: 'auto',
             alignItems: 'center',
-            paddingRight: '14%',
           },
         },
       }),
@@ -122,6 +121,7 @@ export default {
   getData: (params) =>
     getTreeCoverLossByDriverType(params).then((response) => {
       const { data } = (response && response.data) || {};
+
       return data;
     }),
   getDataURL: (params) => [

--- a/components/widgets/forest-change/_tree-loss-drivers/index.js
+++ b/components/widgets/forest-change/_tree-loss-drivers/index.js
@@ -20,25 +20,6 @@ export default {
   },
   types: ['global', 'country'],
   admins: ['global', 'adm0'],
-  // alerts: {
-  //   default: [
-  //     {
-  //       id: 'tree-loss-drivers-alert-1',
-  //       text: `The methods behind this data have changed over time. Be cautious comparing old and new, data especially before/after 2015. [Read more here](https://www.globalforestwatch.org/blog/data-and-research/tree-cover-loss-satellite-data-trend-analysis/).`,
-  //       icon: 'warning',
-  //       visible: ['global', 'country', 'geostore', 'aoi', 'wdpa', 'use'],
-  //     },
-  //   ],
-  //   indonesia: [
-  //     {
-  //       id: 'tree-loss-drivers-indonesia-alert-1',
-  //       text: `Indonesia’s rates of deforestation have slowed significantly in recent years (2016-2021), largely due to reductions in commodity-driven expansion. Much of the primary forest loss from commodity-driven deforestation in Indonesia according to the GFW data actually took place in areas legally classified as secondary forests, not primary forests. Please note that ground verification is recommended before any hard conclusions are drawn about the type of forest affected, or cause of loss, in specific patches of loss on the GFW map.`,
-  //       icon: 'warning',
-  //       visible: ['global', 'country', 'geostore', 'aoi', 'wdpa', 'use'],
-  //       areaWhitelist: ['IDN'],
-  //     },
-  //   ],
-  // },
   categories: ['summary', 'forest-change'],
   subcategories: ['forest-loss'],
   large: true,

--- a/components/widgets/forest-change/_tree-loss-drivers/index.js
+++ b/components/widgets/forest-change/_tree-loss-drivers/index.js
@@ -99,15 +99,7 @@ export default {
 
     return {
       ...((dashboard || embed) && {
-        groupedLegends: true,
         size: 'small',
-        legend: {
-          style: {
-            display: 'flex',
-            justifyContent: 'center',
-            paddingLeft: '8%',
-          },
-        },
         chart: {
           style: {
             display: 'flex',
@@ -116,6 +108,7 @@ export default {
           },
         },
       }),
+      groupedLegends: true,
     };
   },
   getData: (params) =>

--- a/components/widgets/forest-change/_tree-loss-drivers/selectors.js
+++ b/components/widgets/forest-change/_tree-loss-drivers/selectors.js
@@ -127,14 +127,8 @@ export const parseSentence = createSelector(
   }
 );
 
-// export const parseCaution = createSelector(
-//   [getCaution, getAdm0],
-//   (caution, adm0) => (adm0 === 'IDN' ? caution.indonesia : caution.default)
-// );
-
 export default createStructuredSelector({
   data: parseData,
   title: parseTitle,
   sentence: parseSentence,
-  // caution: parseCaution,
 });

--- a/components/widgets/forest-change/_tree-loss-drivers/selectors.js
+++ b/components/widgets/forest-change/_tree-loss-drivers/selectors.js
@@ -9,11 +9,25 @@ const getColors = (state) => state.colors;
 const getSettings = (state) => state.settings;
 const getTitle = (state) => state.title;
 const getSentences = (state) => state.sentences;
-const getCaution = (state) => state.caution;
 const getLocationLabel = (state) => state.locationLabel;
-const getAdm0 = (state) => state.adm0;
 const getSortedCategories = () =>
   tscLossCategories.sort((a, b) => (a.position > b.position ? 1 : -1));
+
+const groupedLegends = {
+  'commodity driven deforestation': 'Drivers of temporary deforestation',
+  forestry: 'Drivers of temporary deforestation',
+  'forest management': 'Drivers of temporary  deforestation',
+  'shifting cultivation': 'Drivers of temporary deforestation',
+  'shifting agriculture': 'Drivers of temporary deforestation',
+  wildfire: 'Drivers of temporary deforestation',
+  'other natural disasters': 'Drivers of temporary  deforestation',
+  'hard commodities': 'Drivers of permanent deforestation',
+  'Drivers of permanent deforestation agriculture':
+    'Drivers of permanent deforestation',
+  'settlements and infrastructure': 'Drivers of permanent deforestation',
+  urbanization: 'Drivers of permanent deforestation',
+  unknown: 'Drivers of permanent deforestation',
+};
 
 export const getPermanentCategories = createSelector(
   [getSortedCategories],
@@ -47,6 +61,7 @@ export const parseData = createSelector(
       return {
         label: driver_type,
         value: loss_area_ha,
+        category: groupedLegends[driver_type.toLowerCase()],
         color: categoryColors[driver_type],
         percentage: (loss_area_ha * 100) / totalLoss,
       };
@@ -112,14 +127,14 @@ export const parseSentence = createSelector(
   }
 );
 
-export const parseCaution = createSelector(
-  [getCaution, getAdm0],
-  (caution, adm0) => (adm0 === 'IDN' ? caution.indonesia : caution.default)
-);
+// export const parseCaution = createSelector(
+//   [getCaution, getAdm0],
+//   (caution, adm0) => (adm0 === 'IDN' ? caution.indonesia : caution.default)
+// );
 
 export default createStructuredSelector({
   data: parseData,
   title: parseTitle,
   sentence: parseSentence,
-  caution: parseCaution,
+  // caution: parseCaution,
 });

--- a/components/widgets/manifest.js
+++ b/components/widgets/manifest.js
@@ -10,7 +10,7 @@ import treeCoverGainOutsidePlantations from 'components/widgets/forest-change/tr
 import treeGainLocated from 'components/widgets/forest-change/tree-gain-located';
 import treeLossLocated from 'components/widgets/forest-change/tree-loss-located';
 import treeLossPlantations from 'components/widgets/forest-change/tree-loss-plantations';
-import treeLossTsc from 'components/widgets/forest-change/tree-loss-drivers';
+import treeLossTsc from 'components/widgets/forest-change/_tree-loss-drivers';
 import treeCoverGainSimple from 'components/widgets/forest-change/tree-cover-gain-simple';
 import glads from 'components/widgets/forest-change/glads';
 // import gladRanked from 'components/widgets/forest-change/glad-ranked';

--- a/components/widgets/manifest.js
+++ b/components/widgets/manifest.js
@@ -10,7 +10,7 @@ import treeCoverGainOutsidePlantations from 'components/widgets/forest-change/tr
 import treeGainLocated from 'components/widgets/forest-change/tree-gain-located';
 import treeLossLocated from 'components/widgets/forest-change/tree-loss-located';
 import treeLossPlantations from 'components/widgets/forest-change/tree-loss-plantations';
-import treeLossTsc from 'components/widgets/forest-change/_tree-loss-drivers';
+import treeLossTsc from 'components/widgets/forest-change/tree-loss-drivers';
 import treeCoverGainSimple from 'components/widgets/forest-change/tree-cover-gain-simple';
 import glads from 'components/widgets/forest-change/glads';
 // import gladRanked from 'components/widgets/forest-change/glad-ranked';


### PR DESCRIPTION
## Overview

Support adding groups of legend items in doughnut charts. A legend item is composed of (1) a color swatch, (2) a label, and (3) a statistic.

### Acceptance criteria

Groups stack vertically (i.e. flex-direction: column)

Items within a group wrap to form multiple rows if their total width exceeds the parent container (i.e. flex-wrap: wrap)

Groups can have an optional header with the following styles (anything not listed here should be the default for GFW’s typical style):

font-size: 14px

font-weight: bold

There should be a 5px gap between the optional header and the items in the group. This can be achieved though padding, margin, or any other styling that is convenient.

When the widget is shown in full width (e.g. on the dashboard), then the legend should appear to the left of the doughnut. (This is the current behavior).

When the widget is shown in smaller width (e.g. on the analysis panel on the map), then the legend should appear below the doughnut



### Sample data for a country

``` [
  {
    "iso": "ALB",
    "drivers_type": "Forest management",
    "umd_tree_cover_loss__ha": 2024,
    "umd_tree_cover_loss__ha": 415.980,
  },
  ...
]
```

Possible values for drivers_type:

- Drivers of non-permanent loss
  - Forest management
  - Shifting cultivation
  - Wildfires
  - Other natural disasters

- Drivers of permanent deforestation
  - Hard commodities
  - Permanent agriculture
  - Settlements and infrastructure

## Demo

<img width="776" alt="Screenshot 2024-12-02 at 6 43 49 PM" src="https://github.com/user-attachments/assets/c2e9c7c3-f7dd-44d0-a260-790589de9618" />



