### PR TITLE
[FLAG-1000] The map visualization of the integrated deforestation alerts widget doesn't reflect the actual alert count

### DIFF
--- a/components/widgets/utils/config.js
+++ b/components/widgets/utils/config.js
@@ -206,6 +206,8 @@ export const getWidgetDatasets = ({
   threshold,
   dataset,
   adminLevel,
+  endDate,
+  startDate,
 }) => {
   return (
     datasets &&
@@ -232,6 +234,16 @@ export const getWidgetDatasets = ({
               trimEndDate: `${endYear || year}-12-31`,
             },
           }),
+          ...(startDate &&
+            endDate && {
+              timelineParams: {
+                startDate,
+                endDate,
+                trimEndDate: endDate,
+                startDateAbsolute: startDate,
+                endDateAbsolute: endDate,
+              },
+            }),
           ...(weeks && {
             timelineParams: {
               startDate: moment(latestDate || undefined)

--- a/components/widgets/utils/config.js
+++ b/components/widgets/utils/config.js
@@ -235,11 +235,11 @@ export const getWidgetDatasets = ({
             },
           }),
           ...(startDate &&
+            endDate &&
             endDate && {
               timelineParams: {
                 startDate,
                 endDate,
-                trimEndDate: endDate,
                 startDateAbsolute: startDate,
                 endDateAbsolute: endDate,
               },


### PR DESCRIPTION
## Overview

The currently displayed button in the integrated deforestation alerts widget doesn’t work correctly. When I click on it for the first time, I believe it shows the correct alert count on the map, but if I readjust the date ranges in the settings and then click this button, the map on the right doesn’t change. See an example for this area: http://www.globalforestwatch.org/dashboards/aoi/606d3074b53b46001b771b48. Or this area: https://gfw.global/440gEa4.

We need to ensure that this button works correctly, everytime a user adjusts date ranges in the settings. 
