### PR TITLE
[FLAG-1106] Priority 6: Add Plantations as a filter to the 'Forest Type' dropdown of tree cover loss in [area] widget

### DIFF
--- a/components/widgets/forest-change/tree-loss-global/index.js
+++ b/components/widgets/forest-change/tree-loss-global/index.js
@@ -8,8 +8,7 @@ export default {
   title: 'Global Annual Tree cover loss',
   alerts: [
     {
-      text:
-        'The methods behind this data have changed over time. Be cautious comparing old and new data, especially before/after 2015. [Read more here](https://www.globalforestwatch.org/blog/data-and-research/tree-cover-loss-satellite-data-trend-analysis/).',
+      text: 'The methods behind this data have changed over time. Be cautious comparing old and new data, especially before/after 2015. [Read more here](https://www.globalforestwatch.org/blog/data-and-research/tree-cover-loss-satellite-data-trend-analysis/).',
       visible: ['global', 'country', 'geostore', 'aoi', 'wdpa', 'use'],
     },
   ],
@@ -25,7 +24,7 @@ export default {
     {
       key: 'forestType',
       label: 'Forest Type',
-      whitelist: ['ifl', 'primary_forest'],
+      whitelist: ['ifl', 'primary_forest', 'plantations'],
       type: 'select',
       placeholder: 'All tree cover',
       clearable: true,

--- a/components/widgets/forest-change/tree-loss/index.js
+++ b/components/widgets/forest-change/tree-loss/index.js
@@ -52,7 +52,7 @@ export default {
     {
       key: 'forestType',
       label: 'Forest Type',
-      whitelist: ['ifl', 'mangroves_2016'],
+      whitelist: ['ifl', 'mangroves_2016', 'plantations'],
       type: 'select',
       placeholder: 'All tree cover',
       clearable: true,


### PR DESCRIPTION
## Overview

To be consistent with the SDPT layer being available as a “forest type” filter in the tree cover loss due to fires in [area] widget and forest-related greenhouse gas emissions in [area] widget, we would like to add it to the tree cover loss in [area] widget

### Given that:

The user is viewing the [tree cover loss in [area] widget](https://gfw.global/4asb4NQ) on the summary and forest change tabs, and is available for all admin levels


### Add intersection option


In the “settings” button for this widget, there is a “Forest type” dropdown - we will need to add an option for “Plantations” just as we have for the tree cover loss due to fires in [area] widget and forest-related greenhouse gas emissions in [area] widget.

It can be before “Primary forests” just as it is in other widgets.

### Update sentence when intersection is selected

When the user has selected the “Plantations” option in the dropdown, the sentence will change:

#### Global
- From 2001 to 2023, there was a total of 77.3 Mha of tree cover loss globally within Plantations, equivalent to a 7.5% decrease in tree cover since 2000 and 52.1 Gt of CO₂ emissions.
    
#### Country
- From 2001 to 2023, Brazil lost 7.02 Mha of tree cover in Plantations, equivalent to a 2.9% decrease in tree cover since 2000, and 4.94 Gt of CO₂e emissions.
 
#### Region
- From 2001 to 2023, Amapá lost 55.9 kha of tree cover in Plantations, equivalent to a 0.59% decrease in tree cover since 2000, and 44.9 Mt of CO₂e emissions.

#### Subregion
- From 2001 to 2023, Amapá lost 13.8 kha of tree cover in Plantations, equivalent to a 3.7% decrease in tree cover since 2000, and 11.4 Mt of CO₂e emissions.
--



