### PR TITLE
[FLAG-1119] Add a label to the data download button

### DIFF
--- a/layouts/dashboards/components/header/component.jsx
+++ b/layouts/dashboards/components/header/component.jsx
@@ -253,7 +253,8 @@ class Header extends PureComponent {
                     });
                   }}
                 >
-                  <Icon icon={downloadIcon} />
+                  <Icon icon={downloadIcon} style={{ width: '0.75rem' }} />
+                  Download
                 </Button>
               )}
 

--- a/layouts/dashboards/components/header/styles.scss
+++ b/layouts/dashboards/components/header/styles.scss
@@ -208,7 +208,7 @@
 
   #button-download-data {
     color: #fff;
-    background-color: transparent;
+    background-color: #97be32;
 
     svg {
       margin-right: 0.3125rem;


### PR DESCRIPTION
## Overview

Users are finding it difficult to find the global, country, or admin download button on the dashboards. 
To enhance its visibility, we can add a label to the download icon. 

