### PR TITLE
[FLAG-1352] Add content to 'New From Global Forest Watch' carousel at bottom of landing page

### DIFF
--- a/layouts/home/config.js
+++ b/layouts/home/config.js
@@ -180,5 +180,11 @@ export default {
         'Global maps on GFW provide spatially explicit data on net carbon fluxes from forests.',
       link: 'https://blog.globalforestwatch.org/data-and-research/forest-carbon-flux-data-explained/',
     },
+    {
+      name: 'GFW vs. GFW Pro: What’s the Difference?',
+      description:
+        'Explore our comparison table breaking down the features, audiences, and use cases for Global Forest Watch and GFW Pro. Find the right tool for your forest monitoring needs here:',
+      link: 'https://www.globalforestwatch.org/help/gfw-pro/additional-materials/gfw-and-gfw-pro-what-are-the-differences/',
+    },
   ],
 };


### PR DESCRIPTION
## Overview

Add new content to the ‘New from Global Forest Watch’ carousel at the bottom of the landing page

Title: GFW vs. GFW Pro: What’s the Difference?

content: Explore our comparison table breaking down the features, audiences, and use cases for Global Forest Watch and GFW Pro. Find the right tool for your forest monitoring needs here: [GFW and GFW Pro: What are the Differences?  | Global Forest Watch Content](https://nam04.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.globalforestwatch.org%2Fhelp%2Fgfw-pro%2Fadditional-materials%2Fgfw-and-gfw-pro-what-are-the-differences%2F&data=05%7C02%7CNoel.Smyth%40wri.org%7Ce1785f3701d64b6324c908ddc61e1cc3%7C476bac1f36b24ad98699cda6bad1f862%7C0%7C0%7C638884554841121059%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=8DN7h%2F3Gmaak8RgDVCjdN6RhmIlZuivpdIh9avIy9GI%3D&reserved=0)

This previously lived here: https://wri-01.carto.com/tables/gfw_home_news

Now, this is hard-coded but is going to be moved to Wordpress (see: https://gfw.atlassian.net/browse/FLAG-1270 )
