### PR TITLE
[FLAG-831] Add Global Peatlands

### DIFF
--- a/data/land-categories.js
+++ b/data/land-categories.js
@@ -107,6 +107,22 @@ export default [
     ],
   },
   {
+    label: 'Global peat lands',
+    preserveString: true,
+    dataType: 'keyword',
+    value: '', // still need to change to global peat lands
+    metaKey: '', // still need to change to global peat lands
+    tableKey: 'is__gfw_peatlands',
+    global: false,
+    datasets: [
+      {
+        dataset: IND_PEAT_LANDS_DATASET, // still need to change to global peat lands
+        layers: [IND_PEAT_LANDS], // still need to change to global peat lands
+      },
+    ],
+    hidden: true, // FIXME: we are temporary hiding this option until further notice, see FLAG-827 for reference.
+  },
+  {
     label: 'Indonesia & Malaysia peat lands',
     preserveString: true,
     dataType: 'keyword',


### PR DESCRIPTION
## Overview

[In this ticket](https://gfw.atlassian.net/browse/FLAG-827), we removed the Indonesia and Malaysia Peatlands intersection from the widgets below. We’d like to replace this intersection with the Global Peatlands dataset.

Here are widgets (with their country and subnational names, many exist at the global level too) that we’d need to add the Global Peatlands intersection to: 

- Primary Forest Loss in [area] 
- Tree cover loss in [area] 
- Tree cover loss in [area] compared to other areas
- Tree cover gain in [area] compared to other areas
- Location of tree cover gain in [area]
- Tree cover gain outside plantations in [area]
- Tree Cover by type in [area]
- Forest in [area] compared to other areas
- Intact forest in [area]
- Primary forest in [area]
- Location of forest in [area]
- Integrated Deforestation alerts in [area]
- Tree cover loss due to fires in [area]
- Regions with most tree cover loss due to fires in [area]
- Proportion of tree cover loss due to fires in [area]
- Forest-related greenhouse gas fluxes in [area]
- Forest-related greenhouse gas emissions in [area]
- Forest-related greenhouse gas emissions in [area] by dominant driver
