### PR TITLE
[FLAG-1373] Show values with 2 significant figures across all GFW widgets

### DIFF
--- a/components/charts/components/pie-chart-legend/component.jsx
+++ b/components/charts/components/pie-chart-legend/component.jsx
@@ -160,7 +160,7 @@ PieChartLegend.defaultProps = {
   config: {
     unit: '',
     key: 'value',
-    format: '.3s',
+    format: '.2s',
   },
 };
 

--- a/components/widget/components/widget-list-legend/component.jsx
+++ b/components/widget/components/widget-list-legend/component.jsx
@@ -13,7 +13,7 @@ class WidgetListLegend extends PureComponent {
           className="cover-legend"
           data={data}
           config={{
-            format: '.3s',
+            format: '.2s',
             unit: 'ha',
             key: 'value',
             ...settings,

--- a/components/widget/components/widget-lollipop/component.jsx
+++ b/components/widget/components/widget-lollipop/component.jsx
@@ -21,7 +21,7 @@ class WidgetLollipop extends PureComponent {
         config={config}
         settings={{
           ...settings,
-          format: settings.unit === '%' ? '.2r' : '.3s',
+          format: settings.unit === '%' ? '.2r' : '.2s',
         }}
         settingsConfig={settingsConfig}
         handlePageChange={(change) =>

--- a/components/widget/components/widget-numbered-list/component.jsx
+++ b/components/widget/components/widget-numbered-list/component.jsx
@@ -20,7 +20,7 @@ class WidgetNumberedList extends PureComponent {
         data={data}
         settings={{
           ...settings,
-          format: settings.unit === '%' ? '.2r' : '.3s',
+          format: settings.unit === '%' ? '.2r' : '.2s',
         }}
         settingsConfig={settingsConfig}
         handlePageChange={(change) =>

--- a/components/widget/components/widget-pie-chart-legend/component.jsx
+++ b/components/widget/components/widget-pie-chart-legend/component.jsx
@@ -62,7 +62,7 @@ class WidgetPieChart extends PureComponent {
             className="cover-legend"
             data={legendData || data}
             config={{
-              format: '.3s',
+              format: '.2s',
               unit: 'ha',
               key: 'value',
               ...settings,

--- a/components/widgets/climate/emissions/selectors.js
+++ b/components/widgets/climate/emissions/selectors.js
@@ -121,7 +121,7 @@ export const parseSentence = createSelector(
         Math.abs(emissionFraction) < 0.1
           ? '< 0.1%'
           : `${format('.2r')(Math.abs(emissionFraction))}%`,
-      value: `${format('.3s')(
+      value: `${format('.2s')(
         Math.abs(emissionsCount / (endYear - startYear))
       )}tCO₂e`,
       startYear,

--- a/components/widgets/fires/burned-area/selectors.js
+++ b/components/widgets/fires/burned-area/selectors.js
@@ -260,7 +260,7 @@ export const parseConfig = createSelector(
         labelFormat: (value) => moment(value).format('MMM DD YYYY'),
         unit: ` MODIS burned area`,
         color: colors?.main,
-        unitFormat: (value) => `${format('.3s')(value)}ha`,
+        unitFormat: (value) => `${format('.2s')(value)}ha`,
       },
     ];
 
@@ -278,7 +278,7 @@ export const parseConfig = createSelector(
         unit: ` MODIS burned area`,
         color: '#49b5e3',
         nullValue: 'No data available',
-        unitFormat: (value) => `${format('.3s')(value)}ha`,
+        unitFormat: (value) => `${format('.2s')(value)}ha`,
       });
     }
 

--- a/components/widgets/fires/fires-ranked/selectors.js
+++ b/components/widgets/fires/fires-ranked/selectors.js
@@ -233,7 +233,7 @@ export const parseSentence = createSelector(
       topRegion,
       topRegionCount: formatNumber({ num: topRegionCount, unit: 'counts' }),
       topRegionPerc: formatNumber({ num: topRegionPerc, unit: '%' }),
-      topRegionDensity: `${format('.3r')(topRegionDensity)} fires/Mha`,
+      topRegionDensity: `${format('.2r')(topRegionDensity)} fires/Mha`,
       location: locationName === 'global' ? 'globally' : locationName,
       indicator: `${indicator ? `${indicator.label}` : ''}`,
       component:

--- a/components/widgets/forest-change/fao-deforest/selectors.js
+++ b/components/widgets/forest-change/fao-deforest/selectors.js
@@ -70,7 +70,7 @@ export const parseSentence = createSelector(
       currentLabel === 'global'
         ? globalDeforestation
         : countryDeforestation?.def_per_year;
-    const rateFormat = rate < 1 ? '.3r' : '.3s';
+    const rateFormat = rate < 1 ? '.2r' : '.2s';
 
     let sentence = initial;
 

--- a/components/widgets/forest-change/fao-reforest/selectors.js
+++ b/components/widgets/forest-change/fao-reforest/selectors.js
@@ -81,7 +81,7 @@ export const parseSentence = createSelector(
     });
 
     const rate = locationName === 'global' ? globalRate : countryData?.value;
-    const formatType = rate < 1 ? '.3r' : '.3s';
+    const formatType = rate < 1 ? '.2r' : '.2s';
 
     let sentence = globalInitial;
 

--- a/components/widgets/forest-change/glad-ranked/selectors.js
+++ b/components/widgets/forest-change/glad-ranked/selectors.js
@@ -7,17 +7,17 @@ import sumBy from 'lodash/sumBy';
 import moment from 'moment';
 
 // get list data
-const getData = state => state.data && state.data.alerts;
-const getLatestDates = state => state.data && state.data.latest;
-const getExtent = state => state.data && state.data.extent;
-const getSettings = state => state.settings;
-const getOptionsSelected = state => state.optionsSelected;
-const getIndicator = state => state.indicator;
-const getAdm1 = state => state.adm1;
-const getLocationsMeta = state => state.childData;
-const getLocationName = state => state.locationLabel;
-const getColors = state => state.colors;
-const getSentences = state => state.sentences;
+const getData = (state) => state.data && state.data.alerts;
+const getLatestDates = (state) => state.data && state.data.latest;
+const getExtent = (state) => state.data && state.data.extent;
+const getSettings = (state) => state.settings;
+const getOptionsSelected = (state) => state.optionsSelected;
+const getIndicator = (state) => state.indicator;
+const getAdm1 = (state) => state.adm1;
+const getLocationsMeta = (state) => state.childData;
+const getLocationName = (state) => state.locationLabel;
+const getColors = (state) => state.colors;
+const getSentences = (state) => state.sentences;
 
 export const parseList = createSelector(
   [
@@ -27,38 +27,41 @@ export const parseList = createSelector(
     getSettings,
     getAdm1,
     getLocationsMeta,
-    getColors
+    getColors,
   ],
   (data, latest, extent, settings, adm1, meta, colors) => {
     if (!data || isEmpty(data) || !meta || isEmpty(meta)) return null;
     const latestWeek = moment(latest).isoWeek();
     const latestYear = moment(latest).year();
-    const alertsByDate = data.filter(d => d.year && d.week &&
-      moment()
-        .year(d.year)
-        .isoWeek(d.week)
-        .isAfter(
-          moment()
-            .isoWeek(latestWeek)
-            .year(latestYear)
-            .subtract(settings.weeks, 'weeks')
-        )
+    const alertsByDate = data.filter(
+      (d) =>
+        d.year &&
+        d.week &&
+        moment()
+          .year(d.year)
+          .isoWeek(d.week)
+          .isAfter(
+            moment()
+              .isoWeek(latestWeek)
+              .year(latestYear)
+              .subtract(settings.weeks, 'weeks')
+          )
     );
     const groupKey = adm1 ? 'adm2' : 'adm1';
     const groupedAlerts = groupBy(alertsByDate, groupKey);
     const totalCounts = sumBy(alertsByDate, 'alerts');
     const mappedData =
       groupedAlerts &&
-      Object.keys(groupedAlerts).map(k => {
+      Object.keys(groupedAlerts).map((k) => {
         const region = meta[k];
         const regionExtent = extent.find(
-          a => parseInt(a[groupKey], 10) === parseInt(k, 10)
+          (a) => parseInt(a[groupKey], 10) === parseInt(k, 10)
         );
         const regionData = groupedAlerts[k];
         const countsArea = sumBy(regionData, 'area_ha') || 0;
         const counts = sumBy(regionData, 'alerts') || 0;
         const countsAreaPerc =
-          counts && totalCounts ? counts / totalCounts * 100 : 0;
+          counts && totalCounts ? (counts / totalCounts) * 100 : 0;
         const countsPerHa =
           counts && regionExtent ? counts / regionExtent.extent : 0;
 
@@ -70,14 +73,14 @@ export const parseList = createSelector(
           count: counts,
           area: countsArea,
           value: settings.unit === 'ha' ? countsArea : countsAreaPerc,
-          label: (region && region.label) || ''
+          label: (region && region.label) || '',
         };
       });
     return sortBy(mappedData, 'area').reverse();
   }
 );
 
-export const parseData = createSelector([parseList], data => {
+export const parseData = createSelector([parseList], (data) => {
   if (isEmpty(data)) return null;
   return sortBy(data, 'value').reverse();
 });
@@ -89,7 +92,7 @@ export const parseSentence = createSelector(
     getOptionsSelected,
     getIndicator,
     getLocationName,
-    getSentences
+    getSentences,
   ],
   (data, sortedList, optionsSelected, indicator, locationName, sentences) => {
     if (!data || !optionsSelected || !locationName) return null;
@@ -105,9 +108,9 @@ export const parseSentence = createSelector(
       percentileCount += sortedList[percentileLength].count;
       percentileLength += 1;
     }
-    const topCount = percentileCount / totalCount * 100;
+    const topCount = (percentileCount / totalCount) * 100;
     const countArea = sumBy(data, 'area') || 0;
-    const formatType = countArea < 1 ? '.3r' : '.3s';
+    const formatType = countArea < 1 ? '.2r' : '.2s';
     const timeFrame = optionsSelected.weeks;
 
     const params = {
@@ -120,7 +123,7 @@ export const parseSentence = createSelector(
           ? `${percentileLength} region`
           : `${percentileLength} regions`,
       location: locationName,
-      indicator: `${indicator ? `${indicator.label}` : ''}`
+      indicator: `${indicator ? `${indicator.label}` : ''}`,
     };
     const sentence = indicator ? withInd : initial;
     return { sentence, params };
@@ -129,5 +132,5 @@ export const parseSentence = createSelector(
 
 export default createStructuredSelector({
   data: parseData,
-  sentence: parseSentence
+  sentence: parseSentence,
 });

--- a/components/widgets/forest-change/integrated-alerts-ranked/selectors.js
+++ b/components/widgets/forest-change/integrated-alerts-ranked/selectors.js
@@ -112,7 +112,7 @@ export const parseSentence = createSelector(
     }
     const topCount = (percentileCount / totalCount) * 100;
     const countArea = sumBy(data, 'area') || 0;
-    const formatType = countArea < 1 ? '.3r' : '.3s';
+    const formatType = countArea < 1 ? '.2r' : '.2s';
     const timeFrame = optionsSelected.weeks;
 
     const params = {

--- a/components/widgets/forest-change/tree-gain-located/selectors.js
+++ b/components/widgets/forest-change/tree-gain-located/selectors.js
@@ -86,8 +86,8 @@ export const parseSentence = createSelector(
       sentence = !indicator ? initial : withIndicator;
     }
 
-    const valueFormat = topRegion.gain < 1 ? '.3r' : '.3s';
-    const aveFormat = avgGain < 1 ? '.3r' : '.3s';
+    const valueFormat = topRegion.gain < 1 ? '.2r' : '.2s';
+    const aveFormat = avgGain < 1 ? '.2r' : '.2s';
 
     const params = {
       baselineYear: dateFromMapLayer || dateFromDashboard || 2000,

--- a/components/widgets/land-cover/global-land-cover/selectors.js
+++ b/components/widgets/land-cover/global-land-cover/selectors.js
@@ -67,7 +67,7 @@ export const parseSentence = createSelector(
       location: locationName,
       year,
       category: label,
-      extent: `${format('.3s')(value)}ha`,
+      extent: `${format('.2s')(value)}ha`,
     };
     return {
       sentence,

--- a/utils/__tests__/format.spec.js
+++ b/utils/__tests__/format.spec.js
@@ -55,7 +55,7 @@ describe('formatNumber', () => {
         unit: 'ha',
         spaceUnit: true,
       });
-      const expected = '1.20 Mha';
+      const expected = '1.2 Mha';
 
       expect(formattedNumber).toBe(expected);
     });
@@ -67,7 +67,7 @@ describe('formatNumber', () => {
         unit: 'ha',
         spaceUnit: true,
       });
-      const expected = '1.20 kha';
+      const expected = '1.2 kha';
 
       expect(formattedNumber).toBe(expected);
     });
@@ -79,7 +79,7 @@ describe('formatNumber', () => {
         unit: 'ha',
         spaceUnit: true,
       });
-      const expected = '3.92 Gha';
+      const expected = '3.9 Gha';
 
       expect(formattedNumber).toBe(expected);
     });
@@ -119,7 +119,7 @@ describe('formatNumber', () => {
         unit: 'tCO2',
         spaceUnit: true,
       });
-      const expected = '1.23 GtCO\u2082e';
+      const expected = '1.2 GtCO\u2082e';
 
       expect(formattedNumber).toBe(expected);
     });
@@ -131,7 +131,7 @@ describe('formatNumber', () => {
         unit: 't',
         spaceUnit: true,
       });
-      const expected = '1.23 Gt';
+      const expected = '1.2 Gt';
 
       expect(formattedNumber).toBe(expected);
     });
@@ -143,7 +143,7 @@ describe('formatNumber', () => {
         unit: 'tCO2',
         spaceUnit: true,
       });
-      const expected = '1.23 MtCO\u2082e';
+      const expected = '1.2 MtCO\u2082e';
 
       expect(formattedNumber).toBe(expected);
     });
@@ -155,7 +155,7 @@ describe('formatNumber', () => {
         unit: 't',
         spaceUnit: true,
       });
-      const expected = '1.23 Mt';
+      const expected = '1.2 Mt';
 
       expect(formattedNumber).toBe(expected);
     });
@@ -169,7 +169,7 @@ describe('formatNumber', () => {
         unit: 'countsK',
         spaceUnit: false,
       });
-      const expected = '123k';
+      const expected = '120k';
 
       expect(formattedNumber).toBe(expected);
     });
@@ -214,13 +214,13 @@ describe('formatNumber', () => {
 
     it('should format using a specialSpecifier from d3-format', () => {
       const unformattedNumber = 1775000;
-      const specialSpecificer = unformattedNumber < 1 ? '.3r' : '.3s';
+      const specialSpecificer = unformattedNumber < 1 ? '.2r' : '.2s';
       const formattedNumber = formatNumber({
         num: unformattedNumber,
         specialSpecificer, // https://github.com/d3/d3-format#format
         spaceUnit: false,
       });
-      const expected = '1.78M';
+      const expected = '1.8M';
 
       expect(formattedNumber).toBe(expected);
     });

--- a/utils/format.js
+++ b/utils/format.js
@@ -8,7 +8,7 @@ export const formatUSD = (value, minimize = true) =>
 
 const setDefaultSpecifier = (unit, precision) => {
   let defaultSpecifier = '';
-  const numberOfDecimalDigits = unit === '%' ? '2' : '3';
+  const numberOfDecimalDigits = '2';
   const properPrecision = Number.isInteger(precision)
     ? Math.abs(precision)
     : numberOfDecimalDigits;
@@ -30,13 +30,13 @@ const formatWithProperSpecifier = ({
   const threshold = unit === '%' ? 0.1 : 1;
 
   // specialSpecifier is a different specifier passed through formatNumber parameter
-  // e.g formatNumber({ num: 12.345, specialSpecifier: value < 1 ? '.3r' : '.3s'; })
+  // e.g formatNumber({ num: 12.345, specialSpecifier: value < 1 ? '.2r' : '.2s'; })
   if (specialSpecifier) {
     return format(specialSpecifier)(num);
   }
 
   if (unit === 'tCO2') {
-    return format('.3s')(num);
+    return format('.2s')(num);
   }
 
   if (num < threshold && num > 0) {
@@ -44,7 +44,7 @@ const formatWithProperSpecifier = ({
   }
 
   if (unit !== '%' && num < threshold && num > 0.01) {
-    return format('.3r')(num);
+    return format('.2r')(num);
   }
 
   if (unit === 'ha' && num < 1000 && num > 0) {


### PR DESCRIPTION
## Overview

David and Liz on the research team have requested a change for all widgets to display two significant figures instead of showing excessive precision. For example, the CO₂e emissions widget http://gfw.global/48PPFOg currently shows 3.43, which should instead be 3.4.

After discussing with Will, I’ve created this investigation ticket. Will will check if the change can be applied holistically across all widgets. During testing, reviewers will confirm which widgets are affected and list any that need further updates (e.g., older widgets).

### Acceptance Criteria

All widgets to display values at 2 significant figures.

Example: 3.43 --> 3.4.

Here are more examples of 2 significant figures:

- 3.4
- 34
- 0.34
- 340
- 0.0034
