### PR TITLE
[FLAG-1343] "Explore on GFW" button misplaced in blog widget embed

### DIFF
--- a/wrappers/embed/styles.scss
+++ b/wrappers/embed/styles.scss
@@ -5,7 +5,6 @@
 
   .embed-content {
     position: relative;
-    height: calc(100vh - 60px);
 
     &.-error {
       display: flex;


### PR DESCRIPTION
## Overview

[In this blog](https://www.globalforestwatch.org/blog/data-and-tools/new-drivers-data-forest-loss/), there is a dashboard widget embed where the "Explore on GFW" button is appearing in the middle of the embed instead of at the bottom, cutting off some of the text (see first screenshot). Both the “For more info” and “Explore on gfw” buttons should be moved to the bottom to avoid obstructing the donut chart.
