### PR TITLE
[FLAG-1348] Error occurs when loading statistics for tree cover loss by dominant driver

### DIFF
--- a/components/widgets/climate/emissions-deforestation-drivers/selectors.js
+++ b/components/widgets/climate/emissions-deforestation-drivers/selectors.js
@@ -204,7 +204,7 @@ export const parseSentence = createSelector(
 export const parseTitle = createSelector(
   [getTitle, getLocationName],
   (title, name) => {
-    let selectedTitle = title.initial;
+    let selectedTitle = title.default;
     if (name === 'global') {
       selectedTitle = title.global;
     }


### PR DESCRIPTION
## Overview

Description: Error occurs when loading statistics for tree cover loss by dominant driver when an administrative area is selected from the map view
Products/Environments Affected: GFW Flagship
Time of occurrence: At least as of Monday
Details: A journalist who is writing a story on the drivers data let me know that the analysis on the platform doesn't seem to be working. I have checked and it appears that when you click on an administrative area on the map and then click 'analyze' with the drivers data selected, an error occurs (see screenshot). The statistics via the dashboard still appear to be working.