### PR TITLE
[FLAG-1107] Add forest type 'plantations' to tree loss drivers widget

### DIFF
--- a/components/widgets/forest-change/tree-loss-drivers/index.js
+++ b/components/widgets/forest-change/tree-loss-drivers/index.js
@@ -49,6 +49,14 @@ export default {
   },
   settingsConfig: [
     {
+      key: 'forestType',
+      label: 'Forest Type',
+      whitelist: ['plantations'],
+      type: 'select',
+      placeholder: 'All tree cover',
+      clearable: true,
+    },
+    {
       key: 'tscDriverGroup',
       label: 'drivers',
       type: 'select',

--- a/components/widgets/forest-change/tree-loss-drivers/index.js
+++ b/components/widgets/forest-change/tree-loss-drivers/index.js
@@ -109,10 +109,14 @@ export default {
   sentences: {
     initial:
       'In {location} from {startYear} to {endYear}, {permPercent} of tree cover loss occurred in areas where the dominant drivers of loss resulted in {deforestation}.',
+    initialWithIndicator:
+      'In {location} from {startYear} to {endYear}, {permPercent} of tree cover loss in {indicator} occurred in areas where the dominant drivers of loss resulted in {deforestation}.',
     noLoss:
       'In {location} from {startYear} to {endYear}, <b>no</b> tree cover loss occurred in areas where the dominant drivers of loss resulted in {deforestation}.',
     globalInitial:
       '{location} from {startYear} to {endYear}, {permPercent} of tree cover loss occurred in areas where the dominant drivers of loss resulted in {deforestation}.',
+    globalWithIndicator:
+      '{location} from {startYear} to {endYear}, {permPercent} of tree cover loss in {indicator} occurred in areas where the dominant drivers of loss resulted in {deforestation}.',
   },
   whitelists: {
     checkStatus: true,

--- a/components/widgets/forest-change/tree-loss-drivers/selectors.js
+++ b/components/widgets/forest-change/tree-loss-drivers/selectors.js
@@ -13,6 +13,7 @@ import tscLossCategories from 'data/tsc-loss-categories.json';
 
 // get list data
 const getLoss = (state) => state.data && state.data.loss;
+const getIndicator = (state) => state.indicator;
 const getSettings = (state) => state.settings;
 const getLocationName = (state) => state.locationLabel;
 const getColors = (state) => state.colors;
@@ -206,15 +207,22 @@ export const parseConfig = createSelector(
 export const parseSentence = createSelector(
   [
     getFilteredData,
+    getIndicator,
     getAllLoss,
     getSettings,
     getLocationName,
     getSentences,
     getPermCats,
   ],
-  (data, allLoss, settings, locationName, sentences, permCats) => {
+  (data, indicator, allLoss, settings, locationName, sentences, permCats) => {
     if (isEmpty(data)) return null;
-    const { initial, globalInitial, noLoss } = sentences;
+    const {
+      initial,
+      initialWithIndicator,
+      globalInitial,
+      globalWithIndicator,
+      noLoss,
+    } = sentences;
     const { startYear, endYear } = settings;
 
     const filteredLoss =
@@ -226,11 +234,17 @@ export const parseSentence = createSelector(
       (allLoss && allLoss.length && sumBy(allLoss, 'area')) || 0;
     const permPercent = (permLoss && (permLoss / totalLoss) * 100) || 0;
 
-    let sentence = locationName === 'global' ? globalInitial : initial;
+    let sentence = indicator ? initialWithIndicator : initial;
+
     if (!permLoss) sentence = noLoss;
+
+    if (locationName === 'global') {
+      sentence = indicator ? globalWithIndicator : globalInitial;
+    }
 
     const params = {
       location: locationName === 'global' ? 'Globally' : locationName,
+      indicator: indicator && indicator.label,
       startYear,
       endYear,
       permPercent: formatNumber({ num: permPercent, unit: '%' }),


### PR DESCRIPTION
## Overview

To be consistent with the SDPT layer being available as a “forest type” filter in the tree cover loss due to fires in [area] widget and forest-related greenhouse gas emissions in [area] widget, we would like to add it to the annual tree cover loss by dominant driver in [area] widget



#### Add “forest type” dropdown

We need to add a “forest type” dropdown in the settings for this widget. It will have two options:All tree cover (the default)PlantationsLuis and Will will see how easy it would be to make this change; it’s a new way of doing things. Please let Teresa know if this won’t work.

#### Add “Plantations” as intersection

In the “settings” button for this widget, there is a “Forest type” dropdown - we will need to add an option for “Plantations” just as we have for the tree cover loss due to fires in [area] widget and forest-related greenhouse gas emissions in [area] widget.


