### PR TITLE
[FLAG-1333] Blacklist the minining concessions intersections for all listed CAR widgets

### DIFF
--- a/components/widgets/selectors.js
+++ b/components/widgets/selectors.js
@@ -112,6 +112,22 @@ export const selectModalClosing = (state) =>
 export const selectNonGlobalDatasets = (state) =>
   state.widgets && state.widgets.data.nonGlobalDatasets;
 
+const applySettingsConfigGlobalRules = (config, params) => {
+  if (!config) return config;
+
+  const isCAR = params.adm0 === 'CAF';
+
+  return config.map((field) => {
+    if (field.key === 'landCategory' && isCAR) {
+      return {
+        ...field,
+        blacklist: ['mining'],
+      };
+    }
+    return field;
+  });
+};
+
 export const getLocationObj = createSelector(
   [getDataLocation, getGeodescriberTitleFull],
   (location, title) => ({
@@ -511,13 +527,18 @@ export const getWidgets = createSelector(
 
       const dataOptions = rawData && rawData.options;
 
-      const settingsConfig =
+      let settingsConfig =
         settingsConfigArr ||
         (settingsConfigFn &&
           settingsConfigFn({
             ...locationObj,
             ...settings,
           }));
+
+      settingsConfig = applySettingsConfigGlobalRules(settingsConfig, {
+        ...locationObj,
+        ...settings,
+      });
 
       const settingsConfigParsed = getSettingsConfig({
         settingsConfig,


### PR DESCRIPTION
## Overview

An external user inquired that data appears in the "[Tree Cover Loss in CAR](https://gfw.global/4maO6lg)" widget when the mining concessions filter is selected, however, we do not have mining concessions data for CAR. The mining concession boundaries from Cameroon and Republic of the Congo spill over slightly into CAR which is causing data to appear. We'd like to disable the mining concessions land category filter for all relevant CAR widgets to avoid having this filter option available to users.

Remove the mining concessions filter from all listed CAR widgets below:

### Land Cover Tab:

- Natural Forests in [Central African Republic]: https://gfw.global/4meZz3i
- Forests in [Central African Republic]: https://gfw.global/4m8DwLB
- Tree Cover in [Central African Republic]: https://gfw.global/3HoiZiO
- Location of Tree Cover in [Central African Republic]: https://gfw.global/4k4RTOY
- Tree Cover Density in [Central African Republic]: https://gfw.global/4jL0k2f
- Intact Forest in [Central African Republic]: https://gfw.global/4jNvki3
- Primary Forest in [Central African Republic]: https://gfw.global/3YEw94n

### Forest Change Tab:
- Primary Forest Loss in [Central African Republic]: https://gfw.global/456F3LZ
- Tree Cover Loss in [Central African Republic]: https://gfw.global/4maO6lg
- Tree Cover Loss in [Central African Republic] Compared to Other Areas: https://gfw.global/3GPN6CT
- Integrated Deforestation Alerts in [Central African Republic]: https://gfw.global/3F77lva
- Location of Tree Cover Gain in [Central African Republic]: https://gfw.global/4jL1db5
- Tree Cover Gain in [Central African Republic] Compared to Other Areas: https://gfw.global/3YDibQp
- Tree Cover Gain Outside Plantations in [Central African Republic]: https://gfw.global/44sGDrn

### Fires Tab:

- Weekly Fire Alerts in [Central African Republic]: https://gfw.global/4kc01gI
- Cumulative Fires Alerts in [Central African Republic]: https://gfw.global/3F0r3sB
- Tree Cover Loss due to Fires in [Central African Republic]: https://gfw.global/437rUjj
- Regions with the Most Fire Alerts in [Central African Republic]: https://gfw.global/3GKych6
- Historical Fire Alerts in [Central African Republic]: https://gfw.global/3RURRNV
- Fire Alerts in [Central African Republic]: https://gfw.global/4jUAWHE
- Regions with the Most Tree Cover Loss due to Fires in [Central African Republic]: https://gfw.global/4kimWHv
- Proportion of Tree Cover Loss due to Fires in [Central African Republic]: https://gfw.global/4k9Sq2f

### Climate Tab:

- Forest-Related Greenhouse Gas Fluxes in [Central African Republic]: https://gfw.global/44xhUCb
- Forest-Related Greenhouse Gas Emissions in [Central African Republic]: https://gfw.global/43aSBUj
- Forest-Related Greenhouse Gas Emissions in [Central African Republic] by Dominant Driver