### PR TITLE
[FLAG-1174] Remove repeat words in integrated alerts widget

### DIFF
--- a/components/widgets/forest-change/integrated-deforestation-alerts/index.js
+++ b/components/widgets/forest-change/integrated-deforestation-alerts/index.js
@@ -58,9 +58,9 @@ export default {
     withInd:
       'There were {total} deforestation alerts reported within {indicator} in {location} between {startDate} and {endDate}, {totalArea} of which {highConfPerc} were high confidence alerts detected by a single system and {highestConfPerc} were alerts detected by multiple systems.',
     singleSystem:
-      'There were {total} {system} alerts reported in {location} between {startDate} and {endDate}, {totalArea} of which {highConfPerc} were {highConfidenceAlerts}.',
+      'There were {total} {system} alerts reported in {location} between {startDate} and {endDate}, {totalArea} of which {highConfPerc} were {high confidence alerts}.',
     singleSystemWithInd:
-      'There were {total} {system} alerts reported within {indicator} in {location} between {startDate} and {endDate}, {totalArea} of which {highConfPerc} were {highConfidenceAlerts}.',
+      'There were {total} {system} alerts reported within {indicator} in {location} between {startDate} and {endDate}, {totalArea} of which {highConfPerc} were {high confidence alerts}.',
     highConf:
       'There were {total} high or highest confidence {system} alerts reported in {location} between {startDate} and {endDate}, {totalArea}.',
     noReportedAlerts:

--- a/components/widgets/forest-change/integrated-deforestation-alerts/selectors.js
+++ b/components/widgets/forest-change/integrated-deforestation-alerts/selectors.js
@@ -201,11 +201,12 @@ export const parseSentence = createSelector(
       totalArea: !totalArea
         ? ' '
         : translateText('covering a total of {area}', {
-          area: formatNumber({
-            num: totalArea,
-            unit: 'ha',
-            spaceUnit: true,
-          })}),
+            area: formatNumber({
+              num: totalArea,
+              unit: 'ha',
+              spaceUnit: true,
+            }),
+          }),
       total: formatNumber({ num: totalAlertCount, unit: ',' }),
       highConfPerc:
         highAlertPercentage === 0
@@ -220,7 +221,7 @@ export const parseSentence = createSelector(
       ...((systemSlug === 'glad_l' && {
         component: {
           key: 'high confidence alerts',
-          fine: true,
+          fine: false,
           tooltip:
             'Alerts are classified as high confidence when a second satellite pass has also identified the pixel as an alert. Most of the alerts that remain unclassified have not had another satelite pass, due to the 8-day revisit time or cloud cover.',
         },
@@ -228,7 +229,7 @@ export const parseSentence = createSelector(
         (systemSlug === 'glad_s2' && {
           component: {
             key: 'high confidence alerts',
-            fine: true,
+            fine: false,
             tooltip:
               'Alerts are classified as high confidence when at least two or four subsequent observations are labeled as forest loss.',
           },
@@ -236,7 +237,7 @@ export const parseSentence = createSelector(
         (systemSlug === 'radd' && {
           component: {
             key: 'high confidence alerts',
-            fine: true,
+            fine: false,
             tooltip:
               'Alerts are marked as high confidence when they reach a probability threshold of 97.5% across multiple images in a 90-day window.',
           },


### PR DESCRIPTION
## Overview

When any individual alert system (GLAD-S2, GLAD-L, RADD) is selected in the [Integrated Deforestation Alerts in Brazil widget](https://gfw.global/3HVq7nm), an extra “high confidence alerts” appears after the widget sentence’s period. This underlined area that produces a modal when a user hovers it should replace the bolded high confidence alerts” text before it. We want users to be able to hover over “high confidence alerts” and see this explanation (“Alerts are classified as high confidence when…”).

## Demo

<img width="356" alt="Screenshot 2025-04-08 at 13 38 36" src="https://github.com/user-attachments/assets/2762fdcc-5bef-4ec3-a2d1-6f3e378a7988" />


