### PR TITLE
[FLAG-1261] Provide GADM Version when Creating/Updating an Area

### DIFF
--- a/components/forms/area-of-interest/actions.js
+++ b/components/forms/area-of-interest/actions.js
@@ -15,124 +15,130 @@ import { getWidgetsData } from 'components/widgets/actions';
 export const saveAreaOfInterest = createThunkAction(
   'saveAreaOfInterest',
   ({
-    id,
-    name,
-    tags,
-    email,
-    webhookUrl,
-    language,
-    alerts,
-    admin,
-    wdpaid,
-    use,
-    application,
-    viewAfterSave,
-    publicArea,
-    deforestationAlertsType,
-    geostore: geostoreId,
-  }) => (dispatch, getState) => {
-    const { location, geostore } = getState();
-    const { data: geostoreData } = geostore || {};
-    const {
-      payload: { type, adm0, adm1, adm2 },
-    } = location || {};
-    const isCountry = type === 'country';
-
-    const postData = {
       id,
       name,
-      type,
-      application: application || 'gfw',
-      geostore:
-        type !== 'wdpa'
-          ? geostoreId || (geostoreData && geostoreData.id)
-          : null,
+      tags,
       email,
+      webhookUrl,
       language,
-      deforestationAlerts: alerts.includes('deforestationAlerts'),
+      alerts,
+      admin,
+      wdpaid,
+      use,
+      application,
+      viewAfterSave,
+      publicArea,
       deforestationAlertsType,
-      monthlySummary: alerts.includes('monthlySummary'),
-      fireAlerts: alerts.includes('fireAlerts'),
-      ...(admin && {
-        admin,
-      }),
-      ...(wdpaid && {
-        wdpaid,
-      }),
-      ...(use && {
-        use,
-      }),
-      ...(isCountry && {
-        admin: {
-          adm0,
-          adm1,
-          adm2,
-        },
-      }),
-      ...(type === 'use' && {
-        use: {
-          id: adm1,
-          name: adm0,
-        },
-      }),
-      ...(type === 'wdpa' && {
-        wdpaid: parseInt(adm0, 10),
-        geostoreDataAPI: geostoreId || (geostoreData && geostoreData.id),
-      }),
-      ...(webhookUrl && {
-        webhookUrl,
-      }),
-      tags: tags || [],
-      public: publicArea,
-      ...((isCountry || type === 'wdpa') && {
-        status: 'saved',
-      }),
-    };
+      geostore: geostoreId,
+    }) =>
+    (dispatch, getState) => {
+      const { location, geostore } = getState();
+      const { data: geostoreData } = geostore || {};
+      const {
+        payload: { type, adm0, adm1, adm2 },
+      } = location || {};
+      const isCountry = type === 'country';
 
-    return saveArea(postData)
-      .then((area) => {
-        dispatch(setArea({ ...area, userArea: true }));
-        if (viewAfterSave) {
-          dispatch(viewArea({ areaId: area.id }));
-        }
-        if (
-          location.payload.type === 'geostore' ||
-          location.payload.type === 'aoi'
-        ) {
-          dispatch(getWidgetsData());
-        }
-      })
-      .catch((error) => {
-        const { errors } = error.response.data;
+      const postData = {
+        id,
+        name,
+        type,
+        application: application || 'gfw',
+        geostore:
+          type !== 'wdpa'
+            ? geostoreId || (geostoreData && geostoreData.id)
+            : null,
+        email,
+        language,
+        deforestationAlerts: alerts.includes('deforestationAlerts'),
+        deforestationAlertsType,
+        monthlySummary: alerts.includes('monthlySummary'),
+        fireAlerts: alerts.includes('fireAlerts'),
+        ...(admin && {
+          admin,
+        }),
+        ...(wdpaid && {
+          wdpaid,
+        }),
+        ...(use && {
+          use,
+        }),
+        ...(isCountry && {
+          admin: {
+            source: {
+              provider: 'gadm',
+              version: '3.6',
+            },
+            adm0,
+            adm1,
+            adm2,
+          },
+        }),
+        ...(type === 'use' && {
+          use: {
+            id: adm1,
+            name: adm0,
+          },
+        }),
+        ...(type === 'wdpa' && {
+          wdpaid: parseInt(adm0, 10),
+          geostoreDataAPI: geostoreId || (geostoreData && geostoreData.id),
+        }),
+        ...(webhookUrl && {
+          webhookUrl,
+        }),
+        tags: tags || [],
+        public: publicArea,
+        ...((isCountry || type === 'wdpa') && {
+          status: 'saved',
+        }),
+      };
 
-        return {
-          [FORM_ERROR]: errors[0].detail,
-        };
-      });
-  }
+      return saveArea(postData)
+        .then((area) => {
+          dispatch(setArea({ ...area, userArea: true }));
+          if (viewAfterSave) {
+            dispatch(viewArea({ areaId: area.id }));
+          }
+          if (
+            location.payload.type === 'geostore' ||
+            location.payload.type === 'aoi'
+          ) {
+            dispatch(getWidgetsData());
+          }
+        })
+        .catch((error) => {
+          const { errors } = error.response.data;
+
+          return {
+            [FORM_ERROR]: errors[0].detail,
+          };
+        });
+    }
 );
 
 export const deleteAreaOfInterest = createThunkAction(
   'deleteAreaOfInterest',
-  ({ id, clearAfterDelete, callBack }) => (dispatch, getState) => {
-    const { data: areas } = getState().areas || {};
+  ({ id, clearAfterDelete, callBack }) =>
+    (dispatch, getState) => {
+      const { data: areas } = getState().areas || {};
 
-    return deleteArea(id)
-      .then(() => {
-        dispatch(setAreas(areas.filter((a) => a.id !== id)));
-        if (clearAfterDelete) {
-          dispatch(clearArea());
-        }
-        if (callBack) {
-          callBack();
-        }
-      })
-      .catch((error) => {
-        const { errors } = error.response.data;
+      return deleteArea(id)
+        .then(() => {
+          dispatch(setAreas(areas.filter((a) => a.id !== id)));
+          if (clearAfterDelete) {
+            dispatch(clearArea());
+          }
+          if (callBack) {
+            callBack();
+          }
+        })
+        .catch((error) => {
+          const { errors } = error.response.data;
 
-        return {
-          [FORM_ERROR]: errors[0].detail,
-        };
-      });
-  }
+          return {
+            [FORM_ERROR]: errors[0].detail,
+          };
+        });
+    }
 );


### PR DESCRIPTION
## Overview

The RW Area microservice and Flagship are aware of the concept of a provider and version for Areas that are administrative boundaries (GADM 3.6 or 4.1).

Therefore, when areas are created or updated using the Areas microservice, it’s necessary to provide the provider and version as part of the Area payload.

Implementation Details

[Areas Service where Areas are saved/updated](https://github.com/wri/gfw/blob/2d31f12257cc0783b85938bd662ad49acf2f3f52/services/areas.js#L68) in Flagship

Area payloads should have a source attribute in either its iso or admin object (or both) when saving/updating an Area representing an administrative boundary.

This schema is the same shape as what is currently returned in an Area representation from the MS:

```
"iso": {
  "source": {                   <= If the new area has `iso` values, add a `source` property
    "provider": "gadm",
    "version": "4.1"
  },
  "country": "HND",
  "region": "8",
  "subregion: "4"
},
"admin": {                      <= If the new area has `admin` values, add a `source` property
  "source": {
    "provider": "gadm",
    "version": "4.1"
  },
  "adm0": "HND",
  "adm1": 8,
  "adm2": 4
},
```

The Miro board has an [example of an Area Representation](https://miro.com/app/board/uXjVLKsI-90=/?moveToWidget=3458764609164177591&cot=14) with the source properties.
