### PR TITLE
[FLAG-1271] Add `simplify` query param when GETing admin geostores

### DIFF
--- a/services/__tests__/geostore.spec.js
+++ b/services/__tests__/geostore.spec.js
@@ -55,7 +55,7 @@ describe('fetchGeostore', () => {
     });
 
     expect(dataRequest.get).toHaveBeenCalledWith(
-      'https://data-api.globalforestwatch.org/geostore/admin/BRA?source[provider]=gadm&source[version]=3.6',
+      'https://data-api.globalforestwatch.org/geostore/admin/BRA?source[provider]=gadm&source[version]=3.6&simplify=0.1',
       expect.any(Object)
     );
   });
@@ -86,7 +86,7 @@ describe('fetchGeostore', () => {
     });
 
     expect(dataRequest.get).toHaveBeenCalledWith(
-      'https://data-api.globalforestwatch.org/geostore/admin/BRA/25?source[provider]=gadm&source[version]=3.6',
+      'https://data-api.globalforestwatch.org/geostore/admin/BRA/25?source[provider]=gadm&source[version]=3.6&simplify=0.01',
       expect.any(Object)
     );
   });

--- a/services/geostore.js
+++ b/services/geostore.js
@@ -85,13 +85,13 @@ export const getGeostore = ({ type, adm0, adm1, adm2, token }) => {
       });
     case 'use':
       return fetchGeostore({
-        url: `/geostore/use/${adm0}${adm1 ? `/${adm1}` : ''}`,
+        url: `/geostore/use/${adm0}/${adm1}`,
         queryParams,
         token,
       });
     case 'geostore':
       return fetchGeostore({
-        url: `/geostore/use/${adm0}`,
+        url: `/geostore/${adm0}`,
         queryParams,
         token,
       });

--- a/services/geostore.js
+++ b/services/geostore.js
@@ -50,7 +50,7 @@ const setThreshold = (iso, adm1, adm2) => {
  * @return {object} - An object with area id, geojson and bbox objects
  *
  */
-const fetchGeostore = ({ url, token, queryParams }) => {
+const fetchGeostore = ({ url, token, queryParams = '' }) => {
   return dataRequest
     .get(`https://data-api.globalforestwatch.org${url}?${queryParams}`, {
       cancelToken: token,

--- a/services/geostore.js
+++ b/services/geostore.js
@@ -72,7 +72,7 @@ export const getGeostore = ({ type, adm0, adm1, adm2, token }) => {
   const sourceProvider = 'source[provider]=gadm';
   const sourceVersion = 'source[version]=3.6';
   const threshold = `simplify=${setThreshold(adm0, adm1, adm2)}`;
-  const queryParams = `${sourceProvider}&${sourceVersion}&${threshold}`;
+  const queryParams = `${sourceProvider}&${sourceVersion}`;
 
   switch (type) {
     case 'country':
@@ -80,7 +80,7 @@ export const getGeostore = ({ type, adm0, adm1, adm2, token }) => {
         url: `/geostore/admin/${adm0}${adm1 ? `/${adm1}` : ''}${
           adm2 ? `/${adm2}` : ''
         }`,
-        queryParams,
+        queryParams: `${queryParams}&${threshold}`,
         token,
       });
     case 'use':

--- a/services/geostore.js
+++ b/services/geostore.js
@@ -24,13 +24,22 @@ const getWDPAGeostore = ({ id, token }) =>
     })
   );
 
-const parseSimplifyGeom = (iso, id1, id2) => {
+/**
+ * Calculate the threshold for geostore endpoint
+ * Big countries has a different threshold. eg. Brazil
+ * @param {string} iso - admin level 0 (e.g BRA)
+ * @param {string} adm1 - admin level 1 (e.g 25)
+ * @param {string} adm2 - admin level 2 (e.g 390)
+ * @return {number} - threshold value
+ *
+ */
+const setThreshold = (iso, adm1, adm2) => {
   const bigCountries = ['USA', 'RUS', 'CAN', 'CHN', 'BRA', 'IDN'];
   const baseThresh = bigCountries.includes(iso) ? 0.1 : 0.005;
-  if (iso && !id1 && !id2) {
+  if (iso && !adm1 && !adm2) {
     return baseThresh;
   }
-  return id1 && !id2 ? baseThresh / 10 : baseThresh / 100;
+  return adm1 && !adm2 ? baseThresh / 10 : baseThresh / 100;
 };
 
 /**
@@ -62,7 +71,7 @@ export const getGeostore = ({ type, adm0, adm1, adm2, token }) => {
 
   const sourceProvider = 'source[provider]=gadm';
   const sourceVersion = 'source[version]=3.6';
-  const threshold = `simplify=${parseSimplifyGeom(adm0, adm1, adm2)}`;
+  const threshold = `simplify=${setThreshold(adm0, adm1, adm2)}`;
   const queryParams = `${sourceProvider}&${sourceVersion}&${threshold}`;
 
   switch (type) {


### PR DESCRIPTION
## Overview

This card makes the geojson simplification explicit when a geostore is requested from the Data API Area microservice.

Previously, Flagship passed a thresh query parameter when GETing administrative boundary geostores. The RW Geostore MS ignored the param because it wasn’t named correctly.

 It looked like it worked because the RW Geostore MS implemented its own default simplification values. I’ve documented [this on the miro board](https://miro.com/app/board/uXjVLKsI-90=/?moveToWidget=3458764605651383931&cot=14).

Going forward, we want to make sure we’re sending (and receiving) the simplified geostores that we’ve asked for and not rely on the RW Geostore MS defaults.

### Scope

This involves adding one query parameter to the Data API geostore GET request.

Currently, requests for a user’s Areas look like this in Flagship: GET /geostore/admin/:iso/:adm1/:adm2?source[provider]=gadm&source[version]=4.1

The updated implementation will add one query parameter: 

GET /geostore/admin/:iso/:adm1/:adm2?source[provider]=gadm&source[version]=4.1&simplify=<value>

This will work for GADM 3.6 requests, too

Implementation Details

[Here is the function](https://github.com/gfw-api/gfw-geostore-api/blob/a20d800e8083ff7f03e5b2d2a0840ad86fe65dce/app/src/services/cartoDBServiceV2.js#L62) used in the RW Geostore MS to calculate the default simplification value. 

The assumption is that this code can be copied over to the [services/geostore.js module](https://github.com/wri/gfw/blob/feat/gadm-geostore-service-FLAG-1252/services/geostore.js).
