### PR TITLE
[FLAG-1306] Hide "Land cover change in United States" widget

### DIFF
--- a/components/widgets/manifest.js
+++ b/components/widgets/manifest.js
@@ -39,7 +39,7 @@ import faoCover from 'components/widgets/land-cover/fao-cover';
 import intactTreeCover from 'components/widgets/land-cover/intact-tree-cover';
 import primaryForest from 'components/widgets/land-cover/primary-forest';
 import treeCoverLocated from 'components/widgets/land-cover/tree-cover-located';
-import USLandCover from 'components/widgets/land-cover/us-land-cover';
+// import USLandCover from 'components/widgets/land-cover/us-land-cover';
 import rankedForestTypes from 'components/widgets/land-cover/ranked-forest-types';
 import treeCoverDensity from 'components/widgets/land-cover/tree-cover-density';
 import naturalForest from 'components/widgets/land-cover/natural-forest';
@@ -96,7 +96,7 @@ export default {
   treeCover2010,
   treeCoverRanked,
   rankedPlantations,
-  USLandCover,
+  // USLandCover,
   treeCoverPlantations,
   faoCover,
   intactTreeCover,


### PR DESCRIPTION
## Overview

In [this Slack thread](https://gfwlcl.slack.com/archives/C0JRCDUQH/p1714415846710529), we discussed hiding the widget for now while the Zeno/LCL team ensure they’re able to examine/save code.

