### PR TITLE
FLAG-1297 - Fix unresponsive map when panning or zooming

### DIFF
--- a/components/map/selectors.js
+++ b/components/map/selectors.js
@@ -48,7 +48,9 @@ export const getMapViewport = createSelector([getMapSettings], (settings) => {
     pitch,
     latitude: center?.lat,
     longitude: center?.lng,
-    transitionDuration: 500,
+    // The map transition needs to always be 0 otherwise the map becomes sluggish when panned or zoomed. Only set a
+    // different value when flying between locations and only temporarily.
+    transitionDuration: 0,
   };
 });
 

--- a/components/ui/map/component.jsx
+++ b/components/ui/map/component.jsx
@@ -271,6 +271,9 @@ class Map extends Component {
           onResize={this.onResize}
           onLoad={this.onLoad}
           getCursor={getCursor}
+          // If the `transitionDuration` is not 0, then the map becomes sluggish when panned or zoomed. Nevertheless,
+          // we still want a transition when flying between locations.
+          transitionDuration={flying ? viewport.transitionDuration || 0 : 0}
           transitionInterpolator={new FlyToInterpolator()}
           transitionEasing={easeCubic}
           preventStyleDiffing


### PR DESCRIPTION
This PR fixes a regression from [dbfa56b](https://github.com/wri/gfw/commit/dbfa56b6179407b6410bdfd58d6ad6a1caf0af2c) when React was bumped to v18. The problem meant that the map was unresponsive when panning and zooming.

The proposed fix implies removing any map transition duration unless when flying between location (and in such case only temporarily).

## Tracking

[FLAG-1297](https://gfw.atlassian.net/browse/FLAG-1297)


[FLAG-1297]: https://gfw.atlassian.net/browse/FLAG-1297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ