### PR TITLE
[FLAG-1347] Create new home for "Impact" cards on about page

### DIFF
--- a/layouts/about/impacts/config.js
+++ b/layouts/about/impacts/config.js
@@ -1,0 +1,71 @@
+export const impactsProjects = {
+  rows: [
+    {
+      outcome:
+        "The Durrell Wildlife Conservation Trust used GFW's annual tree cover loss data as evidence of catastrophic recent forest loss in Menabe-Antimena reserve in Madagascar. The tree cover loss data helped convince the Ministry of Environment to increase patrols to monitor the protected area and remove the people that were illegally clearing the land. ",
+      link: 'https://www.durrell.org/wildlife/',
+      image: 'https://image.ibb.co/fqWiT6/1392351280_f1054b98ba_b.jpg',
+      image_credit: 'lithopman',
+    },
+    {
+      outcome:
+        'Congresswoman Yap of the House of Representative of the Philipines cited Global Forest Watch data on Mangrove loss to support arguments for the National Mangrove Forests Conservation and Rehabilitation Act, which prohibits further damage or destruction of mangrove forests. The Act was passed by the House of Representatives in June, 2015. ',
+      link: 'http://www.congress.gov.ph/press/details.php?pressid=8604',
+      image: 'https://image.ibb.co/i5LXMR/6085508295_2a8e1c6e63_b.jpg',
+      image_credit: 'Stefan Krasowski',
+    },
+    {
+      outcome:
+        "Amazon Conservation Association (ACA) used satellite-based data from GFW to break a story about the company United Cacao clearing intact forests in Peru illegally. GFW's data helped ACA investigate the case and communicate the extent of the damage, ultimately leading to United Cacao losing its listing on the London Stock Exchange.",
+      link: 'https://www.globalforestwatch.org/blog/climate/how-much-rainforest-is-in-that-chocolate-bar',
+      image: 'https://image.ibb.co/bOpZ1R/United_Cacao.jpg',
+      image_credit: 'Environmental Investigation Agency',
+    },
+    {
+      outcome:
+        "Forest monitors from Uganda's National Forest Authority (NFA) used GFW's GLAD deforestation alerts to detect a small-scale illegal logging camp in the Kasyoha Kitomi Forest Reserve. The NFA prosecuted the loggers using GFW data, leading to a fine for the violation.",
+      link: 'https://www.globalforestwatch.org/blog/data-and-research/big-data-is-all-around-how-do-we-harness-it-to-drive-the-change-we-need',
+      image: 'https://image.ibb.co/g2hU1R/JGI_Lilian_Pintea5.jpg',
+      image_credit: 'Jane Goodall Institute',
+    },
+    {
+      the_geom: null,
+      the_geom_webmercator: null,
+      outcome:
+        'Environmental Rights Action (ERA) and Friends of the Earth (FoE) Nigeria worked to empower local communities in Edo state, South-South Nigeria to advocate against land grabbing and deforestation for large-scale plantations by using GFW to map, monitor and communicate incidences of land grabbing and deforestation. The resulting campaign, a joint petition by ERA/FoE and the communities to the Edo State Government, and meetings with local government officials led to a successful revocation of about 13,750 hectares of land that had been grabbed by a plantation company.',
+      link: 'https://www.globalforestwatch.org/blog/people/announcing-recipients-of-small-grants-fund-2015',
+      image: 'https://image.ibb.co/nGPRgR/10707591965_166f53a043_k.jpg',
+      image_credit: 'jbdodane',
+    },
+    {
+      outcome:
+        "Unilever used GFW's PALM Risk Tool to identify 29 high risk palm oil mills in their supply chain that they can now engage to reduce deforestation and adopt more sustainable practices.",
+      link: 'https://www.globalforestwatch.org/blog/commodities/companies-can-now-spot-deforestation-in-their-palm-oil-supply-chains-before-it-happens',
+      image: 'https://image.ibb.co/ho1iT6/4074823996_c8fa98c562_o.jpg',
+      image_credit: 'Marufish',
+    },
+    {
+      outcome:
+        'Global Wildlife Conservation worked with the Rama and Kriol communities in Nicaragua to establish a new indigenous forest ranger program to protect the Indio-Maiz Reserve. Indigenous forest rangers use Global Forest Watch forest cover loss and fire data, which helps them to define the rangers’ patrol routes by identifying areas under the greatest immediate threat, and document illegal deforestation by navigating to alerts. The forest rangers have been successful in getting local authorities to remove illegal colonists from the reserve.',
+      link: 'https://www.globalforestwatch.org/blog/people/zooming-in-gfw-small-grant-fund-recipients-discover-endangered-wildlife-threatened-by-nicaragua-canal',
+      image: 'https://image.ibb.co/bFv5am/Nicaragua.png',
+      image_credit: 'Global Wildlife Conservation',
+    },
+    {
+      the_geom: null,
+      the_geom_webmercator: null,
+      outcome:
+        "Peru's Supervisory Body for Forest and Wildlife Resources (OSINFOR) uses GFW deforestation alerts to prioritize field inspections. GFW's alerts led them to detect roads transporting illegally-harvested timber coming from the buffer zone of Cordillera Azul National Park.",
+      link: 'https://www.globalforestwatch.org/blog/people/wri-to-collaborate-with-peruvian-forests-and-wildlife-agency-through-global-forest-watch',
+      image: 'https://image.ibb.co/cW0tT6/OSINFOR_Peru.jpg',
+      image_credit: 'OSINFOR',
+    },
+    {
+      outcome:
+        'Instituto Araguaia, a Brazilian NGO, used GFW maps and support to make the case for the government to establish a new legally-recognized buffer zone for a critical ecosystem in Cantao. The buffer zone will help to protect the rich ecosystem from expanding soy plantations.',
+      link: 'https://www.globalforestwatch.org/blog/people/gfw-user-profile-silvana-campello',
+      image: 'https://image.ibb.co/kv4sMR/35743222401_9a554efde6_o.jpg',
+      image_credit: 'CIFOR',
+    },
+  ],
+};

--- a/pages/about.js
+++ b/pages/about.js
@@ -3,8 +3,9 @@ import About from 'layouts/about';
 
 import PropTypes from 'prop-types';
 
-import { getImpactProjects, getSGFProjects } from 'services/projects';
+import { getSGFProjects } from 'services/projects';
 import { getCountriesProvider } from 'services/country';
+import { impactsProjects } from 'layouts/about/impacts/config';
 
 import { getPublishedNotifications } from 'services/notifications';
 
@@ -20,7 +21,15 @@ const AboutPage = (props) => (
 
 export const getStaticProps = async () => {
   const { sgfProjects } = await getSGFProjects({ params: { per_page: 100 } });
-  const impactProjects = await getImpactProjects();
+  // const impactProjects = await getImpactProjects();
+
+  const impactProjects = impactsProjects?.rows?.map((d) => ({
+    summary: d.outcome,
+    image: d.image,
+    imageCredit: d.image_credit,
+    extLink: d.link,
+  }));
+
   const countries = await getCountriesProvider();
   const notifications = await getPublishedNotifications();
 

--- a/services/projects.js
+++ b/services/projects.js
@@ -1,26 +1,7 @@
-import { cartoRequest } from 'utils/request';
 import apiFetch from '@wordpress/api-fetch';
 import axios from 'axios';
 
 import { getCountriesProvider } from 'services/country';
-
-const SQL_QUERIES = {
-  impactProjects: 'SELECT * FROM gfw_outcomes_for_about_page_images',
-  sgfProjects: 'SELECT * FROM sgf_stories',
-};
-
-export const getImpactProjects = () => {
-  const url = `/sql?q=${SQL_QUERIES.impactProjects}`;
-  return cartoRequest.get(url).then((response) =>
-    response?.data?.rows?.map((d) => ({
-      id: d.cartodb_id,
-      summary: d.outcome,
-      image: d.image,
-      imageCredit: d.image_credit,
-      extLink: d.link,
-    }))
-  );
-};
 
 apiFetch.setFetchHandler(async (options) => {
   const headers = { 'Content-Type': 'application/json' };


### PR DESCRIPTION
## Overview

From Will’s work on https://gfw.atlassian.net/browse/FLAG-1336?atlOrigin=eyJpIjoiYzU5OWU4YTIxY2Y2NDQ3ZWI5ZDA2YjkxYzViYTNmOWMiLCJwIjoiaiJ9 , we now know that the “Impacts” section of the https://www.globalforestwatch.org/about/ page pulls from Carto. We’ll want to ensure that we’re able to store this outside of Carto (maybe Wordpress).

#### Impact Projects

Carto is also used to retrieve the list of impact projects shown on the “About” page.

Method: `getImpactProjects`

```
SELECT * FROM gfw_outcomes_for_about_page_images
```

