### PR TITLE
[FLAG-1304] Add note in cloud cover selector: "Increase cloud cover % to retrieve more images" 

### DIFF
--- a/components/recent-imagery/components/recent-imagery-settings/component.jsx
+++ b/components/recent-imagery/components/recent-imagery-settings/component.jsx
@@ -202,7 +202,7 @@ class RecentImagerySettings extends PureComponent {
           {!error && (!tiles || !tiles.length) && !loading && (
             <NoContent
               className="placeholder"
-              message="We can't find additional images for the selection"
+              message="We can't find additional images for the selection. Increase cloud cover percentage to retrieve more images."
             />
           )}
           {loading && !error && <Loader className="placeholder" />}


### PR DESCRIPTION
## Overview

Since the default max cloud cover is 25%, images often won't appear for a location unless the cloud cover % is bumped up. It may not be clear to users that they need to manually increase the max cloud cover percentage if they get the message "We can't find additional images for the selection." Adding a note here such as "increase cloud cover % to retrieve more images" could be helpful.

Steps to Reproduce:

Select [Landsat 8 / Sentinel 2](https://gfw.global/3Fkw3rQ) from the list of available imagery options.

Find a location on the map with no imagery coverage.

The message will read: “We can’t find additional images for the selection.”

If you increase the cloud cover from 25% to 50% or higher, it's likely that the images will appear.

Users may not realize they need to manually increase the cloud cover percentage to resolve this issue.

### Acceptance criteria: 

The message will say "We can't find additional images for the selection. Increase cloud cover percentage to retrieve more images.”

