### PR TITLE
chore(gadm): comment gadm 4.1 logic inside getAreas

### DIFF
--- a/services/__tests__/areas.spec.js
+++ b/services/__tests__/areas.spec.js
@@ -115,14 +115,16 @@ describe('Areas Service', () => {
               adm0: 'BRA',
               source: {
                 provider: 'gadm',
-                version: '4.1',
+                // version: '4.1',
+                version: '3.6', // remove it before release gadm 4.1
               },
             },
             iso: {
               country: 'BRA',
               source: {
                 provider: 'gadm',
-                version: '4.1',
+                // version: '4.1',
+                version: '3.6', // remove it before release gadm 4.1
               },
             },
             use: {},

--- a/services/areas.js
+++ b/services/areas.js
@@ -16,13 +16,13 @@ const parseArea = (area) => {
     },
     ...(iso &&
       iso.country && {
-      admin: {
-        adm0: iso.country,
-        adm1: iso.region,
-        adm2: iso.subregion,
-        ...admin,
-      },
-    }),
+        admin: {
+          adm0: iso.country,
+          adm1: iso.region,
+          adm2: iso.subregion,
+          ...admin,
+        },
+      }),
     userArea: true,
   };
 };
@@ -39,7 +39,7 @@ export const getArea = (id, userToken = null) =>
     .then((areaResponse) => {
       const { data: area } = areaResponse.data;
 
-      return parseArea(area)
+      return parseArea(area);
     });
 
 export const getAreas = () => {
@@ -48,23 +48,27 @@ export const getAreas = () => {
     .then((areasResponse) => {
       const { data: areas } = areasResponse.data;
 
-      return areas.map((area) => parseArea(area))
-    })
+      return areas.map((area) => parseArea(area));
+    });
 
   const gadm41 = apiAuthRequest
     .get(`${REQUEST_URL}?source[provider]=gadm&source[version]=4.1`)
-    .then((areasResponse) => {
-      const { data: areas } = areasResponse.data;
+    .then(() => {
+      // Commenting this logic to avoid gadm 4.1 in production
+      // .then((areasResponse) => {
+      // const { data: areas } = areasResponse.data;
 
-      return areas.map((area) => parseArea(area))
-    })
+      // return areas.map((area) => parseArea(area))
+
+      return [];
+    });
 
   return Promise.all([gadm36, gadm41]).then(([areas36, areas41]) => {
     // logic to return only unique values, preferring 4.1 over 3.6
     const areasMap = new Map();
 
-    areas36.map(area => areasMap.set(area.id, area));
-    areas41.map(area => areasMap.set(area.id, area));
+    areas36.map((area) => areasMap.set(area.id, area));
+    areas41.map((area) => areasMap.set(area.id, area));
 
     return Array.from(areasMap.values());
   });


### PR DESCRIPTION
## Overview

Since we're still on 3.6 in production. We need to remove the second 4.1 request to the RW Areas MS.

#4957 

