### PR TITLE
Add support for grouped legends

### DIFF
--- a/components/legend/components/legend-item-types/legend-item-type-basic/legend-item-type-basic-item/index.js
+++ b/components/legend/components/legend-item-types/legend-item-type-basic/legend-item-type-basic-item/index.js
@@ -30,9 +30,9 @@ class LegendItem extends React.PureComponent {
         <div
           className={`icon-${icon}`}
           style={{
-            boderRightWidth: size / 2,
-            boderLeftWidth: size / 2,
-            boderBottomWidth: size,
+            borderRightWidth: size / 2,
+            borderLeftWidth: size / 2,
+            borderBottomWidth: size,
             borderBottomColor: color,
           }}
         />

--- a/components/legend/components/legend-item-types/legend-item-type-basic/legend-item-type-basic-item/styles.scss
+++ b/components/legend/components/legend-item-types/legend-item-type-basic/legend-item-type-basic-item/styles.scss
@@ -14,6 +14,22 @@
     margin-left: 5px;
   }
 
+  // If `.c-legend-item-basic` is placed before `.legend-basic-group` i.e. it's a group title
+  &:has(+ .legend-basic-group) {
+    // Hide the icon
+    > .icon-square,
+    > .icon-line,
+    > .icon-circle,
+    > .icon-triangle,
+    .custom-icon {
+      display: none;
+    }
+
+    .name {
+      font-weight: 700;
+    }
+  }
+
   > .icon-square,
   > .icon-line,
   > .icon-circle,

--- a/components/legend/components/legend-item-types/legend-item-type-basic/styles.scss
+++ b/components/legend/components/legend-item-types/legend-item-type-basic/styles.scss
@@ -37,10 +37,15 @@
         }
       }
     }
+
+    // Make sure the last `.legend-basic-group` doesn't have a bottom padding (used to separate the groups)
+    li:last-child .legend-basic-group {
+      padding-bottom: 0;
+    }
   }
 
   .legend-basic-group {
-    padding: 8px 0 0 10px;
+    padding: 5px 0 12px;
   }
 
   li {


### PR DESCRIPTION
This PR adds support for grouped legends by reusing the “basic” legend type which already had most of the feature implemented.

![Legend for the “Tree cover loss by dominant driver - 2001-2023” layer showing groups of items](https://github.com/user-attachments/assets/939ef16d-8bc0-434a-b10e-59b2e1c8cf01)

To defined groups, nest an `items` array inside each item. You can test the implementation by defining a legend as follows:
```json
{
  "type": "basic",
  "items": [
    {
      "name": "Drivers of temporary disturbances",
      "items": [
        {
          "name": "Forest management",
          "color": "#FF00DD"
        },
        {
          "name": "Shifting cultivation",
          "color": "#34EE64"
        },
        {
          "name": "Wildfires",
          "color": "#A200FF"
        },
        {
          "name": "Other natural disturbances",
          "color": "#DDD"
        },
      ]
    },
    {
      "name": "Drivers of deforestation",
      "items": [
        {
          "name": "Hard commodities",
          "color": "#FFDEDD"
        },
        {
          "name": "Permanent agriculture",
          "color": "#D4E36D"
        },
        {
          "name": "Settlements and infrastructure",
          "color": "#0200FF"
        }
      ]
    }
  ]
}
```

## Tracking

[FLAG-1231](https://gfw.atlassian.net/browse/FLAG-1231)