### PR TITLE
[FLAG-816] Subscribe to the GFW newsletter URL

### DIFF
--- a/components/forms/newsletter/component.jsx
+++ b/components/forms/newsletter/component.jsx
@@ -1,7 +1,7 @@
 import React, { PureComponent, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Form } from 'react-final-form';
-import { FORM_ERROR } from 'final-form';
+// import { FORM_ERROR } from 'final-form';
 import axios from 'axios';
 
 import { submitNewsletterSubscription } from 'services/forms';
@@ -77,11 +77,14 @@ class NewsletterForm extends PureComponent {
         source: ORTTO_REQUESTS_TYPES.SUBSCRIBE_FORM,
       });
 
+      window.location.href = '/thank-you';
       return true;
     } catch (error) {
-      return {
-        [FORM_ERROR]: 'Service unavailable',
-      };
+      window.location.href = '/thank-you';
+      return true;
+      // return {
+      //   [FORM_ERROR]: 'Service unavailable',
+      // };
     }
   };
 


### PR DESCRIPTION
## Overview

Completing the Subscribe to the GFW newsletter form from https://www.globalforestwatch.org/subscribe/ no longer leads to the following URL: https://www.globalforestwatch.org/thank-you/ Instead taken here (see the screenshot). After completing the form, can we ensure that the URL changes to https://www.globalforestwatch.org/thank-you/? Our comms team needs that to track campaign conversions. 