### PR TITLE
[FLAG-1021] update the number of GFW users

### DIFF
--- a/layouts/about/projects/component.jsx
+++ b/layouts/about/projects/component.jsx
@@ -129,7 +129,7 @@ const AboutProjectsSection = ({
             style={{ backgroundImage: `url(${growth})` }}
           >
             <h4>
-              Since its launch in 2014, over 4 million people have visited
+              Since its launch in 2014, over 8 million people have visited
               Global Forest Watch from every single country in the world.
             </h4>
           </div>


### PR DESCRIPTION
## Overview

Can we update the following sentence on the about page: https://www.globalforestwatch.org/about/ to say over 8 million users instead of over 4 million users.

