### PR TITLE
[FLAG-1274] Update Areas Service to get both 3.6 and 4.1 User Areas

### DIFF
--- a/services/__tests__/areas.spec.js
+++ b/services/__tests__/areas.spec.js
@@ -1,6 +1,6 @@
 import { jest } from '@jest/globals';
 
-import { getArea, getAreas, saveArea, deleteArea } from '../areas';
+import { getAreas, saveArea, deleteArea } from '../areas';
 import { apiAuthRequest } from '../../utils/request';
 import { trackEvent } from '../../utils/analytics';
 
@@ -26,32 +26,13 @@ describe('Areas Service', () => {
     jest.clearAllMocks();
   });
 
-  describe('Getting a Single Area', () => {
-    describe('The Request to the API', () => {
-      it('should add source params for gadm 3.6', async () => {
-        // arrange
-        apiAuthRequest.get.mockResolvedValueOnce({
-          data: { data: { attributes: {} } },
-        });
-
-        // act
-        await getArea('abcdef123456789');
-
-        // assert
-        expect(apiAuthRequest.get).toHaveBeenCalledWith(
-          '/v2/area/abcdef123456789?source[provider]=gadm&source[version]=3.6',
-          {
-            headers: {},
-          }
-        );
-      });
-    });
-  });
-
   describe('Getting Multiple Areas', () => {
     describe('The Request to the API', () => {
-      it('should add source params for gadm 3.6', async () => {
+      it('should add source params for gadm', async () => {
         // arrange
+        apiAuthRequest.get.mockResolvedValueOnce({
+          data: { data: [{ attributes: {} }] },
+        });
         apiAuthRequest.get.mockResolvedValueOnce({
           data: { data: [{ attributes: {} }] },
         });
@@ -65,7 +46,7 @@ describe('Areas Service', () => {
         );
       });
 
-      it('should return a valid array containing area item', async () => {
+      it('should return a valid array containing area item giving preferrence for gadm 4.1', async () => {
         // arrange
         apiAuthRequest.get.mockResolvedValueOnce({
           data: {
@@ -94,6 +75,33 @@ describe('Areas Service', () => {
             ],
           },
         });
+        apiAuthRequest.get.mockResolvedValueOnce({
+          data: {
+            data: [
+              {
+                type: 'area',
+                id: '67892867738cd20016c88173',
+                attributes: {
+                  name: 'Brazil',
+                  admin: {
+                    adm0: 'BRA',
+                    source: {
+                      provider: 'gadm',
+                      version: '4.1',
+                    },
+                  },
+                  iso: {
+                    country: 'BRA',
+                    source: {
+                      provider: 'gadm',
+                      version: '4.1',
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        });
 
         // act
         const result = await getAreas();
@@ -107,14 +115,14 @@ describe('Areas Service', () => {
               adm0: 'BRA',
               source: {
                 provider: 'gadm',
-                version: '3.6',
+                version: '4.1',
               },
             },
             iso: {
               country: 'BRA',
               source: {
                 provider: 'gadm',
-                version: '3.6',
+                version: '4.1',
               },
             },
             use: {},

--- a/services/areas.js
+++ b/services/areas.js
@@ -2,11 +2,34 @@ import { apiAuthRequest } from 'utils/request';
 import { trackEvent } from 'utils/analytics';
 
 const REQUEST_URL = '/v2/area';
-const SOURCE = `?source[provider]=gadm&source[version]=3.6`;
+
+const parseArea = (area) => {
+  const admin = area.attributes && area.attributes.admin;
+  const iso = area.attributes && area.attributes.iso;
+
+  return {
+    id: area.id,
+    ...area.attributes,
+    ...{
+      ...area.attributes,
+      use: {},
+    },
+    ...(iso &&
+      iso.country && {
+      admin: {
+        adm0: iso.country,
+        adm1: iso.region,
+        adm2: iso.subregion,
+        ...admin,
+      },
+    }),
+    userArea: true,
+  };
+};
 
 export const getArea = (id, userToken = null) =>
   apiAuthRequest
-    .get(`${REQUEST_URL}/${id}${SOURCE}`, {
+    .get(`${REQUEST_URL}/${id}`, {
       headers: {
         ...(userToken && {
           Authorization: `Bearer ${userToken}`,
@@ -15,55 +38,37 @@ export const getArea = (id, userToken = null) =>
     })
     .then((areaResponse) => {
       const { data: area } = areaResponse.data;
-      const admin = area.attributes && area.attributes.admin;
-      const iso = area.attributes && area.attributes.iso;
 
-      return {
-        id: area.id,
-        ...{
-          ...area.attributes,
-          use: {},
-        },
-        ...(iso &&
-          iso.country && {
-            admin: {
-              adm0: iso.country,
-              adm1: iso.region,
-              adm2: iso.subregion,
-              ...admin,
-            },
-          }),
-      };
+      return parseArea(area)
     });
 
-export const getAreas = () =>
-  apiAuthRequest.get(`${REQUEST_URL}${SOURCE}`).then((areasResponse) => {
-    const { data: areas } = areasResponse.data;
+export const getAreas = () => {
+  const gadm36 = apiAuthRequest
+    .get(`${REQUEST_URL}?source[provider]=gadm&source[version]=3.6`)
+    .then((areasResponse) => {
+      const { data: areas } = areasResponse.data;
 
-    return areas.map((area) => {
-      const admin = area.attributes && area.attributes.admin;
-      const iso = area.attributes && area.attributes.iso;
+      return areas.map((area) => parseArea(area))
+    })
 
-      return {
-        id: area.id,
-        ...area.attributes,
-        ...{
-          ...area.attributes,
-          use: {},
-        },
-        ...(iso &&
-          iso.country && {
-            admin: {
-              adm0: iso.country,
-              adm1: iso.region,
-              adm2: iso.subregion,
-              ...admin,
-            },
-          }),
-        userArea: true,
-      };
-    });
+  const gadm41 = apiAuthRequest
+    .get(`${REQUEST_URL}?source[provider]=gadm&source[version]=4.1`)
+    .then((areasResponse) => {
+      const { data: areas } = areasResponse.data;
+
+      return areas.map((area) => parseArea(area))
+    })
+
+  return Promise.all([gadm36, gadm41]).then(([areas36, areas41]) => {
+    // logic to return only unique values, preferring 4.1 over 3.6
+    const areasMap = new Map();
+
+    areas36.map(area => areasMap.set(area.id, area));
+    areas41.map(area => areasMap.set(area.id, area));
+
+    return Array.from(areasMap.values());
   });
+};
 
 export const saveArea = (data) =>
   apiAuthRequest({


### PR DESCRIPTION
## Overview

### RW Areas MS Behavior

The RW Areas MS allows clients to filter administrative areas with a source[provider] and source[version] filter.

Regardless of the filter, all custom areas are always returned

For backward compatibility, when the filter isn’t used OR it’s used with the values gadm and 3.6, administrative boundary areas (those with iso or admin values) with a 3.6 version will also be returned. Any user’s administrative boundary that is only 4.1 will NOT be returned. This is so legacy clients do not try to interpret the 4.1 GADM IDs as 3.6 

Going forward, when the filter is used for values gadm and 4.1, administrative boundary areas with a 4.1 version will be returned. Any user’s administrative boundary area that is only 3.6 (areas that could not be automatically updated to 4.1) are NOT returned.

### Flagship Changes

Therefore, when Flagship wishes to update to GADM 4.1, it’s necessary to make two calls to the RW Areas MS. One with a filter of 3.6 and another with a filter of 4.1 and then create a union of the two sets to pass to the Redux store.

Here is a [basic diagram in the GADM miro board](https://miro.com/app/board/uXjVLKsI-90=/?moveToWidget=3458764618749660950&cot=14) to explain the operation.

### Scope

This should only affect the services/areas.js [module](https://github.com/wri/gfw/blob/d4d62a0e24c3af11b5a4d85441057385775b984a/services/areas.js). Specifically, getting Areas that are later loaded into Redux.