### PR TITLE
[FLAG-1231] Support grouped legend in layer panel item

### DIFF
--- a/components/legend/components/legend-item-types/legend-item-type-basic/legend-item-type-basic-item/index.js
+++ b/components/legend/components/legend-item-types/legend-item-type-basic/legend-item-type-basic-item/index.js
@@ -30,9 +30,9 @@ class LegendItem extends React.PureComponent {
         <div
           className={`icon-${icon}`}
           style={{
-            boderRightWidth: size / 2,
-            boderLeftWidth: size / 2,
-            boderBottomWidth: size,
+            borderRightWidth: size / 2,
+            borderLeftWidth: size / 2,
+            borderBottomWidth: size,
             borderBottomColor: color,
           }}
         />

--- a/components/legend/components/legend-item-types/legend-item-type-basic/legend-item-type-basic-item/styles.scss
+++ b/components/legend/components/legend-item-types/legend-item-type-basic/legend-item-type-basic-item/styles.scss
@@ -14,6 +14,22 @@
     margin-left: 5px;
   }
 
+  // If `.c-legend-item-basic` is placed before `.legend-basic-group` i.e. it's a group title
+  &:has(+ .legend-basic-group) {
+    // Hide the icon
+    > .icon-square,
+    > .icon-line,
+    > .icon-circle,
+    > .icon-triangle,
+    .custom-icon {
+      display: none;
+    }
+
+    .name {
+      font-weight: 700;
+    }
+  }
+
   > .icon-square,
   > .icon-line,
   > .icon-circle,

--- a/components/legend/components/legend-item-types/legend-item-type-basic/styles.scss
+++ b/components/legend/components/legend-item-types/legend-item-type-basic/styles.scss
@@ -45,7 +45,7 @@
   }
 
   .legend-basic-group {
-    padding: 5px 0 12px;
+    padding: 0.3125rem 0 1 0.75rem;
   }
 
   li {

--- a/components/legend/components/legend-item-types/legend-item-type-basic/styles.scss
+++ b/components/legend/components/legend-item-types/legend-item-type-basic/styles.scss
@@ -37,10 +37,15 @@
         }
       }
     }
+
+    // Make sure the last `.legend-basic-group` doesn't have a bottom padding (used to separate the groups)
+    li:last-child .legend-basic-group {
+      padding-bottom: 0;
+    }
   }
 
   .legend-basic-group {
-    padding: 8px 0 0 10px;
+    padding: 5px 0 12px;
   }
 
   li {

--- a/providers/datasets-provider/actions.js
+++ b/providers/datasets-provider/actions.js
@@ -113,10 +113,15 @@ export const fetchDatasets = createThunkAction(
                       const { tiles } = source || {}; // previously url
                       const decodeFunction =
                         decodeLayersConfig[decode_function];
-                      const customColor =
-                        legendConfig &&
-                        legendConfig.items &&
-                        legendConfig.items[0].color;
+
+                      const hasGroupedLegend =
+                        Array.isArray(legendConfig?.items) &&
+                        legendConfig.items.length > 0 &&
+                        Array.isArray(legendConfig.items[0]?.items);
+
+                      const customColor = hasGroupedLegend
+                        ? legendConfig?.items?.[0]?.items?.[0]?.color
+                        : legendConfig?.items?.[0]?.color;
 
                       // check if has a timeline
                       const hasParamsTimeline =


### PR DESCRIPTION
## Overview

Support adding groups of legend items in layer panel items. A legend item is composed of (1) a color swatch, (2) a label, and (3) a statistic.

### Acceptance criteria

Groups stack vertically (i.e. flex-direction: column)

Items within a group stack vertically

Groups can have an optional header with the following styles (anything not listed here should be the default for GFW’s typical style):

font-size: 14px

font-weight: bold

There should be a 5px gap between the optional header and the items in the group. This can be achieved though padding, margin, or any other styling that is convenient.

Sample data for a country

Possible values for drivers_type:

- Drivers of temporary disturbances
- Logging
- Shifting cultivation
- Wildfires
- Other natural disturbances
- Drivers of deforestation
- Hard commodities
- Permanent agriculture
- Settlements and infrastructure

To defined groups, nest an `items` array inside each item. You can test the implementation by defining a legend as follows:
```json
{
  "type": "basic",
  "items": [
    {
      "name": "Drivers of temporary disturbances",
      "items": [
        {
          "name": "Forest management",
          "color": "#FF00DD"
        },
        {
          "name": "Shifting cultivation",
          "color": "#34EE64"
        },
        {
          "name": "Wildfires",
          "color": "#A200FF"
        },
        {
          "name": "Other natural disturbances",
          "color": "#DDD"
        },
      ]
    },
    {
      "name": "Drivers of deforestation",
      "items": [
        {
          "name": "Hard commodities",
          "color": "#FFDEDD"
        },
        {
          "name": "Permanent agriculture",
          "color": "#D4E36D"
        },
        {
          "name": "Settlements and infrastructure",
          "color": "#0200FF"
        }
      ]
    }
  ]
}
```

