### PR TITLE
[FLAG-972] Dashboard widget embeds are displayed incorrectly within all blog posts

### DIFF
--- a/components/charts/composed-chart/styles.scss
+++ b/components/charts/composed-chart/styles.scss
@@ -7,6 +7,12 @@ $layout-breakpoint-xl: 1024px;
 $layout-breakpoint-2xl: 1280px;
 $layout-breakpoint-3xl: 1536px;
 
+.embed-widget {
+  .c-composed-chart {
+    overflow: hidden !important;
+  }
+}
+
 .c-composed-chart {
   width: 100%;
   overflow-x: hidden;

--- a/components/widgets/component.jsx
+++ b/components/widgets/component.jsx
@@ -78,15 +78,7 @@ class Widgets extends PureComponent {
     const hasWidgets = !isEmpty(allWidgets) && !isEmpty(widgetGroups);
 
     return (
-      <div
-        className={cx(
-          'c-widgets',
-          className,
-          { simple },
-          { embed },
-          { 'no-widgets': !hasWidgets }
-        )}
-      >
+      <div>
         {loadingData && <Loader className="widgets-loader large" />}
 
         {!loadingData && hasWidgets && (


### PR DESCRIPTION
## Overview

There is an appearance issue with dashboard widget embeds within all blog posts. [This blog post](https://www.globalforestwatch.org/blog/data-and-research/trends-tree-loss-from-fires-unprecedented-detail/) shows three scroll bars in the TREE COVER LOSS DUE TO FIRES IN RUSSIA embed. This issue surfaced a few months ago and happens across different browsers (chrome, firefox). 

Luis noted this may be because Wordpress adds some sort of styling or that the embed has a defined height; we can add a style/remove default to remove the scroll bar. This is only seen in Windows. 


### Acceptance Criteria: 
The three scroll bars that you see to the right of the TCL due to fires in Russia widget shouldn’t be there. 
