### PR TITLE
hide widgets for geostore and aoi types

### DIFF
--- a/components/widgets/climate/emissions-deforestation-drivers/index.js
+++ b/components/widgets/climate/emissions-deforestation-drivers/index.js
@@ -30,7 +30,7 @@ export default {
   title:
     'Forest-related greenhouse gas emissions in {location} by dominant driver',
   admins: ['adm0', 'adm1', 'adm2'],
-  types: ['geostore', 'country', 'aoi', 'use', 'wdpa'],
+  types: ['country', 'use', 'wdpa'],
   settingsConfig: [
     {
       key: 'threshold',

--- a/components/widgets/forest-change/_tree-loss-drivers/index.js
+++ b/components/widgets/forest-change/_tree-loss-drivers/index.js
@@ -19,7 +19,7 @@ export default {
     initial: 'Tree cover loss by dominant driver in {location}',
     global: 'Global tree cover loss by dominant driver',
   },
-  types: ['global', 'country', 'geostore', 'aoi', 'use', 'wdpa'],
+  types: ['global', 'country', 'use', 'wdpa'],
   admins: ['global', 'adm0', 'adm1', 'adm2'],
   categories: ['summary', 'forest-change'],
   subcategories: ['forest-loss'],


### PR DESCRIPTION
## Overview

hide both widgets when user draws a custom area in the map and then goes to the dashboard of that custom area

## Demo

If applicable: screenshots, gifs, etc.

## Notes

If applicable: ancilary topics, caveats, alternative strategies that didn't work out, etc.

## Testing

- Include any steps to verify the features this PR introduces.
- If this fixes a bug, include bug reproduction steps.

